### PR TITLE
Updated Barefoot to Intel as ASIC Vendor

### DIFF
--- a/Supported-Devices-and-Platforms.html
+++ b/Supported-Devices-and-Platforms.html
@@ -471,7 +471,7 @@ function Port_Config() {
 <tr>
 <td>Arista</td>
 <td>7170-32CD</td>
-<td class="asic_vendor">Barefoot</td>
+<td class="asic_vendor">Intel</td>
 <td>Tofino</td>
 <td>32x100G + 2x10G</td>
 <td></td>
@@ -479,7 +479,7 @@ function Port_Config() {
 <tr>
 <td>Arista</td>
 <td>7170-64C</td>
-<td class="asic_vendor">Barefoot</td>
+<td class="asic_vendor">Intel</td>
 <td>Tofino</td>
 <td>64x100G</td>
 <td></td>
@@ -509,25 +509,17 @@ function Port_Config() {
 <td></td>
 </tr>
 <tr>
-<td>Barefoot</td>
-<td>SONiC-P4</td>
-<td class="asic_vendor">Barefoot</td>
-<td>P4 Emulated</td>
-<td>Configurable</td>
-<td></td>
-</tr>
-<tr>
-<td>Barefoot</td>
+<td>Accton</td>
 <td>Wedge 100BF-32</td>
-<td class="asic_vendor">Barefoot</td>
+<td class="asic_vendor">Intel</td>
 <td>Tofino</td>
 <td>32x100G</td>
 <td></td>
 </tr>
 <tr>
-<td>Barefoot</td>
+<td>Accton</td>
 <td>Wedge 100BF-65X</td>
-<td class="asic_vendor">Barefoot</td>
+<td class="asic_vendor">Intel</td>
 <td>Tofino</td>
 <td>32x100G</td>
 <td></td>
@@ -837,7 +829,7 @@ function Port_Config() {
 <tr>
 <td>Ingrasys</td>
 <td>S9180-32X</td>
-<td class="asic_vendor">Barefoot</td>
+<td class="asic_vendor">Intel</td>
 <td>Tofino</td>
 <td>32x100G</td>
 <td></td>
@@ -861,7 +853,7 @@ function Port_Config() {
 <tr>
 <td>Ingrasys</td>
 <td>S9280-64X</td>
-<td class="asic_vendor">Barefoot</td>
+<td class="asic_vendor">Intel</td>
 <td>Tofino</td>
 <td>64x100G</td>
 <td></td>
@@ -1093,7 +1085,7 @@ function Port_Config() {
 <tr>
 <td>Wnc</td>
 <td>OSW1800</td>
-<td class="asic_vendor">Barefoot</td>
+<td class="asic_vendor">Intel</td>
 <td>Tofino</td>
 <td>48x25G + 6x100G</td>
 <td></td>


### PR DESCRIPTION
Updated Barefoot to Intel as ASIC Vendor for Supported device and platform html file.