### PR TITLE
[password-hardening]Add small modification in compilation chapter in …

### DIFF
--- a/doc/passw_hardening/hld_password_hardening.md
+++ b/doc/passw_hardening/hld_password_hardening.md
@@ -49,7 +49,7 @@
 
 ###  1.2. <a name='Scope'></a>Scope
 
-This password hardening hld doc described the requirements, architecture and configuration details of password hardening feature in switches Sonic OS based.
+This password hardening hld doc described the requirements, architecture and configuration details of password hardening feature in switches SONIC OS based.
 
 ###  1.3. <a name='DefinitionsAbbreviations'></a>Definitions/Abbreviations
 	PW - password
@@ -100,7 +100,7 @@ See linux 3d party component chapter for more description
 ![password hardening flow](ph_diagram.jpg)
 
 ####  1.7.1. <a name='Flowdescription:'></a>Flow description:
-When the feature is enabled, Users by using Sonic CLI will set new password policies/configuration (see PW options below) saving those in CONF_DB in PASSWH_TABLE.
+When the feature is enabled, Users by using SONIC CLI will set new password policies/configuration (see PW options below) saving those in CONF_DB in PASSWH_TABLE.
 
 The daemon named hostcfgd daemon will be extended to listen to password hardening policies/configurations from PASSWH table, parse the inputs and set the new policies to PAM lib using pam-cracklib, chage, pwhistory libs.
 
@@ -231,15 +231,11 @@ For saving password with sha512, need to modify the /etc/pam.d/system-auth-a fil
 
 ###  1.8. <a name='InitFlow'></a>Init Flow
 ####  1.8.1. <a name='Compilation'></a>Compilation
-This feature will be enabled by default in the compilation stage, this means that it will be compiled, and will be not compiled only when the user specifically adds the relevant compilation flag "INCLUDE_PASSWH=n" in sonic-buildimage/rules/config file.
+This feature will be compiled always, but it will be disabled by default (from running time point of view).
+Meaning that the switch will boot with an image that includes the feature code and the status of the feature will be disabled, so no password hardening policies are configured in the system. 
+This default configuration can be founded in init_cfg.json.j2.
 
-In addition, the feature will have CLI as a "plugin", meaning that when the feature is not compiled will be not appear in the CLI of the switch, and vice versa.
-
-Feature enable details:
-when compilation flag is enabled(default value), users can still enable or disable this feature in runtime.
-By default if the feature was compiled, the feature status will be disabled, meaning that the switch will boot with the feature compiled, but disable.
-the disable default configuration can be founded in init_cfg.json.j2 file.
-In case, the user want to enable the feature it can be done by using the Sonic CLI (details in CLI chapter).
+In addition, the user can enable/disable the feature in running time by using the SONIC CLI (details in CLI chapter).
 
 ####  1.8.2. <a name='Dependencies'></a>Dependencies
 Service dependencies: same dependencies as HOSTCFGD, INIT_CONF and NTP service.

--- a/doc/passw_hardening/sonic-passwh.yang
+++ b/doc/passw_hardening/sonic-passwh.yang
@@ -1,7 +1,7 @@
 module sonic-passwh {
     yang-version 1.1;
     namespace "http://github.com/Azure/sonic-passwh";
-    prefix passwh;
+    prefix password;
 
     description "PASSWORD HARDENING YANG Module for SONiC OS";
 
@@ -18,75 +18,58 @@ module sonic-passwh {
             }
         }
 
-		container PASSWH {
-			description "PASSWORD HARDENING part of config_db.json";
-			container POLICIES {
-				leaf state {
-					description "state of the feature";
-					type feature_state;
-					default "disabled";
-				}
-				leaf expiration {
-					description "expiration time (days unit)";
-					default 180;
-					type uint32 {
-						range 1..365;
-					}
-				}
-				leaf expiration_warning {
-					description "expiration warning time (days unit)";
-					default 15;
-					type uint8 {
-						range 1..30;
-					}
-				}
-				leaf history_cnt {
-					description "num of old password that the system will recorded";
-					default 10;
-					type uint8 {
-						range 1..100;
-					}
-				}
-				leaf len_max {
-					description "password max length";
-					default 64;
-					type uint8 {
-						range 64..80;
-					}
-				}
-				leaf len_min {
-					description "password min length";
-					default 8;
-					type uint8 {
-						range 1..32;
-					}
-				}
-				leaf username_passw_match{
-					description "username password match";
-					default true;
-					type boolean;
-				}
-				leaf lower_class{
-					description "password lower chars policy";
-					default true;
-					type boolean;
-				}
-				leaf upper_class{
-					description "password upper chars policy";
-					default true;
-					type boolean;
-				}
-				leaf digits_class{
-					description "password digits chars policy";
-					default true;
-					type boolean;
-				}
-				leaf special_class{
-					description "password special chars policy";
-					default true;
-					type boolean;
-				}
-			}/*container policies */
-		} /* container PASSWH  */
+        container PASSW_HARDENING {
+            description "PASSWORD HARDENING part of config_db.json";
+            container POLICIES {
+                leaf state {
+                    description "state of the feature";
+                    type feature_state;
+                }
+                leaf expiration {
+                    description "expiration time (days unit)";
+                    type uint16 {
+                        range 1..365;
+                    }
+                }
+                leaf expiration_warning {
+                    description "expiration warning time (days unit)";
+                    type uint8 {
+                        range 1..30;
+                    }
+                }
+                leaf history_cnt {
+                    description "num of old password that the system will recorded";
+                    type uint8 {
+                        range 1..100;
+                    }
+                }
+                leaf len_min {
+                    description "password min length";
+                    type uint8 {
+                        range 1..32;
+                    }
+                }
+                leaf reject_user_passw_match{
+                    description "username password match";
+                    type boolean;
+                }
+                leaf lower_class{
+                    description "password lower chars policy";
+                    type boolean;
+                }
+                leaf upper_class{
+                    description "password upper chars policy";
+                    type boolean;
+                }
+                leaf digits_class{
+                    description "password digits chars policy";
+                    type boolean;
+                }
+                leaf special_class{
+                    description "password special chars policy";
+                    type boolean;
+                }
+            }/*container policies */
+        } /* container PASSWH  */
     }/* container sonic-passwh */
 }/* end of module sonic-passwh */


### PR DESCRIPTION
The Password Hardening compilation chapter is updated to include recent decisions taken during the code review.
The feature is always compiled when building the image, and is disabled by default.

This modification was done because in general the user always wants to have the possibility to enable/disable the feature and if the user for some reason does not compile the feature, this will enforce him to burn the image again.

In addition, the code of the feature exists in hostcfgd and this daemon is coded in python so it does not really influence the compilation time because python code is an interpreter.ng HLD