### PR TITLE
Update RSyslog HLD with new functionality

### DIFF
--- a/doc/syslog/syslog-design.md
+++ b/doc/syslog/syslog-design.md
@@ -1,83 +1,75 @@
-# 1. SONiC Syslog Source IP
+<!-- omit in toc -->
+# SONiC Syslog Source IP
 
-## 1.1. High Level Design document
+## High Level Design document
 
-## 1.2. Table of contents
+## Table of contents
 
-- [1. SONiC Syslog Source IP](#1-sonic-syslog-source-ip)
-  - [1.1. High Level Design document](#11-high-level-design-document)
-  - [1.2. Table of contents](#12-table-of-contents)
-  - [1.3. Revision](#13-revision)
-  - [1.4. About this manual](#14-about-this-manual)
-  - [1.5. Scope](#15-scope)
-  - [1.6. Abbreviations](#16-abbreviations)
-  - [1.7. List of figures](#17-list-of-figures)
-  - [1.8. List of tables](#18-list-of-tables)
-- [2. Introduction](#2-introduction)
-  - [2.1. Feature overview](#21-feature-overview)
-  - [2.2. Requirements](#22-requirements)
-    - [2.2.1. Functionality](#221-functionality)
-    - [2.2.2. Command interface](#222-command-interface)
-    - [2.2.3. Error handling](#223-error-handling)
-    - [2.2.4. Event logging](#224-event-logging)
-      - [2.2.4.1. Table 1: Event logging](#2241-table-1-event-logging)
-- [3. Design](#3-design)
-  - [3.1. Overview](#31-overview)
-  - [3.2. Syslog Forwarding Output Module](#32-syslog-forwarding-output-module)
-    - [3.2.1. Overview](#321-overview)
-      - [3.2.1.1. Table 2: Syslog global config Module](#3211-table-2-syslog-global-config-module)
-      - [3.2.1.2. Table 3: Syslog Forwarding Output Module](#3212-table-3-syslog-forwarding-output-module)
-    - [3.2.2. IpFreeBind](#322-ipfreebind)
-  - [3.3. Configuration agent](#33-configuration-agent)
-    - [3.3.1. Overview](#331-overview)
-    - [3.3.2. global syslog configuration](#332-global-syslog-configuration)
-      - [3.3.2.1. Table 4: Global configuration parameters](#3321-table-4-global-configuration-parameters)
-      - [3.3.2.2. Format: `set`:](#3322-format-set)
-    - [3.3.3. SSIP parameters](#333-ssip-parameters)
-      - [3.3.3.1. Table 5: SSIP parameters](#3331-table-5-ssip-parameters)
-    - [3.3.4. SSIP configuration](#334-ssip-configuration)
-      - [3.3.4.1. VRF/Source: `unset/unset`](#3341-vrfsource-unsetunset)
-      - [3.3.4.2. VRF/Source: `unset/set`](#3342-vrfsource-unsetset)
-      - [3.3.4.3. VRF/Source: `set/unset`](#3343-vrfsource-setunset)
-      - [3.3.4.4. VRF/Source: `set/set`](#3344-vrfsource-setset)
-      - [3.3.4.5. Filter/Trap: `set/set`](#3345-filtertrap-setset)
-      - [3.3.4.6. Protocol: `set`](#3346-protocol-set)
-  - [3.4. DB schema](#34-db-schema)
-    - [3.4.1. Config DB](#341-config-db)
-      - [3.4.1.1. Global syslog table](#3411-global-syslog-table)
-      - [3.4.1.2. SSIP table](#3412-ssip-table)
-    - [3.4.2. Data sample](#342-data-sample)
-    - [3.4.3. Configuration sample](#343-configuration-sample)
-    - [3.4.4. Configuration migration](#344-configuration-migration)
-  - [3.5. Flows](#35-flows)
-    - [3.5.1. SSIP add](#351-ssip-add)
-      - [3.5.1.1. Figure 1: SSIP add flow](#3511-figure-1-ssip-add-flow)
-    - [3.5.2. SSIP remove](#352-ssip-remove)
-      - [3.5.2.1. Figure 2: SSIP remove flow](#3521-figure-2-ssip-remove-flow)
-  - [3.6. CLI](#36-cli)
-    - [3.6.1. Command structure](#361-command-structure)
-    - [3.6.2. Usage examples](#362-usage-examples)
-      - [3.6.2.1. Config command group](#3621-config-command-group)
-      - [3.6.2.2. Show command group](#3622-show-command-group)
-  - [3.7. YANG model](#37-yang-model)
-  - [3.8. Warm/Fast boot](#38-warmfast-boot)
-- [4. Test plan](#4-test-plan)
-  - [4.1. Unit tests via VS](#41-unit-tests-via-vs)
-  - [4.2. Data plane tests via PTF](#42-data-plane-tests-via-ptf)
+- [1. Introduction](#1-introduction)
+  - [1.1. Feature overview](#11-feature-overview)
+  - [1.2. Requirements](#12-requirements)
+    - [1.2.1. Functionality](#121-functionality)
+    - [1.2.2. Command interface](#122-command-interface)
+    - [1.2.3. Error handling](#123-error-handling)
+    - [1.2.4. Event logging](#124-event-logging)
+      - [1.2.4.1. Table 1: Event logging](#1241-table-1-event-logging)
+- [2. Design](#2-design)
+  - [2.1. Overview](#21-overview)
+  - [2.2. Syslog Forwarding Output Module](#22-syslog-forwarding-output-module)
+    - [2.2.1. Overview](#221-overview)
+      - [2.2.1.1. Table 2: Syslog global config Module](#2211-table-2-syslog-global-config-module)
+      - [2.2.1.2. Table 3: Syslog Forwarding Output Module](#2212-table-3-syslog-forwarding-output-module)
+    - [2.2.2. IpFreeBind](#222-ipfreebind)
+  - [2.3. Configuration agent](#23-configuration-agent)
+    - [2.3.1. Overview](#231-overview)
+    - [2.3.2. global syslog configuration](#232-global-syslog-configuration)
+      - [2.3.2.1. Table 4: Global configuration parameters](#2321-table-4-global-configuration-parameters)
+      - [2.3.2.2. Format: `set`:](#2322-format-set)
+    - [2.3.3. SSIP parameters](#233-ssip-parameters)
+      - [2.3.3.1. Table 5: SSIP parameters](#2331-table-5-ssip-parameters)
+    - [2.3.4. SSIP configuration](#234-ssip-configuration)
+      - [2.3.4.1. VRF/Source: `unset/unset`](#2341-vrfsource-unsetunset)
+      - [2.3.4.2. VRF/Source: `unset/set`](#2342-vrfsource-unsetset)
+      - [2.3.4.3. VRF/Source: `set/unset`](#2343-vrfsource-setunset)
+      - [2.3.4.4. VRF/Source: `set/set`](#2344-vrfsource-setset)
+      - [2.3.4.5. Filter/Trap: `set/set`](#2345-filtertrap-setset)
+      - [2.3.4.6. Protocol: `set`](#2346-protocol-set)
+  - [2.4. DB schema](#24-db-schema)
+    - [2.4.1. Config DB](#241-config-db)
+      - [2.4.1.1. Global syslog table](#2411-global-syslog-table)
+      - [2.4.1.2. SSIP table](#2412-ssip-table)
+    - [2.4.2. Data sample](#242-data-sample)
+    - [2.4.3. Configuration sample](#243-configuration-sample)
+    - [2.4.4. Configuration migration](#244-configuration-migration)
+  - [2.5. Flows](#25-flows)
+    - [2.5.1. SSIP add](#251-ssip-add)
+      - [2.5.1.1. Figure 1: SSIP add flow](#2511-figure-1-ssip-add-flow)
+    - [2.5.2. SSIP remove](#252-ssip-remove)
+      - [2.5.2.1. Figure 2: SSIP remove flow](#2521-figure-2-ssip-remove-flow)
+  - [2.6. CLI](#26-cli)
+    - [2.6.1. Command structure](#261-command-structure)
+    - [2.6.2. Usage examples](#262-usage-examples)
+      - [2.6.2.1. Config command group](#2621-config-command-group)
+      - [2.6.2.2. Show command group](#2622-show-command-group)
+  - [2.7. YANG model](#27-yang-model)
+  - [2.8. Warm/Fast boot](#28-warmfast-boot)
+- [3. Test plan](#3-test-plan)
+  - [3.1. Unit tests via VS](#31-unit-tests-via-vs)
+  - [3.2. Data plane tests via PTF](#32-data-plane-tests-via-ptf)
 
 
-## 1.3. Revision
+## Revision
 
 | Rev | Date       | Author         | Description           |
 |:---:|:----------:|:--------------:|:----------------------|
 | 0.1 | 18/04/2022 | Nazarii Hnydyn | Initial version       |
-| 0.2 | 08/01/2023 | Ido Avraham    | extend capabilities   |
+| 0.2 | 08/01/2023 | Ido Avraham    | Added syslog configuration capabilities. </br> Configure remote syslog servers: protocol, filter, trap severity level. </br> Update global syslog configuration: trap severity kevel, message format |
 
-## 1.4. About this manual
+## About this manual
 
 This document provides general information about Syslog Source IP implementation in SONiC
 
-## 1.5. Scope
+## Scope
 
 This document describes the high level design of Syslog Source IP feature in SONiC
 
@@ -87,7 +79,7 @@ This document describes the high level design of Syslog Source IP feature in SON
 **Out of scope:**  
 1. Syslog Source IP configuration for TCP protocol
 
-## 1.6. Abbreviations
+## Abbreviations
 
 | Term  | Meaning                                   |
 |:------|:------------------------------------------|
@@ -104,12 +96,12 @@ This document describes the high level design of Syslog Source IP feature in SON
 | VS    | Virtual Switch                            |
 | PTF   | Packet Test Framework                     |
 
-## 1.7. List of figures
+## List of figures
 
 - [Figure 1: SSIP add flow](#figure-1-ssip-add-flow)  
 - [Figure 2: SSIP remove flow](#figure-2-ssip-remove-flow)
 
-## 1.8. List of tables
+## List of tables
 
 - [Table 1: Event logging](#2241-table-1-event-logging)
 - [Table 2: Syslog global config Module](#3211-table-2-syslog-global-config-module)
@@ -117,9 +109,9 @@ This document describes the high level design of Syslog Source IP feature in SON
 - [Table 4: Global configuration parameters](#3321-table-4-global-configuration-parameters)
 - [Table 5: SSIP parameters](#3331-table-5-ssip-parameters)
 
-# 2. Introduction
+# 1. Introduction
 
-## 2.1. Feature overview
+## 1.1. Feature overview
 
 SSIP is a feature which allows user to change UDP packet source IP address.  
 Any configured address can be used for source IP mangling.  
@@ -128,9 +120,9 @@ This might be useful for security reasons.
 SSIP also extends the existing syslog implementation with VRF device and server UDP port configuration support.
 The feature doesn't change the existing DB schema which makes it fully backward compatible.
 
-## 2.2. Requirements
+## 1.2. Requirements
 
-### 2.2.1. Functionality
+### 1.2.1. Functionality
 
 **This feature will support the following functionality:**
 1. Syslog Source IP address configuration
@@ -140,7 +132,7 @@ The feature doesn't change the existing DB schema which makes it fully backward 
 5. Syslog message severity level configuration
 6. Syslog filter configuration
 
-### 2.2.2. Command interface
+### 1.2.2. Command interface
 
 **This feature will support the following commands:**
 1. config: add/delete syslog server configuration
@@ -148,27 +140,27 @@ The feature doesn't change the existing DB schema which makes it fully backward 
 3. config: set/unset global syslog configuration
 4. show: display global syslog configuration
 
-### 2.2.3. Error handling
+### 1.2.3. Error handling
 
 **This feature will provide error handling for the next situations:**
 1. Invalid object reference
 2. Invalid options/parameters
 
-### 2.2.4. Event logging
+### 1.2.4. Event logging
 
 **This feature will provide event logging for the next situations:**
 1. Syslog server add/delete
 
-#### 2.2.4.1. Table 1: Event logging
+#### 1.2.4.1. Table 1: Event logging
 
 | Event                             | Severity |
 |:----------------------------------|:---------|
 | Syslog server add/delete: success | NOTICE   |
 | Syslog server add/delete: error   | ERROR    |
 
-# 3. Design
+# 2. Design
 
-## 3.1. Overview
+## 2.1. Overview
 
 SSIP will reuse syslog `omfwd` functionality which offers the next features:  
 1. Source IP address configuration
@@ -178,11 +170,11 @@ SSIP will reuse syslog `omfwd` functionality which offers the next features:
 5. Messages regex filtering 
 6. Messages severity filtering
 
-## 3.2. Syslog Forwarding Output Module
+## 2.2. Syslog Forwarding Output Module
 
-### 3.2.1. Overview
+### 2.2.1. Overview
 
-#### 3.2.1.1. Table 2: Syslog global config Module
+#### 2.2.1.1. Table 2: Syslog global config Module
 
 | Parameter          | Default  | Description                                                                   |
 |:-------------------|:---------|:------------------------------------------------------------------------------|
@@ -195,7 +187,7 @@ SSIP will reuse syslog `omfwd` functionality which offers the next features:
     "Syslog template configuration"
 )
 
-#### 3.2.1.2. Table 3: Syslog Forwarding Output Module
+#### 2.2.1.2. Table 3: Syslog Forwarding Output Module
 
 | Parameter     | Default  | Description                                                                               |
 |:--------------|:---------|:------------------------------------------------------------------------------------------|
@@ -218,7 +210,7 @@ SSIP will reuse syslog `omfwd` functionality which offers the next features:
     "Syslog filter configuration"
 )
 
-### 3.2.2. IpFreeBind
+### 2.2.2. IpFreeBind
 
 **IP_FREEBIND (since Linux 2.4)**
 ```
@@ -233,9 +225,9 @@ This option is the per-socket equivalent of the ip_nonlocal_bind.
     "IP_FREEBIND"
 )
 
-## 3.3. Configuration agent
+## 2.3. Configuration agent
 
-### 3.3.1. Overview
+### 2.3.1. Overview
 
 Configuration management of `rsyslogd` is done by `rsyslog-config` service.  
 The service is triggered by CLI once data is validated and pushed to Config DB.  
@@ -244,29 +236,35 @@ The `rsyslog-config` service performs the next actions:
 1. Renders `rsyslog.conf.j2` template with `sonic-cfggen` to generate a new `rsyslogd` config file
 2. Restarts `rsyslog` service which triggers `rsyslogd` to load a new config file
 
-### 3.3.2. global syslog configuration
+### 2.3.2. global syslog configuration
 
-#### 3.3.2.1. Table 4: Global configuration parameters
+#### 2.3.2.1. Table 4: Global configuration parameters
 | SONiC                 | Rsyslogd | Config DB Schema                           |
 |:----------------------|:---------|:-------------------------------------------|
 | format                | template | SYSLOG_CONFIG\|GLOBAL\|format              |
 | trap                  | priority | SYSLOG_CONFIG\|GLOBAL\|trap                |
 | welf_firewall_name    | trap     | SYSLOG_CONFIG\|GLOBAL\|welf_firewall_name  |
 
-* trap will set rules trap severity if not specified in the rule
+* trap: this field is a global trap severity. 
+  this will be the default value for all the servers in the system
+  unless overridden by setting the `server.trap` field.
+  for example you can look at `2.4.3 configuration sample`
+  server "4.4.4.4" does not set `trap` field so it will use this global trap value.
+  server "4.4.4.5" does set it so it will use his local value and not this global value.
+  
 
-#### 3.3.2.2. Format: `set`:
+#### 2.3.2.2. Format: `set`:
 
-Foramt:
+Format:
 template(name="WelfFormat" type="string" string="%TIMESTAMP% %HOSTNAME% id=firewall time=\"%timereported\
 :::date-year%-%timereported:::date-month%-%timereported:::date-day% %timereported:::date-hour%:%timereported:::date-minute%:%timereported\
 :::date-second%\" fw=\"{{ firewall-name  }}\" pri=%syslogpriority% msg=\"%syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\"\n")
 
-### 3.3.3. SSIP parameters
+### 2.3.3. SSIP parameters
 
 **SSIP will have the next parameter mapping:**
 
-#### 3.3.3.1. Table 5: SSIP parameters
+#### 2.3.3.1. Table 5: SSIP parameters
 | SONiC         | Rsyslogd | Config DB Schema                   |
 |:--------------|:---------|:-----------------------------------|
 | key           | target   | SYSLOG_SERVER\|key                 |
@@ -274,11 +272,11 @@ template(name="WelfFormat" type="string" string="%TIMESTAMP% %HOSTNAME% id=firew
 | port          | port     | SYSLOG_SERVER\|key\|port           |
 | vrf           | device   | SYSLOG_SERVER\|key\|vrf            |
 | protocol      | protocol | SYSLOG_SERVER\|key\|protocol       |
-| filter        | ereregex | SYSLOG_SERVER\|key\|filter         |
+| filter_type   | ereregex | SYSLOG_SERVER\|key\|filter_type    |
 | filter_regex  | ereregex | SYSLOG_SERVER\|key\|filter_regex   |
 | trap          | priority | SYSLOG_SERVER\|key\|trap           |
 
-### 3.3.4. SSIP configuration
+### 2.3.4. SSIP configuration
 
 SSIP offers `vrf` and `source` parameters for flexible configuration management.  
 Each parameter combination requires a dedicated handling approach.
@@ -288,7 +286,7 @@ Each parameter combination requires a dedicated handling approach.
 2. Additional validation is required when MGMT/DATA VRF is removed while reference still exists in syslog configuration
 3. trap will be default rule severity
 
-#### 3.3.4.1. VRF/Source: `unset/unset`
+#### 2.3.4.1. VRF/Source: `unset/unset`
 
 Linux kernel decides which source IP to use within the default VRF.
 
@@ -297,7 +295,7 @@ Linux kernel decides which source IP to use within the default VRF.
 *.notice action(type="omfwd" target="2.2.2.2" protocol="udp")
 ```
 
-#### 3.3.4.2. VRF/Source: `unset/set`
+#### 2.3.4.2. VRF/Source: `unset/set`
 
 Check if source IP is configured on any default VRF member:  
 yes - set source IP, no - generate error
@@ -307,7 +305,7 @@ yes - set source IP, no - generate error
 *.notice action(type="omfwd" target="2.2.2.2" protocol="udp" address="1.1.1.1")
 ```
 
-#### 3.3.4.3. VRF/Source: `set/unset`
+#### 2.3.4.3. VRF/Source: `set/unset`
 
 Check VRF type:
 1. Default
@@ -335,7 +333,7 @@ DATA VRF:
 *.notice action(type="omfwd" target="2.2.2.2" protocol="udp" device="Vrf-Data")
 ```
 
-#### 3.3.4.4. VRF/Source: `set/set`
+#### 2.3.4.4. VRF/Source: `set/set`
 
 Check VRF type:
 1. Default
@@ -369,11 +367,13 @@ DATA VRF:
 *.notice action(type="omfwd" target="2.2.2.2" protocol="udp" address="1.1.1.1" device="Vrf-Data")
 ```
 
-#### 3.3.4.5. Filter/Trap: `set/set`
+#### 2.3.4.5. Filter/Trap: `set/set`
 
 Log regex filter
 
 Filter:
+    Filter value can be either Include or Exclude.
+
     Include:
     Compares the log string against the provided POSIX ERE regular expression.
     yes - sends log string to remote server, no - do not send
@@ -398,7 +398,7 @@ Exclude:
 *.info action(type="omfwd" Target="4.4.4.5" Port="514" Protocol="udp" Device="eth0" Template="SONiCFileFormat")
 ```
 
-#### 3.3.4.6. Protocol: `set`
+#### 2.3.4.6. Protocol: `set`
 
 messages are forwarded via configured protocol
 
@@ -407,11 +407,11 @@ messages are forwarded via configured protocol
 *.notice action(type="omfwd" Target="5.5.5.5" Port="514" Protocol="tcp" Device="eth0" Template="SONiCFileFormat")
 ```
 
-## 3.4. DB schema
+## 2.4. DB schema
 
-### 3.4.1. Config DB
+### 2.4.1. Config DB
 
-#### 3.4.1.1. Global syslog table
+#### 2.4.1.1. Global syslog table
 ```abnf
 ; define schema for syslog global configuration attributes under SYSLOG_CONFIG|GLOBAL
 
@@ -428,7 +428,7 @@ template-format = welf-format / standard-format
 log-level       = "debug" / "info" / "notice" / "warn" / "error" / "crit"
 ```
 
-#### 3.4.1.2. SSIP table
+#### 2.4.1.2. SSIP table
 ```abnf
 ; defines schema for syslog table configuration attributes
 key = SYSLOG_SERVER|server_ip_address ; server IP address. Must be unique
@@ -438,7 +438,7 @@ source      = ip-addr    ; source IP address
 port        = 1*5DIGIT   ; server UDP port (0..65535)
 vrf         = vrf-device ; VRF device
 protocol    = protocol   ; protocol
-filter      = filter-re  ; filter regular expression
+filter_type = filter-re  ; filter regular expression
 trap        = log-level  ; log level severity
 
 ; value annotations
@@ -471,7 +471,7 @@ filter-re   = re-include / re-exclude
 log-level   = "debug" / "info" / "notice" / "warn" / "error" / "crit"
 ```
 
-### 3.4.2. Data sample
+### 2.4.2. Data sample
 
 **Config DB:**
 ```bash
@@ -514,7 +514,7 @@ redis-cli -n 4 HGETALL 'SYSLOG_SERVER|4.4.4.4'
  6) "default"
  7) "protocol"
  8) "udp"
- 9) "filter"
+ 9) "filter_type"
 10) "include"
 11) "filter_regex"
 12) "include_str*"
@@ -528,7 +528,7 @@ redis-cli -n 4 HGETALL 'SYSLOG_SERVER|4.4.4.5'
  6) "default"
  7) "protocol"
  8) "udp"
- 9) "filter"
+ 9) "filter_type"
 10) "exlude"
 11) "filter_regex"
 12) "exclude_str*"
@@ -547,7 +547,7 @@ redis-cli -n 4 HGETALL 'SYSLOG_SERVER|5.5.5.5'
  
  ```
 
-### 3.4.3. Configuration sample
+### 2.4.3. Configuration sample
 
 **Syslog remote logging:**
 ```json
@@ -573,7 +573,7 @@ redis-cli -n 4 HGETALL 'SYSLOG_SERVER|5.5.5.5'
             "port": "514",
             "vrf": "default",
             "protocol": "udp",
-            "filter": "include",
+            "filter_type": "include",
             "filter_regex": "include_str*"
         },
         "4.4.4.5": {
@@ -581,8 +581,8 @@ redis-cli -n 4 HGETALL 'SYSLOG_SERVER|5.5.5.5'
             "port": "514",
             "vrf": "default",
             "protocol": "udp",
-            "filter": "exclude",
-            "filter_regex": "include_str*",
+            "filter_type": "exclude",
+            "filter_regex": "exclude_str*",
             "trap": "info"
         },
          "5.5.5.5": {
@@ -600,27 +600,27 @@ redis-cli -n 4 HGETALL 'SYSLOG_SERVER|5.5.5.5'
 }
 ```
 
-### 3.4.4. Configuration migration
+### 2.4.4. Configuration migration
 
 No special handling is required
 
-## 3.5. Flows
+## 2.5. Flows
 
-### 3.5.1. SSIP add
+### 2.5.1. SSIP add
 
 ![SSIP add flow](images/ssip_add_flow.svg "Figure 1: SSIP add flow")
 
-#### 3.5.1.1. Figure 1: SSIP add flow
+#### 2.5.1.1. Figure 1: SSIP add flow
 
-### 3.5.2. SSIP remove
+### 2.5.2. SSIP remove
 
 ![SSIP remove flow](images/ssip_remove_flow.svg "Figure 2: SSIP remove flow")
 
-#### 3.5.2.1. Figure 2: SSIP remove flow
+#### 2.5.2.1. Figure 2: SSIP remove flow
 
-## 3.6. CLI
+## 2.6. CLI
 
-### 3.6.1. Command structure
+### 2.6.1. Command structure
 
 **User interface**:
 ```
@@ -640,13 +640,13 @@ _config syslog add_
 2. `-p|--port` - server udp port
 3. `-r|--vrf` - vrf device
 4. `--protocol` - server protocol
-5. `--filter_include` - filter include regex
-6. `--filter_exclude` - filter exlude regex
+5. `--filter_type` - filter type <include|exclude>
+6. `--filter_regex` - filter regex value
 7. `-t|--trap` - set trap log severity
 
-### 3.6.2. Usage examples
+### 2.6.2. Usage examples
 
-#### 3.6.2.1. Config command group
+#### 2.6.2.1. Config command group
 
 **The following command adds/deletes syslog server:**
 ```bash
@@ -657,19 +657,22 @@ config syslog add '2.2.2.2' \
 config syslog del '2.2.2.2'
 ```
 
-#### 3.6.2.2. Show command group
+#### 2.6.2.2. Show command group
 
 **The following command shows syslog server configuration:**
 ```bash
 root@sonic:/home/admin# show syslog
-SERVER IP    SOURCE IP    PORT    VRF
------------  -----------  ------  --------
-2.2.2.2      1.1.1.1      514     default
-3.3.3.3      1.1.1.1      514     mgmt
-2222::2222   1111::1111   514     Vrf-Data
+SERVER IP    SOURCE IP    PORT    VRF        PROTOCOL  FILTER_TYPE   FILTER REGEX  TRAP
+-----------  -----------  ------  --------   --------  -----------   ------------  ----
+2.2.2.2      1.1.1.1      514     default     udp                                  notice
+3.3.3.3      1.1.1.1      514     mgmt        udp                                  notice
+2222::2222   1111::1111   514     Vrf-Data    udp                                  notice
+4.4.4.4      4.4.4.4      514     default     udp      include       include_str*  notice
+4.4.4.5      4.4.4.5      514     default     udp      exclude       exclude_str*  info
+5.5.5.5      5.5.5.5      514     default     tcp                                  notice
 ```
 
-## 3.7. YANG model
+## 2.7. YANG model
 
 An existing YANG model `sonic-syslog.yang` will be extended in order to provide support for SSIP.
 
@@ -757,7 +760,7 @@ module sonic-syslog {
                 key "server_address";
 
                 leaf server_address {
-                    description "Syslog server IP address";
+                    description "Syslog server IP address or a DNS domain name";
                     type inet:host;
                 }
 
@@ -785,7 +788,7 @@ module sonic-syslog {
                     or (/mvrf:sonic-mgmt_vrf/mvrf:MGMT_VRF_CONFIG/mvrf:vrf_global/mvrf:mgmtVrfEnabled = 'true')";
                 }
 
-                leaf filter {
+                leaf filter_type {
                     description "Syslog filter type";
                     type syslog-filter-type;
                 }
@@ -803,6 +806,7 @@ module sonic-syslog {
                 leaf trap {
                     description "Limit the severity to send logs to remote server";
                     type rsyslog-severity;
+                    default "notice"
                 }
 
             }
@@ -819,6 +823,7 @@ module sonic-syslog {
                 leaf format {
                     description "Log format";
                     type log-format;
+                    default "standard";
                 }
 
                 leaf welf_firewall_name {
@@ -841,13 +846,13 @@ module sonic-syslog {
 /* end of module sonic-syslog */
 ```
 
-## 3.8. Warm/Fast boot
+## 2.8. Warm/Fast boot
 
 No special handling is required
 
-# 4. Test plan
+# 3. Test plan
 
-## 4.1. Unit tests via VS
+## 3.1. Unit tests via VS
 
 SSIP basic configuration test:
 1. Verify rsyslog.conf after syslog server creation/removal
@@ -858,6 +863,6 @@ SSIP extended configuration test:
 3. Create syslog server with default/mgmt/data VRF device
 4. Verify rsyslog.conf
 
-## 4.2. Data plane tests via PTF
+## 3.2. Data plane tests via PTF
 
 TBD

--- a/doc/syslog/syslog-design.md
+++ b/doc/syslog/syslog-design.md
@@ -71,7 +71,7 @@
 | Rev | Date       | Author         | Description           |
 |:---:|:----------:|:--------------:|:----------------------|
 | 0.1 | 18/04/2022 | Nazarii Hnydyn | Initial version       |
-| 0.2 | 08/01/2022 | Ido Avraham    | extend capabilities   |
+| 0.2 | 08/01/2023 | Ido Avraham    | extend capabilities   |
 
 ## 1.4. About this manual
 
@@ -591,6 +591,11 @@ redis-cli -n 4 HGETALL 'SYSLOG_SERVER|5.5.5.5'
             "vrf": "default",
             "protocol": "tcp",
         },
+    },
+    "SYSLOG_CONFIG": {
+        "format": "welf",
+        "trap": "info",
+        "welf_firewall_name": "my_hostname"
     }
 }
 ```

--- a/doc/syslog/syslog-design.md
+++ b/doc/syslog/syslog-design.md
@@ -1,64 +1,83 @@
-# SONiC Syslog Source IP
+# 1. SONiC Syslog Source IP
 
-## High Level Design document
+## 1.1. High Level Design document
 
-## Table of contents
+## 1.2. Table of contents
 
-- [Revision](#revision)
-- [About this manual](#about-this-manual)
-- [Scope](#scope)
-- [Abbreviations](#abbreviations)
-- [1 Introduction](#1-introduction)
-    - [1.1 Feature overview](#11-feature-overview)
-    - [1.2 Requirements](#12-requirements)
-        - [1.2.1 Functionality](#121-functionality)
-        - [1.2.2 Command interface](#122-command-interface)
-        - [1.2.3 Error handling](#123-error-handling)
-        - [1.2.4 Event logging](#124-event-logging)
-- [2 Design](#2-design)
-    - [2.1 Overview](#21-overview)
-    - [2.2 Syslog Forwarding Output Module](#22-syslog-forwarding-output-module)
-        - [2.2.1 Overview](#221-overview)
-        - [2.2.2 IpFreeBind](#222-ipfreebind)
-    - [2.3 Configuration agent](#23-configuration-agent)
-        - [2.3.1 Overview](#231-overview)
-        - [2.3.2 SSIP parameters](#232-ssip-parameters)
-        - [2.3.3 SSIP configuration](#233-ssip-configuration)
-            - [2.3.3.1 VRF/Source: `unset/unset`](#2331-vrfsource-unsetunset)
-            - [2.3.3.2 VRF/Source: `unset/set`](#2332-vrfsource-unsetset)
-            - [2.3.3.3 VRF/Source: `set/unset`](#2333-vrfsource-setunset)
-            - [2.3.3.4 VRF/Source: `set/set`](#2334-vrfsource-setset)
-    - [2.4 DB schema](#24-db-schema)
-        - [2.4.1 Config DB](#241-config-db)
-            - [2.4.1.1 SSIP table](#2411-ssip-table)
-        - [2.4.2 Data sample](#242-data-sample)
-        - [2.4.3 Configuration sample](#243-configuration-sample)
-        - [2.4.4 Configuration migration](#244-configuration-migration)
-    - [2.5 Flows](#25-flows)
-        - [2.5.1 SSIP add](#251-ssip-add)
-        - [2.5.2 SSIP remove](#252-ssip-remove)
-    - [2.6 CLI](#26-cli)
-        - [2.6.1 Command structure](#261-command-structure)
-        - [2.6.2 Usage examples](#262-usage-examples)
-            - [2.6.2.1 Config command group](#2621-config-command-group)
-            - [2.6.2.2 Show command group](#2622-show-command-group)
-    - [2.7 YANG model](#27-yang-model)
-    - [2.8 Warm/Fast boot](#28-warmfast-boot)
-- [3 Test plan](#3-test-plan)
-    - [3.1 Unit tests via VS](#31-unit-tests-via-vs)
-    - [3.2 Data plane tests via PTF](#32-data-plane-tests-via-ptf)
+- [1. SONiC Syslog Source IP](#1-sonic-syslog-source-ip)
+  - [1.1. High Level Design document](#11-high-level-design-document)
+  - [1.2. Table of contents](#12-table-of-contents)
+  - [1.3. Revision](#13-revision)
+  - [1.4. About this manual](#14-about-this-manual)
+  - [1.5. Scope](#15-scope)
+  - [1.6. Abbreviations](#16-abbreviations)
+  - [1.7. List of figures](#17-list-of-figures)
+  - [1.8. List of tables](#18-list-of-tables)
+- [2. Introduction](#2-introduction)
+  - [2.1. Feature overview](#21-feature-overview)
+  - [2.2. Requirements](#22-requirements)
+    - [2.2.1. Functionality](#221-functionality)
+    - [2.2.2. Command interface](#222-command-interface)
+    - [2.2.3. Error handling](#223-error-handling)
+    - [2.2.4. Event logging](#224-event-logging)
+      - [2.2.4.1. Table 1: Event logging](#2241-table-1-event-logging)
+- [3. Design](#3-design)
+  - [3.1. Overview](#31-overview)
+  - [3.2. Syslog Forwarding Output Module](#32-syslog-forwarding-output-module)
+    - [3.2.1. Overview](#321-overview)
+      - [3.2.1.1. Table 2: Syslog global config Module](#3211-table-2-syslog-global-config-module)
+      - [3.2.1.2. Table 3: Syslog Forwarding Output Module](#3212-table-3-syslog-forwarding-output-module)
+    - [3.2.2. IpFreeBind](#322-ipfreebind)
+  - [3.3. Configuration agent](#33-configuration-agent)
+    - [3.3.1. Overview](#331-overview)
+    - [3.3.2. global syslog configuration](#332-global-syslog-configuration)
+      - [3.3.2.1. Table 4: Global configuration parameters](#3321-table-4-global-configuration-parameters)
+      - [3.3.2.2. Format: `set`:](#3322-format-set)
+    - [3.3.3. SSIP parameters](#333-ssip-parameters)
+      - [3.3.3.1. Table 5: SSIP parameters](#3331-table-5-ssip-parameters)
+    - [3.3.4. SSIP configuration](#334-ssip-configuration)
+      - [3.3.4.1. VRF/Source: `unset/unset`](#3341-vrfsource-unsetunset)
+      - [3.3.4.2. VRF/Source: `unset/set`](#3342-vrfsource-unsetset)
+      - [3.3.4.3. VRF/Source: `set/unset`](#3343-vrfsource-setunset)
+      - [3.3.4.4. VRF/Source: `set/set`](#3344-vrfsource-setset)
+      - [3.3.4.5. Filter/Trap: `set/set`](#3345-filtertrap-setset)
+      - [3.3.4.6. Protocol: `set`](#3346-protocol-set)
+  - [3.4. DB schema](#34-db-schema)
+    - [3.4.1. Config DB](#341-config-db)
+      - [3.4.1.1. Global syslog table](#3411-global-syslog-table)
+      - [3.4.1.2. SSIP table](#3412-ssip-table)
+    - [3.4.2. Data sample](#342-data-sample)
+    - [3.4.3. Configuration sample](#343-configuration-sample)
+    - [3.4.4. Configuration migration](#344-configuration-migration)
+  - [3.5. Flows](#35-flows)
+    - [3.5.1. SSIP add](#351-ssip-add)
+      - [3.5.1.1. Figure 1: SSIP add flow](#3511-figure-1-ssip-add-flow)
+    - [3.5.2. SSIP remove](#352-ssip-remove)
+      - [3.5.2.1. Figure 2: SSIP remove flow](#3521-figure-2-ssip-remove-flow)
+  - [3.6. CLI](#36-cli)
+    - [3.6.1. Command structure](#361-command-structure)
+    - [3.6.2. Usage examples](#362-usage-examples)
+      - [3.6.2.1. Config command group](#3621-config-command-group)
+      - [3.6.2.2. Show command group](#3622-show-command-group)
+  - [3.7. YANG model](#37-yang-model)
+  - [3.8. Warm/Fast boot](#38-warmfast-boot)
+- [4. Test plan](#4-test-plan)
+  - [4.1. Unit tests via VS](#41-unit-tests-via-vs)
+  - [4.2. Data plane tests via PTF](#42-data-plane-tests-via-ptf)
 
-## Revision
 
-| Rev | Date       | Author         | Description     |
-|:---:|:----------:|:--------------:|:----------------|
-| 0.1 | 18/04/2022 | Nazarii Hnydyn | Initial version |
+## 1.3. Revision
 
-## About this manual
+| Rev | Date       | Author         | Description           |
+|:---:|:----------:|:--------------:|:----------------------|
+| 0.1 | 18/04/2022 | Nazarii Hnydyn | Initial version       |
+| 0.2 | 08/01/2022 | Ido Avraham    | extend capabilities   |
+
+## 1.4. About this manual
 
 This document provides general information about Syslog Source IP implementation in SONiC
 
-## Scope
+## 1.5. Scope
 
 This document describes the high level design of Syslog Source IP feature in SONiC
 
@@ -68,7 +87,7 @@ This document describes the high level design of Syslog Source IP feature in SON
 **Out of scope:**  
 1. Syslog Source IP configuration for TCP protocol
 
-## Abbreviations
+## 1.6. Abbreviations
 
 | Term  | Meaning                                   |
 |:------|:------------------------------------------|
@@ -85,20 +104,22 @@ This document describes the high level design of Syslog Source IP feature in SON
 | VS    | Virtual Switch                            |
 | PTF   | Packet Test Framework                     |
 
-## List of figures
+## 1.7. List of figures
 
-[Figure 1: SSIP add flow](#figure-1-ssip-add-flow)  
-[Figure 2: SSIP remove flow](#figure-2-ssip-remove-flow)
+- [Figure 1: SSIP add flow](#figure-1-ssip-add-flow)  
+- [Figure 2: SSIP remove flow](#figure-2-ssip-remove-flow)
 
-## List of tables
+## 1.8. List of tables
 
-[Table 1: Event logging](#table-1-event-logging)  
-[Table 2: Syslog Forwarding Output Module](#table-2-syslog-forwarding-output-module)  
-[Table 3: SSIP parameters](#table-3-ssip-parameters)
+- [Table 1: Event logging](#2241-table-1-event-logging)
+- [Table 2: Syslog global config Module](#3211-table-2-syslog-global-config-module)
+- [Table 3: Syslog Forwarding Output Module](#3212-table-3-syslog-forwarding-output-module)
+- [Table 4: Global configuration parameters](#3321-table-4-global-configuration-parameters)
+- [Table 5: SSIP parameters](#3331-table-5-ssip-parameters)
 
-# 1 Introduction
+# 2. Introduction
 
-## 1.1 Feature overview
+## 2.1. Feature overview
 
 SSIP is a feature which allows user to change UDP packet source IP address.  
 Any configured address can be used for source IP mangling.  
@@ -107,69 +128,97 @@ This might be useful for security reasons.
 SSIP also extends the existing syslog implementation with VRF device and server UDP port configuration support.
 The feature doesn't change the existing DB schema which makes it fully backward compatible.
 
-## 1.2 Requirements
+## 2.2. Requirements
 
-### 1.2.1 Functionality
+### 2.2.1. Functionality
 
 **This feature will support the following functionality:**
 1. Syslog Source IP address configuration
-2. Syslog server UDP port configuration
+2. Syslog server port configuration
 3. Syslog VRF device support
+4. Syslog protocol configuration
+5. Syslog message severity level configuration
+6. Syslog filter configuration
 
-### 1.2.2 Command interface
+### 2.2.2. Command interface
 
 **This feature will support the following commands:**
 1. config: add/delete syslog server configuration
 2. show: display syslog server configuration
+3. config: set/unset global syslog configuration
+4. show: display global syslog configuration
 
-### 1.2.3 Error handling
+### 2.2.3. Error handling
 
 **This feature will provide error handling for the next situations:**
 1. Invalid object reference
 2. Invalid options/parameters
 
-### 1.2.4 Event logging
+### 2.2.4. Event logging
 
 **This feature will provide event logging for the next situations:**
 1. Syslog server add/delete
 
-###### Table 1: Event logging
+#### 2.2.4.1. Table 1: Event logging
 
 | Event                             | Severity |
 |:----------------------------------|:---------|
 | Syslog server add/delete: success | NOTICE   |
 | Syslog server add/delete: error   | ERROR    |
 
-# 2 Design
+# 3. Design
 
-## 2.1 Overview
+## 3.1. Overview
 
 SSIP will reuse syslog `omfwd` functionality which offers the next features:  
 1. Source IP address configuration
-2. Server UDP port configuration
+2. Server port configuration
 3. VRF device configuration
+4. Server protocol configuration
+5. Messages regex filtering 
+6. Messages severity filtering
 
-## 2.2 Syslog Forwarding Output Module
+## 3.2. Syslog Forwarding Output Module
 
-### 2.2.1 Overview
+### 3.2.1. Overview
 
-###### Table 2: Syslog Forwarding Output Module
+#### 3.2.1.1. Table 2: Syslog global config Module
 
-| Parameter  | Default  | Description                                                                               |
-|:-----------|:---------|:------------------------------------------------------------------------------------------|
-| target     | none     | Name or IP-Address of the system that shall receive messages. Any resolvable name is fine |
-| address    | none     | Bind socket to a given local IP address. This option is only supported for UDP, not TCP   |
-| port       | 514      | Name or numerical value of port to use when connecting to target                          |
-| protocol   | udp      | Type of protocol to use for forwarding (e.g., tcp/udp)                                    |
-| device     | none     | Bind socket to given device (e.g., eth0/vrf0)                                             |
-| ipfreebind | 2        | Manages the IP_FREEBIND option on the UDP socket                                          |
+| Parameter          | Default  | Description                                                                   |
+|:-------------------|:---------|:------------------------------------------------------------------------------|
+| format             | standard | template format                                                               |
+| trap               | notice   | messages with severity equal or grater then this severity will be forwarded   |
+| welf_firewall_name | hostname | firewall name to be used in template, default is system current hostname      |
+
+**MAN page:** [template](
+    https://www.rsyslog.com/doc/v8-stable/configuration/templates.html
+    "Syslog template configuration"
+)
+
+#### 3.2.1.2. Table 3: Syslog Forwarding Output Module
+
+| Parameter     | Default  | Description                                                                               |
+|:--------------|:---------|:------------------------------------------------------------------------------------------|
+| target        | none     | Name or IP-Address of the system that shall receive messages. Any resolvable name is fine |
+| address       | none     | Bind socket to a given local IP address. This option is only supported for UDP, not TCP   |
+| port          | 514      | Name or numerical value of port to use when connecting to target                          |
+| protocol      | udp      | Type of protocol to use for forwarding (e.g., tcp/udp)                                    |
+| device        | none     | Bind socket to given device (e.g., eth0/vrf0)                                             |
+| ipfreebind    | 2        | Manages the IP_FREEBIND option on the UDP socket                                          |
+| filter        | none     | compares the log against the provided regular expression                                  |
+| priority      | notice   | logs with specified priority and higher will be forwarded                                 |
 
 **MAN page:** [omfwd](
     https://www.rsyslog.com/doc/v8-stable/configuration/modules/omfwd.html#omfwd-syslog-forwarding-output-module
     "Syslog Forwarding Output Module"
 )
 
-### 2.2.2 IpFreeBind
+**MAN page:** [filter](
+    https://www.rsyslog.com/doc/v8-stable/configuration/filters.html
+    "Syslog filter configuration"
+)
+
+### 3.2.2. IpFreeBind
 
 **IP_FREEBIND (since Linux 2.4)**
 ```
@@ -184,9 +233,9 @@ This option is the per-socket equivalent of the ip_nonlocal_bind.
     "IP_FREEBIND"
 )
 
-## 2.3 Configuration agent
+## 3.3. Configuration agent
 
-### 2.3.1 Overview
+### 3.3.1. Overview
 
 Configuration management of `rsyslogd` is done by `rsyslog-config` service.  
 The service is triggered by CLI once data is validated and pushed to Config DB.  
@@ -195,20 +244,41 @@ The `rsyslog-config` service performs the next actions:
 1. Renders `rsyslog.conf.j2` template with `sonic-cfggen` to generate a new `rsyslogd` config file
 2. Restarts `rsyslog` service which triggers `rsyslogd` to load a new config file
 
-### 2.3.2 SSIP parameters
+### 3.3.2. global syslog configuration
+
+#### 3.3.2.1. Table 4: Global configuration parameters
+| SONiC                 | Rsyslogd | Config DB Schema                           |
+|:----------------------|:---------|:-------------------------------------------|
+| format                | template | SYSLOG_CONFIG\|GLOBAL\|format              |
+| trap                  | priority | SYSLOG_CONFIG\|GLOBAL\|trap                |
+| welf_firewall_name    | trap     | SYSLOG_CONFIG\|GLOBAL\|welf_firewall_name  |
+
+* trap will set rules trap severity if not specified in the rule
+
+#### 3.3.2.2. Format: `set`:
+
+Foramt:
+template(name="WelfFormat" type="string" string="%TIMESTAMP% %HOSTNAME% id=firewall time=\"%timereported\
+:::date-year%-%timereported:::date-month%-%timereported:::date-day% %timereported:::date-hour%:%timereported:::date-minute%:%timereported\
+:::date-second%\" fw=\"{{ firewall-name  }}\" pri=%syslogpriority% msg=\"%syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\"\n")
+
+### 3.3.3. SSIP parameters
 
 **SSIP will have the next parameter mapping:**
 
-###### Table 3: SSIP parameters
+#### 3.3.3.1. Table 5: SSIP parameters
+| SONiC         | Rsyslogd | Config DB Schema                   |
+|:--------------|:---------|:-----------------------------------|
+| key           | target   | SYSLOG_SERVER\|key                 |
+| source        | address  | SYSLOG_SERVER\|key\|source         |
+| port          | port     | SYSLOG_SERVER\|key\|port           |
+| vrf           | device   | SYSLOG_SERVER\|key\|vrf            |
+| protocol      | protocol | SYSLOG_SERVER\|key\|protocol       |
+| filter        | ereregex | SYSLOG_SERVER\|key\|filter         |
+| filter_regex  | ereregex | SYSLOG_SERVER\|key\|filter_regex   |
+| trap          | priority | SYSLOG_SERVER\|key\|trap           |
 
-| SONiC  | Rsyslogd | Config DB Schema           |
-|:-------|:---------|:---------------------------|
-| key    | target   | SYSLOG_SERVER\|key         |
-| source | address  | SYSLOG_SERVER\|key\|source |
-| port   | port     | SYSLOG_SERVER\|key\|port   |
-| vrf    | device   | SYSLOG_SERVER\|key\|vrf    |
-
-### 2.3.3 SSIP configuration
+### 3.3.4. SSIP configuration
 
 SSIP offers `vrf` and `source` parameters for flexible configuration management.  
 Each parameter combination requires a dedicated handling approach.
@@ -216,27 +286,28 @@ Each parameter combination requires a dedicated handling approach.
 **Note:**
 1. The destination might be not reachable over the specified `vrf`/`source`: no way to check - user's responsibility
 2. Additional validation is required when MGMT/DATA VRF is removed while reference still exists in syslog configuration
+3. trap will be default rule severity
 
-#### 2.3.3.1 VRF/Source: `unset/unset`
+#### 3.3.4.1. VRF/Source: `unset/unset`
 
 Linux kernel decides which source IP to use within the default VRF.
 
 **Example:**
 ```
-*.* action(type="omfwd" target="2.2.2.2" protocol="udp")
+*.notice action(type="omfwd" target="2.2.2.2" protocol="udp")
 ```
 
-#### 2.3.3.2 VRF/Source: `unset/set`
+#### 3.3.4.2. VRF/Source: `unset/set`
 
 Check if source IP is configured on any default VRF member:  
 yes - set source IP, no - generate error
 
 **Example:**
 ```
-*.* action(type="omfwd" target="2.2.2.2" protocol="udp" address="1.1.1.1")
+*.notice action(type="omfwd" target="2.2.2.2" protocol="udp" address="1.1.1.1")
 ```
 
-#### 2.3.3.3 VRF/Source: `set/unset`
+#### 3.3.4.3. VRF/Source: `set/unset`
 
 Check VRF type:
 1. Default
@@ -257,14 +328,14 @@ yes - set VRF, no - generate error
 **Example:**
 ```
 Default VRF:
-*.* action(type="omfwd" target="2.2.2.2" protocol="udp")
+*.notice action(type="omfwd" target="2.2.2.2" protocol="udp")
 MGMT VRF:
-*.* action(type="omfwd" target="2.2.2.2" protocol="udp" device="mgmt")
+*.notice action(type="omfwd" target="2.2.2.2" protocol="udp" device="mgmt")
 DATA VRF:
-*.* action(type="omfwd" target="2.2.2.2" protocol="udp" device="Vrf-Data")
+*.notice action(type="omfwd" target="2.2.2.2" protocol="udp" device="Vrf-Data")
 ```
 
-#### 2.3.3.4 VRF/Source: `set/set`
+#### 3.3.4.4. VRF/Source: `set/set`
 
 Check VRF type:
 1. Default
@@ -291,26 +362,84 @@ yes - set source IP, no - generate error
 **Example:**
 ```
 Default VRF:
-*.* action(type="omfwd" target="2.2.2.2" protocol="udp" address="1.1.1.1")
+*.notice action(type="omfwd" target="2.2.2.2" protocol="udp" address="1.1.1.1")
 MGMT VRF:
-*.* action(type="omfwd" target="2.2.2.2" protocol="udp" address="1.1.1.1" device="mgmt")
+*.notice action(type="omfwd" target="2.2.2.2" protocol="udp" address="1.1.1.1" device="mgmt")
 DATA VRF:
-*.* action(type="omfwd" target="2.2.2.2" protocol="udp" address="1.1.1.1" device="Vrf-Data")
+*.notice action(type="omfwd" target="2.2.2.2" protocol="udp" address="1.1.1.1" device="Vrf-Data")
 ```
 
-## 2.4 DB schema
+#### 3.3.4.5. Filter/Trap: `set/set`
 
-### 2.4.1 Config DB
+Log regex filter
 
-#### 2.4.1.1 SSIP table
+Filter:
+    Include:
+    Compares the log string against the provided POSIX ERE regular expression.
+    yes - sends log string to remote server, no - do not send
+
+    Exclude:
+    Compares the log string against the provided POSIX ERE regular expression.
+    yes - does not send string log to remote server, no - sends
+
+Protocol:
+messages are forwarded via configured protocol
+
+Trap:
+sends logs with severity equal or higher then configured
+
+**Example:**
+```
+Include:
+:msg, ereregex, "include_str*" 
+*.notice action(type="omfwd" Target="4.4.4.4" Port="514" Protocol="tcp" Device="eth0" Template="SONiCFileFormat")
+Exclude:
+:msg, !ereregex, "exclude_str*" 
+*.info action(type="omfwd" Target="4.4.4.5" Port="514" Protocol="udp" Device="eth0" Template="SONiCFileFormat")
+```
+
+#### 3.3.4.6. Protocol: `set`
+
+messages are forwarded via configured protocol
+
+**Example:**
+```
+*.notice action(type="omfwd" Target="5.5.5.5" Port="514" Protocol="tcp" Device="eth0" Template="SONiCFileFormat")
+```
+
+## 3.4. DB schema
+
+### 3.4.1. Config DB
+
+#### 3.4.1.1. Global syslog table
+```abnf
+; define schema for syslog global configuration attributes under SYSLOG_CONFIG|GLOBAL
+
+; field = value
+format              = template-format ; template to send logs
+welf_firewall_name  = template
+trap                = log-level
+
+; value annotations
+template        = rsyslog template  ; string regex 
+welf-format     = "welf"            ; WebTrends Enhanced Log file Format
+standard-format = "standard"        ; Standard Log file format
+template-format = welf-format / standard-format
+log-level       = "debug" / "info" / "notice" / "warn" / "error" / "crit"
+```
+
+#### 3.4.1.2. SSIP table
 ```abnf
 ; defines schema for syslog table configuration attributes
 key = SYSLOG_SERVER|server_ip_address ; server IP address. Must be unique
 
 ; field = value
-source  = ip-addr    ; source IP address
-port    = 1*5DIGIT   ; server UDP port (0..65535)
-vrf     = vrf-device ; VRF device
+source      = ip-addr    ; source IP address
+port        = 1*5DIGIT   ; server UDP port (0..65535)
+vrf         = vrf-device ; VRF device
+protocol    = protocol   ; protocol
+filter      = filter-re  ; filter regular expression
+trap        = log-level  ; log level severity
 
 ; value annotations
 h16         = 1*4HEXDIG
@@ -335,9 +464,14 @@ vrf-default = "default"
 vrf-mgmt    = "mgmt"
 vrf-data    = "Vrf-" 1*255VCHAR
 vrf-device  = vrf-default / vrf-mgmt / vrf-data
+protocol    = udp / tcp
+re-include  = "egregex"
+re-exclude  = "!egregex"
+filter-re   = re-include / re-exclude
+log-level   = "debug" / "info" / "notice" / "warn" / "error" / "crit"
 ```
 
-### 2.4.2 Data sample
+### 3.4.2. Data sample
 
 **Config DB:**
 ```bash
@@ -348,6 +482,8 @@ redis-cli -n 4 HGETALL 'SYSLOG_SERVER|2.2.2.2'
 4) "514"
 5) "vrf"
 6) "default"
+7) "protocol"
+8) "udp"
 
 redis-cli -n 4 HGETALL 'SYSLOG_SERVER|3.3.3.3'
 1) "source"
@@ -356,6 +492,8 @@ redis-cli -n 4 HGETALL 'SYSLOG_SERVER|3.3.3.3'
 4) "514"
 5) "vrf"
 6) "mgmt"
+7) "protocol"
+8) "udp"
 
 redis-cli -n 4 HGETALL 'SYSLOG_SERVER|2222::2222'
 1) "source"
@@ -364,9 +502,52 @@ redis-cli -n 4 HGETALL 'SYSLOG_SERVER|2222::2222'
 4) "514"
 5) "vrf"
 6) "Vrf-Data"
-```
+7) "protocol"
+8) "udp"
 
-### 2.4.3 Configuration sample
+redis-cli -n 4 HGETALL 'SYSLOG_SERVER|4.4.4.4'
+ 1) "source"
+ 2) "4.4.4.4"
+ 3) "port"
+ 4) "514"
+ 5) "vrf"
+ 6) "default"
+ 7) "protocol"
+ 8) "udp"
+ 9) "filter"
+10) "include"
+11) "filter_regex"
+12) "include_str*"
+
+redis-cli -n 4 HGETALL 'SYSLOG_SERVER|4.4.4.5'
+ 1) "source"
+ 2) "4.4.4.4"
+ 3) "port"
+ 4) "514"
+ 5) "vrf"
+ 6) "default"
+ 7) "protocol"
+ 8) "udp"
+ 9) "filter"
+10) "exlude"
+11) "filter_regex"
+12) "exclude_str*"
+13) "trap"
+14) "info"
+
+redis-cli -n 4 HGETALL 'SYSLOG_SERVER|5.5.5.5'
+ 1) "source"
+ 2) "5.5.5.5"
+ 3) "port"
+ 4) "514"
+ 5) "vrf"
+ 6) "default"
+ 7) "protocol"
+ 8) "tcp"
+ 
+ ```
+
+### 3.4.3. Configuration sample
 
 **Syslog remote logging:**
 ```json
@@ -386,32 +567,55 @@ redis-cli -n 4 HGETALL 'SYSLOG_SERVER|2222::2222'
             "source": "1111::1111",
             "port": "514",
             "vrf": "Vrf-Data"
-        }
+        },
+        "4.4.4.4": {
+            "source": "4.4.4.4",
+            "port": "514",
+            "vrf": "default",
+            "protocol": "udp",
+            "filter": "include",
+            "filter_regex": "include_str*"
+        },
+        "4.4.4.5": {
+            "source": "4.4.4.5",
+            "port": "514",
+            "vrf": "default",
+            "protocol": "udp",
+            "filter": "exclude",
+            "filter_regex": "include_str*",
+            "trap": "info"
+        },
+         "5.5.5.5": {
+            "source": "5.5.5.5",
+            "port": "514",
+            "vrf": "default",
+            "protocol": "tcp",
+        },
     }
 }
 ```
 
-### 2.4.4 Configuration migration
+### 3.4.4. Configuration migration
 
 No special handling is required
 
-## 2.5 Flows
+## 3.5. Flows
 
-### 2.5.1 SSIP add
+### 3.5.1. SSIP add
 
 ![SSIP add flow](images/ssip_add_flow.svg "Figure 1: SSIP add flow")
 
-###### Figure 1: SSIP add flow
+#### 3.5.1.1. Figure 1: SSIP add flow
 
-### 2.5.2 SSIP remove
+### 3.5.2. SSIP remove
 
 ![SSIP remove flow](images/ssip_remove_flow.svg "Figure 2: SSIP remove flow")
 
-###### Figure 2: SSIP remove flow
+#### 3.5.2.1. Figure 2: SSIP remove flow
 
-## 2.6 CLI
+## 3.6. CLI
 
-### 2.6.1 Command structure
+### 3.6.1. Command structure
 
 **User interface**:
 ```
@@ -430,10 +634,14 @@ _config syslog add_
 1. `-s|--source` - source ip address
 2. `-p|--port` - server udp port
 3. `-r|--vrf` - vrf device
+4. `--protocol` - server protocol
+5. `--filter_include` - filter include regex
+6. `--filter_exclude` - filter exlude regex
+7. `-t|--trap` - set trap log severity
 
-### 2.6.2 Usage examples
+### 3.6.2. Usage examples
 
-#### 2.6.2.1 Config command group
+#### 3.6.2.1. Config command group
 
 **The following command adds/deletes syslog server:**
 ```bash
@@ -444,7 +652,7 @@ config syslog add '2.2.2.2' \
 config syslog del '2.2.2.2'
 ```
 
-#### 2.6.2.2 Show command group
+#### 3.6.2.2. Show command group
 
 **The following command shows syslog server configuration:**
 ```bash
@@ -456,7 +664,7 @@ SERVER IP    SOURCE IP    PORT    VRF
 2222::2222   1111::1111   514     Vrf-Data
 ```
 
-## 2.7 YANG model
+## 3.7. YANG model
 
 An existing YANG model `sonic-syslog.yang` will be extended in order to provide support for SSIP.
 
@@ -466,11 +674,15 @@ module sonic-syslog {
 
     yang-version 1.1;
 
-    namespace "http://github.com/Azure/sonic-system-syslog";
+    namespace "http://github.com/sonic-net/sonic-system-syslog";
     prefix syslog;
 
     import ietf-inet-types {
         prefix inet;
+    }
+
+    import sonic-mgmt_vrf {
+        prefix mvrf;
     }
 
     import sonic-vrf {
@@ -491,6 +703,44 @@ module sonic-syslog {
         }
     }
 
+    typedef log-format {
+        description "Represents syslog log format";
+        type enumeration {
+            enum welf;
+            enum standard;
+        }
+    }
+
+    typedef rsyslog-protocol {
+        description "The protocol to send logs to remote server";
+        type enumeration {
+            enum tcp;
+            enum udp;
+        }
+    }
+
+    typedef syslog-filter-type {
+        description "The filter type";
+        type enumeration {
+            enum include;
+            enum exclude;
+        }
+    }
+
+    typedef rsyslog-severity {
+        description "The protocol to send logs to remote server";
+        type enumeration {
+            enum none;
+            enum debug;
+            enum info;
+            enum notice;
+            enum warn;
+            enum error;
+            enum crit;
+        }
+    }
+
+
     container sonic-syslog {
 
         container SYSLOG_SERVER {
@@ -503,12 +753,14 @@ module sonic-syslog {
 
                 leaf server_address {
                     description "Syslog server IP address";
-                    type inet:ip-address;
+                    type inet:host;
                 }
 
                 leaf source {
                     description "Syslog source IP address";
                     type inet:ip-address;
+                    must "(contains(current(), '.') and contains(../server_address, '.'))
+                    or (contains(current(), ':') and contains(../server_address, ':'))";
                 }
 
                 leaf port {
@@ -524,25 +776,73 @@ module sonic-syslog {
                         }
                         type vrf-device;
                     }
+                    must "(current() != 'mgmt')
+                    or (/mvrf:sonic-mgmt_vrf/mvrf:MGMT_VRF_CONFIG/mvrf:vrf_global/mvrf:mgmtVrfEnabled = 'true')";
+                }
+
+                leaf filter {
+                    description "Syslog filter type";
+                    type syslog-filter-type;
+                }
+
+                leaf filter_regex {
+                    description "Filter regex";
+                    type string;
+                }
+
+                leaf protocol {
+                    description "The protocol to send logs to remote server";
+                    type rsyslog-protocol;
+                }
+
+                leaf trap {
+                    description "Limit the severity to send logs to remote server";
+                    type rsyslog-severity;
                 }
 
             }
             /* end of list SYSLOG_SERVER_LIST */
         }
         /* end of container SYSLOG_SERVER */
+
+        container SYSLOG_CONFIG {
+
+            description "SYSLOG_CONFIG part of config_db.json";
+
+            container GLOBAL {
+
+                leaf format {
+                    description "Log format";
+                    type log-format;
+                }
+
+                leaf welf_firewall_name {
+                    description "WELF format Firewall name";
+                    type string;
+                    must "(../format != 'standard')";
+                }
+
+                leaf trap {
+                    type rsyslog-severity;
+                }
+
+            }
+            /* end of list SYSLOG_CONFIG_LIST */
+        }
+        /* end of container SYSLOG_CONFIG */
     }
     /* end of container sonic-syslog */
 }
 /* end of module sonic-syslog */
 ```
 
-## 2.8 Warm/Fast boot
+## 3.8. Warm/Fast boot
 
 No special handling is required
 
-# 3 Test plan
+# 4. Test plan
 
-## 3.1 Unit tests via VS
+## 4.1. Unit tests via VS
 
 SSIP basic configuration test:
 1. Verify rsyslog.conf after syslog server creation/removal
@@ -553,6 +853,6 @@ SSIP extended configuration test:
 3. Create syslog server with default/mgmt/data VRF device
 4. Verify rsyslog.conf
 
-## 3.2 Data plane tests via PTF
+## 4.2. Data plane tests via PTF
 
 TBD


### PR DESCRIPTION
Adding the following functionality:

- Configure remote syslog servers: protocol, filter, trap severity level
- Update global syslog configuration: trap severity kevel, message format

these are the implementation PRs for community review:
| Repo  | PR title | State |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
| sonic-swss-common | [[rsyslog]add syslog global config to db](https://github.com/sonic-net/sonic-swss-common/pull/771) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-swss-common/771) |
| sonic-host-services | [[rsyslog]Add remote syslog configuration](https://github.com/sonic-net/sonic-host-services/pull/53)  | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-host-services/53) |  
| sonic-buildimage | [[rsyslog]Add remote syslog configuration](https://github.com/sonic-net/sonic-buildimage/pull/14513) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-buildimage/14513) |
| sonic-utilities | [[syslog] Adjust runningconfiguration syslog command](https://github.com/sonic-net/sonic-utilities/pull/2843) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/sonic-net/sonic-utilities/2843) |