### PR TITLE
dos2unix run on shell script. And added # in first line of script

### DIFF
--- a/supported_devices_platforms_md.sh
+++ b/supported_devices_platforms_md.sh
@@ -1,4 +1,4 @@
-!/usr/bin/env bash
+#!/usr/bin/env bash
 git checkout -b sonic_image_md_update
 git config --global user.email "sonicbld@microsoft.com"
 git config --global user.name "mssonicbld"


### PR DESCRIPTION
The workflow related to automatic image link updates on Supported_platforms markdown file was failing as given [here](https://github.com/sonic-net/SONiC/actions/runs/4474319872).
Root cause of the error is unknown. But, it is suspected that the failure was due to the DOS fileformat of the shell script.
Also, it was noted that the character "#" was missing in first line as first character in the shell script.
Hence, "dos2unix" is being run to convert the DOS fileformat to unix format which would remove the ctrlM from the script.
"#" is also added at the beginning of the file.
After this change, the workflow is expected to succeed.