### PR TITLE
Update VRF unbind CLI command

### DIFF
--- a/doc/vrf/sonic-vrf-hld.md
+++ b/doc/vrf/sonic-vrf-hld.md
@@ -715,7 +715,7 @@ $ config vrf del <vrf_name>
 $ config interface vrf bind <interface_name> <vrf_name>
 
 //unbind an interface from a VRF
-$ config interface vrf unbind <interface_name> <vrf_name>
+$ config interface vrf unbind <interface_name>
 
 // create loopback device
 $ config loopback add Loopback<0-999>
@@ -824,7 +824,7 @@ This command will do the following:
 To unbind an interface from VRF:
 
 ```bash
-$ config interface unbind Ethernet0 Vrf-blue
+$ config interface unbind Ethernet0
 ```
 
 This command will do the following:


### PR DESCRIPTION
### Why I did it
`config interface bind vrf` does not take the additional `<vrf_name>` argument.

### Where I tested it
KVM testbed using 202205 sonic image 

### How I tested it
a) `--help` argument for above-mentioned command shows that the additional argument is not supported
![image](https://user-images.githubusercontent.com/77692425/185307846-235fb470-7f90-417b-a887-bc56d769ecfa.png)

b) `unbind` only works when additional argument is not provided.
![image](https://user-images.githubusercontent.com/77692425/185308824-8643a8db-39de-4ad1-9d7b-1babbcf92579.png)

c) commands differ in HLD and [CLI](https://github.com/sonic-net/sonic-utilities/blob/master/config/main.py) 
<img width="392" alt="image" src="https://user-images.githubusercontent.com/77692425/185311169-77cddc65-20d6-4701-b48f-5f0f5f30cabd.png">
