### PR TITLE
Update for Barefoot images

### DIFF
--- a/Supported-Devices-and-Platforms.html
+++ b/Supported-Devices-and-Platforms.html
@@ -405,6 +405,22 @@ function Port_Config() {
 <td></td>
 </tr>
 <tr>
+<td>Accton</td>
+<td>Wedge 100BF-32</td>
+<td class="asic_vendor">Barefoot</td>
+<td>Tofino</td>
+<td>32x100G</td>
+<td></td>
+</tr>
+<tr>
+<td>Accton</td>
+<td>Wedge 100BF-65X</td>
+<td class="asic_vendor">Barefoot</td>
+<td>Tofino</td>
+<td>32x100G</td>
+<td></td>
+</tr>
+<tr>
 <td>Alphanetworks</td>
 <td>SNH60A0-320Fv2</td>
 <td class="asic_vendor">Broadcom</td>
@@ -471,7 +487,7 @@ function Port_Config() {
 <tr>
 <td>Arista</td>
 <td>7170-32CD</td>
-<td class="asic_vendor">Intel</td>
+<td class="asic_vendor">Barefoot</td>
 <td>Tofino</td>
 <td>32x100G + 2x10G</td>
 <td></td>
@@ -479,7 +495,7 @@ function Port_Config() {
 <tr>
 <td>Arista</td>
 <td>7170-64C</td>
-<td class="asic_vendor">Intel</td>
+<td class="asic_vendor">Barefoot</td>
 <td>Tofino</td>
 <td>64x100G</td>
 <td></td>
@@ -506,22 +522,6 @@ function Port_Config() {
 <td class="asic_vendor">Broadcom</td>
 <td>Jericho 2</td>
 <td>32x100G + 4x400G</td>
-<td></td>
-</tr>
-<tr>
-<td>Accton</td>
-<td>Wedge 100BF-32</td>
-<td class="asic_vendor">Intel</td>
-<td>Tofino</td>
-<td>32x100G</td>
-<td></td>
-</tr>
-<tr>
-<td>Accton</td>
-<td>Wedge 100BF-65X</td>
-<td class="asic_vendor">Intel</td>
-<td>Tofino</td>
-<td>32x100G</td>
 <td></td>
 </tr>
 <tr>
@@ -829,7 +829,7 @@ function Port_Config() {
 <tr>
 <td>Ingrasys</td>
 <td>S9180-32X</td>
-<td class="asic_vendor">Intel</td>
+<td class="asic_vendor">Barefoot</td>
 <td>Tofino</td>
 <td>32x100G</td>
 <td></td>
@@ -853,7 +853,7 @@ function Port_Config() {
 <tr>
 <td>Ingrasys</td>
 <td>S9280-64X</td>
-<td class="asic_vendor">Intel</td>
+<td class="asic_vendor">Barefoot</td>
 <td>Tofino</td>
 <td>64x100G</td>
 <td></td>
@@ -1085,7 +1085,7 @@ function Port_Config() {
 <tr>
 <td>Wnc</td>
 <td>OSW1800</td>
-<td class="asic_vendor">Intel</td>
+<td class="asic_vendor">Barefoot</td>
 <td>Tofino</td>
 <td>48x25G + 6x100G</td>
 <td></td>


### PR DESCRIPTION
Updating the supported platform file for Barefoot images. Due to ASIC vendor name change(Barefoot to Intel) the images where not populated. Reverting the ASIC vendor name back to Barefoot from Intel, which will reflect the image name for the devices supporting barefoot images.