### PR TITLE
System health update - support checking PSU power exceeding threshold status

### DIFF
--- a/doc/system_health_monitoring/system-health-HLD.md
+++ b/doc/system_health_monitoring/system-health-HLD.md
@@ -221,6 +221,8 @@ psud need to collect more PSU data to the DB to satisfy the requirement of this 
 	voltage                 = INT                            ; output voltage of the PSU
 	voltage_max_th          = INT                            ; max threshold of the output voltage
 	voltage_min_th          = INT                            ; min threshold of the output voltage
+    power_overload          = "true" / "false"               ; whether the PSU's power exceeds the threshold
+    power_threshold         = 1*4.3DIGIT                     ; The power threshold which is exceeded in case power_overload is true
 
 ## 5. System health monitor CLI
 
@@ -275,6 +277,7 @@ When something is wrong
         orchagent is not running
 	Hardware           Fault
         PSU 1 temp 85C and threshold is 70C
+		PSU 1 power (66.32w) exceeds threshold (60.00w)
         FAN 2 is broken
 
 for the "detail" sub command output, it will give out all the services and devices status which is under monitoring, and also the ignored service/device list will also be displayed.
@@ -290,6 +293,7 @@ Fault condition and CLI output string table
  | Any fan is missing/broken   |[FAN name] is missing/broken|
  | Fan speed is below minimal range|[FAN name] speed is lower than expected|
  | PSU power voltage is out of range|[PSU name] voltage is out of range|
+ | PSU power exceeds threshold|[PSU name] power exceeds threshold|
  | PSU temp is too hot|[PSU name] is overheated|
  | PSU is in bad status|[PSU name] is broken|
  | ASIC temperature is too hot|[ASIC name] is overheated|


### PR DESCRIPTION
Support checking PSU power exceeding threshold status.
If `PSU_INFO|<PSU name>.power_overload` is `True`, the system health state will be `Not OK` and corresponding message will be pushed into `STATE_DB|SYSTEM_HEALTH_INFO`.

Depends on #1060

Signed-off-by: Stephen Sun <stephens@nvidia.com>