### PR TITLE
Add details of sff_mgr regarding deterministic bringup for SFF compliant modules

### DIFF
--- a/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
+++ b/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
@@ -192,7 +192,7 @@ D --> End
 graph TD;
 A[subscribe to events]
 B[while task_stopping_event is not set]
-C[check for insertion event and host_tx_ready change event for the intended ports]
+C[check for insertion event and host_tx_ready change event for each intended port]
 D[double check if module is present]
 E[fetch DB and update host_tx_ready value in local cahce, if not available locally]
 F[calculate the target tx_disable value based on host_tx_ready]

--- a/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
+++ b/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
@@ -211,7 +211,8 @@ C --> D
 D -- true --> E
 E -- if either happened --> F
 E -- if neither happened --> D
-F --> G
+F -- true --> G
+F -- false --> D
 G --> H
 H -- true --> D
 H -- false --> I

--- a/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
+++ b/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
@@ -196,8 +196,8 @@ if transceiver is not present:
 graph TD;
 A[wait for PortConfigDone]
 B[check if enable_sff_mgr flag exists and is set to true]
-C[spawns sff_mgr]
-D[proceed to other thread spawning]
+C[spawn sff_mgr]
+D[proceed to other thread spawning and tasks]
 
 Start --> A
 A --> B

--- a/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
+++ b/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
@@ -191,34 +191,46 @@ if transceiver is not present:
  - xcvrd will not perform any action on receiving host_tx_ready field update 
 
 # Flow chart
-## SFF task manager (sff_mgr)
+## How Xcvrd main thread spawns SFF task manager thread:
 ```mermaid
 graph TD;
-A[check if sff_mgr is enabled]
-B[spawn sff_mgr]
-C[subscribe to events]
-D[while task_stopping_event is not set]
-E[check for insertion event and host_tx_ready change event]
-F[double check if module is present]
-G[calculate the target tx_disable value based on host_tx_ready]
-H[check if tx_disable status on module is already the target value]
-I[go ahead to enable/disable TX based on the target tx_disable value]
+A[wait for PortConfigDone]
+B[check if enable_sff_mgr flag exists and is set to true]
+C[spawns sff_mgr]
+D[proceed to other thread spawning]
 
 Start --> A
-A -- true --> B
-B --> C
+A --> B
+B -- true --> C
 C --> D
-D -- true --> E
-E -- if either happened --> F
-E -- if neither happened --> D
-F -- true --> G
-F -- false --> D
-G --> H
-H -- true --> D
-H -- false --> I
-I --> D
-D -- false --> End
-A -- false --> End
+B -- false --> D
+D --> End
+```
+## SFF task manager main flow:
+```mermaid
+graph TD;
+A[subscribe to events]
+B[while task_stopping_event is not set]
+C[check for insertion event and host_tx_ready change event]
+D[double check if module is present]
+E[fetch DB and update host_tx_ready value in local cahce, if not available locally]
+F[calculate the target tx_disable value based on host_tx_ready]
+G[check if tx_disable status on module is already the target value]
+H[go ahead to enable/disable TX based on the target tx_disable value]
+
+Start --> A
+A --> B
+B -- true --> C
+C -- if either happened --> E
+C -- if neither happened --> B
+E --> D
+D -- true --> F
+D -- false --> B
+F --> G
+G -- true --> B
+G -- false --> H
+H --> B
+B -- false --> End
 ```
 
 # Out of Scope 

--- a/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
+++ b/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
@@ -34,6 +34,7 @@ Deterministic Approach for Interface Link bring-up sequence
 | 0.7 | 02/02/2022  | Jaganathan Anbalagan               | Added Breakout Handling 
 | 0.8 | 02/16/2022  | Shyam Kumar                        | Updated feature-enablement workflow
 | 0.9 | 04/05/2022  | Shyam Kumar                        | Addressed review comments           |
+| 0.10| 06/26/2023  | Longyin Huang                      | Added details for sff_mgr           |
 
 
 # About this Manual

--- a/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
+++ b/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
@@ -166,7 +166,7 @@ Note: This feature flag (skip_xcvrd_cmis_mgr) was added as a flexibility in case
   ![Enabling 'Interface link bring-up sequence' feature(2)](https://user-images.githubusercontent.com/69485234/154403945-654b49d7-e85f-4a7a-bb4d-e60a16b826a7.png)
 
 ## For SFF compliant modules:
-- SFF task manager (sff_mgr) feature brings the deterministic approach for interface link bring-up to SFF compliant module.
+- SFF task manager (sff_mgr) feature brings the deterministic approach for interface link bring-up to SFF compliant modules. (Refer to [here](#plan) for the reasons of sff_mgr)
 - By default, sff_mgr feature is disabled.
 - In order to enable sff_mgr feature, the platform would set ‘enable_xcvrd_sff_mgr’ to ‘true’ in their respective pmon_daemon_control.json. Xcvrd would parse ‘enable_xcvrd_sff_mgr’ and if found 'true', it would launch SFF task manager (sff_mgr).
 > **_Pre-requisite for enabling sff_mgr:_**

--- a/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
+++ b/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
@@ -149,13 +149,12 @@ Please refer to the  flow/sequence diagrams which covers the following required 
   - No transceiver present
 
 # Feature enablement
-
   This feature (optics Interface Link bring-up sequence) would be enabled on per platform basis.
   There could be cases where vendor(s)/platform(s) may take time to shift from existing codebase to the model (work-flows) described in this document.
 ## For CMIS/C-CMIS modules:
   In order to avoid any breakage and ensure gradual migration of different platforms/vendors to this model, will add this new workflow to enable/disable this feature:
   
-  In order to enable this feature, the platform would set ‘skip_xcvrd_cmis_mgr’ to ‘false’ in their respective pmon_daemon_control.json as part of platform bootstrap. When xcvrd would spawn on that hwsku (LC/board), it would parse ‘skip_xcvrd_cmis_mgr’ and if found 'false', it would launch CMIS task manager. This implies enabling this feature.
+  In order to enable this feature, the platform would set ‘skip_xcvrd_cmis_mgr’ to ‘false’ in their respective pmon_daemon_control.json as part of platform bootstrap. When xcvrd would spawn on that hwsku (LC/board), it would parse ‘skip_xcvrd_cmis_mgr’ and if found 'false', it would launch CMIS task manager. This implies enabling this feature. 
 
 Else, if ‘skip_xcvrd_cmis_mgr’ is set/found 'true' by xcvrd, it would skip launching CMIS task manager and this feature would remain disabled.
 If a platform/vendor does not specify/set ‘skip_xcvrd_cmis_mgr’, xcvrd would exercise the default workflow (i.e. when xcvrd detects QSFP-DD, it would luanch CMIS task manager and initialize the module per CMIS specification). 
@@ -232,6 +231,7 @@ B -- false --> End
 if transceiver is not present:
  - All the workflows mentioned above will reamin same ( or get exercised) till host_tx_ready field update
  - xcvrd will not perform any action on receiving host_tx_ready field update 
+
 
 # Out of Scope 
 Following items are not in the scope of this document. They would be taken up separately


### PR DESCRIPTION
According to [Interface-Link-bring-up-sequence.md](https://github.com/sonic-net/SONiC/blob/fde55e4f3f32fa3b91d42574c31773ab6610e954/doc/sfp-cmis/Interface-Link-bring-up-sequence.md#plan), add a new thread sff_mgr under xcvrd to provide deterministic link bringup feature for SFF compliant modules (100G/40G). Update HLD as such. 