### PR TITLE
[dualtor][active-active] Add `Skip adding ingress drop ACL` section

### DIFF
--- a/doc/dualtor/active_active_hld.md
+++ b/doc/dualtor/active_active_hld.md
@@ -51,6 +51,7 @@ This document provides the high level design of SONiC dual toR solution, support
     - [3.8.1 Advertise updated routes to T1](#381-advertise-updated-routes-to-t1)
     - [3.8.2 Server Servicing & ToR Upgrade](#382-server-servicing--tor-upgrade)
     - [3.8.3 BGP update delay](#383-bgp-update-delay)
+    - [3.8.4 Skip adding ingress drop ACL](#384-skip-adding-ingress-drop-acl)
   - [3.9 Command Line](#39-command-line)
 
 [4 Warm Reboot Support](#4-warm-reboot-support)

--- a/doc/dualtor/active_active_hld.md
+++ b/doc/dualtor/active_active_hld.md
@@ -482,7 +482,7 @@ So for the active-active T0s, a BGP update delay of 10 seconds is introduced to 
 #### 3.8.4 Skip adding ingress drop ACL
 Previously, at a high level, when the mux port comes to standby, the MuxOrch add ingress ACL to drop packets on the mux port. And when the mux port comes to active, the MuxOrch remove the ingress ACL. As described in [3.6], the MuxOrch is acted an intermediate agent between LinkMgrd and the transceiver daemon. Before the NiC receives gRPC request to toggle standby, the ingress drop ACL has already been programmed by MuxOrch. In this period, the server NiC still regard this ToR as active and could send upstream traffic to this ToR, but the upstream traffic will be dropped by the installed ingress drop ACL rule.
 
-A change to skip the installation of ingress drop ACL rule when toggling standby is introduced to forward the upstream traffic with best effort. this is because that, though the mux port is already in standby state in this period, the removal of the ingress drop ACL could allow the upstream traffic to reach the ToR and to be possibly forwarded by the ToR.
+A change to skip the installation of ingress drop ACL rule when toggling standby is introduced to forward the upstream traffic with best effort. This is because that, though the mux port is already in standby state in this period, the removal of the ingress drop ACL could allow the upstream traffic to reach the ToR and to be possibly forwarded by the ToR.
 
 ### 3.9 Command Line
 TBD 


### PR DESCRIPTION
Add `Skip adding ingress drop ACL` section to the dualtor active-active HLD.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>