### PR TITLE
Add note saying LAGs must be using slow rate mode during warm restart

### DIFF
--- a/doc/warm-reboot/SONiC_Warmboot.md
+++ b/doc/warm-reboot/SONiC_Warmboot.md
@@ -255,6 +255,9 @@ After state restore, each application should be able to remove any stale object/
 
 ###	Port
 ###	Lag/teamd
+
+Because of the duration of control-plane downtime during warm restart, LAGs must be using the slow rate mode. This is where LACP PDUs are sent once every 30 seconds, rather than once every second. LAGs using the fast rate mode is not supported for warm restart, and will very likely go down during warm restart.
+
 ### Interface
 ### Fdb
 ### Arp


### PR DESCRIPTION
During warm restart, it's expected that LAGs are using the slow rate mode (one LACP PDU every 30 seconds), and not the fast rate mode (one LACP PDU every second). The control plane will be down for nearly 90 seconds during warm restart, and LAGs using the fast rate mode will go down during this time.