### PR TITLE
Update references of /var/platform to /var/firmwareupdate to match implementation

### DIFF
--- a/doc/fwutil/fwutil.md
+++ b/doc/fwutil/fwutil.md
@@ -576,7 +576,7 @@ New component api is introduced to support the component firmware auto-update as
         """
         raise NotImplementedError
 ```
-The return_code of auto_update_firmware() which indicates the firmware auto-update  status, will be logged in "fw_au_status" under "/var/platform/" directory by fwutil and the status file will be used for the `fwutil show update status` command. 
+The return_code of auto_update_firmware() which indicates the firmware auto-update  status, will be logged in "fw_au_status" under "/var/firmwareupdate/" directory by fwutil and the status file will be used for the `fwutil show update status` command. 
 
 In case that a firmware update needs any additional step to complete the firmware update but the installation time is longer than the boot time requirement, auto-update platform api is expected to install the firmware and perform the complete action during the reboot via `platform_fw_au_reboot_handle` or `platform_reboot` plugin.
 For example, some cpld update needs a power cycle to complete the firmware update and some cpld update needs a register triggered power-cycle to give some refresh time for the new firmware to be effective on the system.
@@ -602,7 +602,7 @@ In this example, BIOS firmware got updated, CPLD firmware got installed but powe
 *powercycle can be triggered by cold reboot script in this case.
 
 ```bash
-admin@sonic:~/fwutil$ cat /var/platform/fw_au_status
+admin@sonic:~/fwutil$ cat /var/firmwareupdate/fw_au_status
 {
     "MSN2700/BIOS":
         {
@@ -634,7 +634,7 @@ And the components available for the update are BIOS, and SSD.
 In this example, BIOS firmware got updated, CPLD firmware update was skipped since the update completion can not be done for warm, and SSD firmware update is scheduled during warm boot.
 
 ```bash
-admin@sonic:~/fwutil$ cat /var/platform/fw_au_status
+admin@sonic:~/fwutil$ cat /var/firmwareupdate/fw_au_status
 {
     "MSN2700/BIOS":
         {
@@ -668,9 +668,9 @@ Automatic FW installation requires default platform_components.json to be create
 _sonic-buildimage/device/<platform_name>/<onie_platform>/platform_components.json_
 Recommended image path is "/lib/firmware/<vendor>".
 
-Here is the /var/platform directory structure while fwutil handles the `fwutil update all fw` and `fwutil show update status` command.
+Here is the /var/firmwareupdate directory structure while fwutil handles the `fwutil update all fw` and `fwutil show update status` command.
 ```
-/var/platform/
+/var/firmwareupdate/
           |--- fw_au_status
           |--- <boot_type>_fw_au_task*
 ```


### PR DESCRIPTION
Minor update to sync documentation with fwutil functionality as it stands today. 