### PR TITLE
[sonic-bootchart] add document on integrating systemd-bootchart

### DIFF
--- a/doc/profiling/sonic_bootchart.md
+++ b/doc/profiling/sonic_bootchart.md
@@ -27,7 +27,13 @@
 
 ### Scope
 
-SONiC OS is highly modular and composible system, where every new feature is often implemented as a new script, utility, daemon or docker container. A lot of these components start at SONiC boot togather with respect to their dependencies requirements. Majority of start scripts use short-living small utilities written in python, bash or other scripting languages, invoke Jinja2 template generation. This leads to potential boot time performance degradation that we need a tool to detect and analyze.
+SONiC OS is highly modular and composible system, where every new feature is
+often implemented as a new script, utility, daemon or docker container. A lot of
+these components start at SONiC boot togather with respect to their dependencies
+requirements. Majority of start scripts use short-living small utilities written
+in python, bash or other scripting languages, invoke Jinja2 template generation.
+This leads to potential boot time performance degradation that we need a tool to
+detect and analyze.
 
 ### Definitions/Abbreviations
 
@@ -35,7 +41,11 @@ N/A
 
 ### Overview
 
-This document describes an integration of one of systemd tools called *systemd-bootchart*. This tool is a sampling based system profiler that is used to analyze boot up performance but not limited to and can be used to collect samples after the system is booted. The output produced by systemd-bootchart is an SVG image that looks like this:
+This document describes an integration of one of systemd tools called
+*systemd-bootchart*. This tool is a sampling based system profiler that is used
+to analyze boot up performance but not limited to and can be used to collect
+samples after the system is booted. The output produced by systemd-bootchart is
+an SVG image that looks like this:
 
 <p align=center>
 <img src="img/bootchart.svg" alt="Figure 1. Bootchart example">
@@ -57,7 +67,9 @@ N/A
 
 ### High-Level Design
 
-SONiC build system includes a new build-time flag to INCLUDE_BOOTCHART (y/n). When this flag is set a *systemd-bootchart* debian package is installed in SONiC host from upstream debian repositories (Installed size 128 KB).
+SONiC build system includes a new build-time flag to INCLUDE_BOOTCHART (y/n).
+When this flag is set a *systemd-bootchart* debian package is installed in SONiC
+host from upstream debian repositories (Installed size 128 KB).
 
 Example INCLUDE_BOOTCHART flag usage:
 
@@ -71,7 +83,8 @@ Do not include bootchart:
 make INCLUDE_BOOTCHART=n target/sonic-mellanox.bin
 ```
 
-SONiC provides a default configuration for bootchart located at /etc/systemd/bootchart.conf:
+SONiC provides a default configuration for bootchart located at
+/etc/systemd/bootchart.conf:
 
 ```ini
 [Bootchart]
@@ -79,9 +92,17 @@ Samples=4500
 Frequency=25
 ```
 
-This configuration means that samples are collected for 3 minutes of uptime with a frequency of 25 samples per second.
+This configuration means that samples are collected for 3 minutes of uptime with
+a frequency of 25 samples per second.
 
-SONiC utilities is extendeded with a new script under *scripts/* to include a new utility *sonic-bootchart*.
+SONiC utilities is extendeded with a new script under *scripts/* to include a
+new utility *sonic-bootchart*.
+
+Also a flag added to the build incdicating default status:
+
+```
+ENABLE_BOOTCHART=y
+```
 
 ### SAI API
 
@@ -89,7 +110,8 @@ N/A
 
 ### Configuration and management
 
-*sonic-bootchart* is a standalone utility, like *sonic-kdump-config*, *sonic-installer*, etc.
+*sonic-bootchart* is a standalone utility, like *sonic-kdump-config*,
+**sonic-installer*, etc.
 
 Command line interface:
 
@@ -118,53 +140,59 @@ admin@sonic:~$ sudo sonic-bootchart disable
 Running command: systemctl disable systemd-bootchart
 ```
 
-In case image is built without bootchart included (INCLUDE_BOOTCHART=n) sonic-bootchart will print an error:
+In case image is built without bootchart included (INCLUDE_BOOTCHART=n)
+sonic-bootchart will print an error:
 
 ```
 admin@sonic:~$ sudo sonic-bootchart enable
 systemd-bootchart is not installed
 ```
 
-Once bootchart is enabled a systemd-bootchart.service is enabled in systemd which starts a daemon early at boot that collects samples.
-This setting is permanent, meaning, after it is enabled, bootchart will always run at boot until disabled, *config save*, *config reload* do not affect this setting.
+Once bootchart is enabled a systemd-bootchart.service is enabled in systemd
+which starts a daemon early at boot that collects samples. This setting is
+permanent, meaning, after it is enabled, bootchart will always run at boot until
+disabled, *config save*, *config reload* do not affect this setting.
 
 
 Update configuration example:
 
 ```
-admin@sonic:~$ sudo sonic-bootchart config --samples 500 --frequency 10
+admin@sonic:~$ sudo sonic-bootchart config --time-span 50 --frequency 10
 ```
 
-This command will update /etc/systemd/bootchart.conf. The next time bootchart will run (at system start after reboot) it will take the new values.
-*systemd-bootchart* saves the plots to a temporary directory /run/log that is flushed after reboot.
+This command will update /etc/systemd/bootchart.conf. The next time bootchart
+will run (at system start after reboot) it will take the new values.
+*systemd-bootchart* saves the plots to a temporary directory /run/log that is
+*flushed after reboot.
 
 Displaying configuration, operational status and output SVG plots:
 
 ```
 admin@sonic:~$ sudo sonic-bootchart show
-Status      Operational Status    Samples    Frequency    Time (sec)  Output
---------  --------------------  ---------  -----------  ------------  ------------------------------------
-enabled              in-active        500           10            50  /run/log/bootchart-20220504-1325.svg
+Status      Operational Status   Frequency    Time Span (sec)  Output
+--------  --------------------  -----------  ----------------  ------------------------------------
+enabled              in-active          10                 50  /run/log/bootchart-20220504-1325.svg
 ```
 
 Fields description:
 
-| Field |  Comment |
-|-------|--------------------------|
-| Status | Output of "systemctl is-enabled systemd-bootchart". Shows whether this service is configured to start at boot (enabled/disabled) |
-| Operational Status | Output of "systemctl is-action systemd-bootchart". Shows whether this service is currently collecting samples (active/in-active) |
-| Samples | Configured amount of samples to collect |
-| Frequency | How frequent to collect samples per second |
-| Time | The time how long after boot samples will be collected, it is a result of division samples/frequency |
-| Output | If systemd-bootchart finished collecting samples (in-active) this column will display resulting plots, otherwise this column is empty |
+| Field              | Comment                                                                                                                               |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Status             | Output of "systemctl is-enabled systemd-bootchart". Shows whether this service is configured to start at boot (enabled/disabled)      |
+| Operational Status | Output of "systemctl is-action systemd-bootchart". Shows whether this service is currently collecting samples (active/in-active)      |
+| Frequency          | How frequent to collect samples per second                                                                                            |
+| Time Span          | The time how long after boot samples will be collected. Based on it the samples count is calculated as Frequency x Time Span          |
+| Output             | If systemd-bootchart finished collecting samples (in-active) this column will display resulting plots, otherwise this column is empty |
 
 
 Usage example:
 
 - First make sure you have SONiC image built with INCLUDE_BOOTCHART=y
 - Enable bootchart: "sudo sonic-bootchart enable"
-- Perform any kind of reboot: "sudo reboot" or "sudo warm-reboot" or "sudo fast-reboot"
-- Wait till system reboots and the plot is generated by quering "sudo sonic-bootchart show"
+- Perform any kind of reboot: "sudo reboot" or "sudo warm-reboot" or "sudo
+fast-reboot"
+ - Wait till system reboots and the plot is generated by quering
+"sudo sonic-bootchart show"
 
 #### Manifest (if the feature is an Application Extension)
 
@@ -199,4 +227,5 @@ N/A
 
 ### Open/Action items
 
-N/A
+- SONiC installer bootchart config migration. Being able to run this tool for reboot with SONiC-2-SONiC upgrade
+- Requested a possibility to run the tool in runtime after boot

--- a/doc/profiling/sonic_bootchart.md
+++ b/doc/profiling/sonic_bootchart.md
@@ -1,0 +1,156 @@
+<!-- omit in toc -->
+# SONiC Boot Chart #
+
+<!-- omit in toc -->
+## Table of Content
+
+- Revision
+- Scope
+- Definitions/Abbreviations
+- Overview
+- Requirements
+- Architecture Design
+- High-Level Design
+- SAI API
+- Configuration and management
+	- Manifest (if the feature is an Application Extension)
+	- CLI/YANG model Enhancements
+	- Config DB Enhancements
+- Warmboot and Fastboot Design Impact
+- Restrictions/Limitations
+- Testing Requirements/Design
+	- Unit Test cases
+	- System Test cases
+- Open/Action items - if any
+
+### Revision
+
+### Scope
+
+SONiC OS is highly modular and composible system, where every new feature is often implemented as a new script, utility, daemon or docker container. A lot of these components start at SONiC boot togather with respect to their dependencies requirements. Majority of start scripts use short-living small utilities written in python, bash or other scripting languages, invoke Jinja2 template generation. This leads to potential boot time performance degradation that we need a tool to detect and analyze.
+
+### Definitions/Abbreviations
+
+N/A
+
+### Overview
+
+This document describes an integration of one of systemd tools called *systemd-bootchart*. This tool is a sampling based system profiler that is used to analyze boot up performance but not limited to and can be used to collect samples after the system is booted. The output produced by systemd-bootchart is an SVG image that looks like this:
+
+<p align=center>
+<img src="img/bootchart.svg" alt="Figure 1. Bootchart example">
+</p>
+
+### Requirements
+
+- Integrate systemd-bootchart with SONiC OS
+- SONiC CLI tool to interact with systemd-bootchart
+- Support commands to enable/disable systemd-bootchart
+- Configure the amount of samples to collect and frequency
+- Displaying systemd-bootchart configuration and generated SVG plots
+
+### Architecture Design
+
+N/A
+
+### High-Level Design
+
+SONiC build system includes a new build-time flag to INCLUDE_BOOTCHART. When this flag is set a *systemd-bootchart* debian package is installed in SONiC host from upstream debian repositories (Installed size 128 KB). 
+SONiC provides a default configuration for bootchart located at /etc/systemd/bootchart.conf:
+
+```ini
+[Bootchart]
+Samples=4500
+Frequency=25
+```
+
+This configuration means that samples are collected for 3 minutes of uptime with a frequency of 25 samples per second.
+
+SONiC utilities is extendeded with a new script under *scripts/* to include a new utility *sonic-bootchart*.
+
+### SAI API
+
+N/A
+
+### Configuration and management
+
+*sonic-bootchart* is a stand alone utility, like *sonic-kdump-config*, *sonic-installer*, etc.
+
+Command line interface:
+
+```
+admin@sonic:~$ sudo sonic-bootchart
+Usage: sonic-bootchart [OPTIONS] COMMAND [ARGS]...
+
+  Main CLI group
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  config   Configure bootchart NOTE: This command requires elevated (root)...
+  disable  Disable bootchart NOTE: This command requires elevated (root)...
+  enable   Enable bootchart NOTE: This command requires elevated (root)...
+  show     Display bootchart configuration
+```
+
+Enable/Disable bootchart:
+
+```
+admin@sonic:~$ sudo sonic-bootchart enable
+Running command: systemctl enable systemd-bootchart
+admin@sonic:~$ sudo sonic-bootchart disable
+Running command: systemctl disable systemd-bootchart
+```
+
+Once bootchart is enabled a systemd-bootchart.service is enabled in systemd which starts a daemon early at boot that collects samples.
+This setting is permanent, meaning, after it is enabled, bootchart will always run at boot until disabled, *config save*, *config reload* do not affect this setting.
+
+
+Update configuration:
+
+```
+admin@sonic:~$ sudo sonic-bootchart config --samples 500 --frequency 10
+admin@sonic:~$ sudo sonic-bootchart show
+Status      Operational Status    Samples    Frequency  Output
+--------  --------------------  ---------  -----------  ------------------------------------
+enabled              in-active        500           10  /run/log/bootchart-20220504-1325.svg
+```
+
+*systemd-bootchart* saves the plots to a temporary directory /run/log that is flushed after reboot.
+
+
+#### Manifest (if the feature is an Application Extension)
+
+N/A
+
+#### CLI/YANG model Enhancements
+
+N/A
+
+#### Config DB Enhancements
+
+N/A
+
+### Warmboot and Fastboot Design Impact
+N/A
+
+### Restrictions/Limitations
+
+### Testing Requirements/Design
+N/A
+
+#### Unit Test cases
+
+Cover CLI with UT for:
+  - enabling bootchart
+  - disabling bootchart
+  - config/show commands
+
+#### System Test cases
+
+N/A
+
+### Open/Action items - if any
+
+N/A

--- a/doc/profiling/sonic_bootchart.md
+++ b/doc/profiling/sonic_bootchart.md
@@ -55,7 +55,7 @@ N/A
 
 ### High-Level Design
 
-SONiC build system includes a new build-time flag to INCLUDE_BOOTCHART. When this flag is set a *systemd-bootchart* debian package is installed in SONiC host from upstream debian repositories (Installed size 128 KB). 
+SONiC build system includes a new build-time flag to INCLUDE_BOOTCHART. When this flag is set a *systemd-bootchart* debian package is installed in SONiC host from upstream debian repositories (Installed size 128 KB).
 SONiC provides a default configuration for bootchart located at /etc/systemd/bootchart.conf:
 
 ```ini
@@ -112,9 +112,9 @@ Update configuration:
 ```
 admin@sonic:~$ sudo sonic-bootchart config --samples 500 --frequency 10
 admin@sonic:~$ sudo sonic-bootchart show
-Status      Operational Status    Samples    Frequency  Output
---------  --------------------  ---------  -----------  ------------------------------------
-enabled              in-active        500           10  /run/log/bootchart-20220504-1325.svg
+Status      Operational Status    Samples    Frequency    Time (sec)  Output
+--------  --------------------  ---------  -----------  ------------  ------------------------------------
+enabled              in-active        500           10            50  /run/log/bootchart-20220504-1325.svg
 ```
 
 *systemd-bootchart* saves the plots to a temporary directory /run/log that is flushed after reboot.


### PR DESCRIPTION
|PR title|state|context|
|-|-|-|
|[[sonic_debian_extension] install systemd-bootchart](https://github.com/Azure/sonic-buildimage/pull/11047)|![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-buildimage/11047)|![GitHub pull request check context](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-buildimage/11047)|
|[[sonic-bootchart] add sonic-bootchart ](https://github.com/Azure/sonic-utilities/pull/2195)|![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-utilities/2195)|![GitHub pull request check context](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-utilities/2195)|
