### PR TITLE
Updated new platform for Barefoot Aurora 610

### DIFF
--- a/Supported-Devices-and-Platforms.html
+++ b/Supported-Devices-and-Platforms.html
@@ -238,7 +238,6 @@ function Port_Config() {
 </tbody>
 </table>
 <h2><p style="text-align: left; font-family: Verdana, sans-serif; color: #2E86C1; font-size: 20px">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Following is the list of platforms that supports SONiC.</p></h2>
-<h2><p style="text-align: left; font-family: Verdana, sans-serif; color: #2E86C1; font-size: 20px">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Note : The column "Successful build" is an auto generated link using script. However due to permission issue on executing the script, the auto generation is not happening. Hence we have manually updated the column until 22nd December 2022 build image. For latest build <a  href="https://sonic-build.azurewebsites.net/ui/sonic/Pipelines">click here</a> </p></h2>
 <br>
 
 <table id="myTable" style="width: 70%; background-color: #ffffff; font-family: Verdana, sans-serif;" align="center">
@@ -406,6 +405,22 @@ function Port_Config() {
 <td></td>
 </tr>
 <tr>
+<td>Accton</td>
+<td>Wedge 100BF-32</td>
+<td class="asic_vendor">Intel</td>
+<td>Tofino</td>
+<td>32x100G</td>
+<td></td>
+</tr>
+<tr>
+<td>Accton</td>
+<td>Wedge 100BF-65X</td>
+<td class="asic_vendor">Intel</td>
+<td>Tofino</td>
+<td>32x100G</td>
+<td></td>
+</tr>
+<tr>
 <td>Alphanetworks</td>
 <td>SNH60A0-320Fv2</td>
 <td class="asic_vendor">Broadcom</td>
@@ -518,19 +533,11 @@ function Port_Config() {
 <td></td>
 </tr>
 <tr>
-<td>Accton</td>
-<td>Wedge 100BF-32</td>
+<td>Aurora 610</td>
+<td>BFN-T10-032D-020</td>
 <td class="asic_vendor">Intel</td>
 <td>Tofino</td>
-<td>32x100G</td>
-<td></td>
-</tr>
-<tr>
-<td>Accton</td>
-<td>Wedge 100BF-65X</td>
-<td class="asic_vendor">Intel</td>
-<td>Tofino</td>
-<td>32x100G</td>
+<td>48x 25G + 8x 100G</td>
 <td></td>
 </tr>
 <tr>
@@ -1123,7 +1130,6 @@ function Port_Config() {
 <td>128x200G</td>
 <td></td>
 </tr>
-
 <tr>
 <td>Wnc</td>
 <td>OSW1800</td>


### PR DESCRIPTION
Updated new platform for Barefoot Aurora 610 and as the build images are auto generating, we have removed the Note.