### PR TITLE
Fix download image links for Arista and DNX images

### DIFF
--- a/Supported-Devices-and-Platforms.html
+++ b/Supported-Devices-and-Platforms.html
@@ -1255,25 +1255,29 @@ Note:
 		    }
 		    var table = document.getElementById("data_table").children;
 		    for (var i = 0; i < table.length; i++) {
+			pvendor = table[i].children[0].textContent;
 			vdata = table[i].children[2].textContent;
+			asic_name = table[i].children[3].textContent;
 			if (vdata == "Nvidia")
 			    vdata = "Mellanox";
-				
-			if (vdata == "Intel")
-			    vdata = "Barefoot";	
 
-			if (vdata == "Marvell"){
+			if (vdata == "Intel")
+			    vdata = "Barefoot";
+
+			if (vdata == "Marvell")
 			    vdata = "Marvell-armhf";
-			}
+
+			if (pvendor == "Arista")
+			    vdata = "Aboot-" + vdata.charAt(0).toLowerCase() + vdata.slice(1);
+
+			if (asic_name.startsWith("Jericho") || asic_name.startsWith("Qumran"))
+			    vdata += "-dnx";
 
 			if(vendor_data[vdata] == "")
 			    table[i].children[5].innerHTML = "<td style=\"text-align: center;\"><span style=\"color: #0000ff;\">N/A</span></td>";
 			else
 				table[i].children[5].innerHTML = vendor_data[vdata];
-			    
 			}
-		    
-
 		});
 
 	});

--- a/generate_sonic_image_links.sh
+++ b/generate_sonic_image_links.sh
@@ -101,8 +101,22 @@ do
 	echo "  \"build\": \"${BUILD_BRCM}\"," >> sonic_image_links.json
 	echo "  \"date\": \"${BUILD_BRCM_TS}\"" >> sonic_image_links.json
 	echo " }," >> sonic_image_links.json
+	echo "\"sonic-broadcom-dnx.bin\": {" >> sonic_image_links.json
+	echo "  \"url\": \"$(echo "${ARTF_BRCM}" | sed 's/format=zip/format=file\&subpath=\/target\/sonic-broadcom-dnx.bin/')\","  >> sonic_image_links.json
+	echo "  \"build-url\": \"https://dev.azure.com/mssonic/build/_build/results?buildId=${BUILD_BRCM}&view=results\"," >> sonic_image_links.json
+	echo " \"diff\": \"https://github.com/sonic-net/sonic-buildimage/compare/"${COMMIT_BRCM_2}"..."${COMMIT_BRCM_1}"\"," >> sonic_image_links.json
+	echo "  \"build\": \"${BUILD_BRCM}\"," >> sonic_image_links.json
+	echo "  \"date\": \"${BUILD_BRCM_TS}\"" >> sonic_image_links.json
+	echo " }," >> sonic_image_links.json
 	echo "\"sonic-aboot-broadcom.swi\": {" >> sonic_image_links.json
 	echo "  \"url\": \"$(echo "${ARTF_BRCM}" | sed 's/format=zip/format=file\&subpath=\/target\/sonic-aboot-broadcom.swi/')\"," >> sonic_image_links.json
+	echo "  \"build-url\": \"https://dev.azure.com/mssonic/build/_build/results?buildId=${BUILD_BRCM}&view=results\"," >> sonic_image_links.json
+	echo " \"diff\": \"https://github.com/sonic-net/sonic-buildimage/compare/"${COMMIT_BRCM_2}"..."${COMMIT_BRCM_1}"\"," >> sonic_image_links.json
+	echo "  \"build\": \"${BUILD_BRCM}\"," >> sonic_image_links.json
+	echo "  \"date\": \"${BUILD_BRCM_TS}\"" >> sonic_image_links.json
+	echo " }," >> sonic_image_links.json
+	echo "\"sonic-aboot-broadcom-dnx.swi\": {" >> sonic_image_links.json
+	echo "  \"url\": \"$(echo "${ARTF_BRCM}" | sed 's/format=zip/format=file\&subpath=\/target\/sonic-aboot-broadcom-dnx.swi/')\"," >> sonic_image_links.json
 	echo "  \"build-url\": \"https://dev.azure.com/mssonic/build/_build/results?buildId=${BUILD_BRCM}&view=results\"," >> sonic_image_links.json
 	echo " \"diff\": \"https://github.com/sonic-net/sonic-buildimage/compare/"${COMMIT_BRCM_2}"..."${COMMIT_BRCM_1}"\"," >> sonic_image_links.json
 	echo "  \"build\": \"${BUILD_BRCM}\"," >> sonic_image_links.json
@@ -138,6 +152,13 @@ do
 	echo " }," >> sonic_image_links.json
 	echo "\"sonic-barefoot.bin\": {" >> sonic_image_links.json
 	echo "  \"url\": \"$(echo "${ARTF_BFT}" | sed 's/format=zip/format=file\&subpath=\/target\/sonic-barefoot.bin/')\"," >> sonic_image_links.json
+	echo "  \"build-url\": \"https://dev.azure.com/mssonic/build/_build/results?buildId=${BUILD_BFT}&view=results\"," >> sonic_image_links.json
+	echo " \"diff\": \"https://github.com/sonic-net/sonic-buildimage/compare/"${COMMIT_BFT_2}"..."${COMMIT_BFT_1}"\"," >> sonic_image_links.json
+	echo "  \"build\": \"${BUILD_BFT}\"," >> sonic_image_links.json
+	echo "  \"date\": \"${BUILD_BFT_TS}\"" >> sonic_image_links.json
+	echo " }," >> sonic_image_links.json
+	echo "\"sonic-aboot-barefoot.swi\": {" >> sonic_image_links.json
+	echo "  \"url\": \"$(echo "${ARTF_BFT}" | sed 's/format=zip/format=file\&subpath=\/target\/sonic-aboot-barefoot.swi/')\"," >> sonic_image_links.json
 	echo "  \"build-url\": \"https://dev.azure.com/mssonic/build/_build/results?buildId=${BUILD_BFT}&view=results\"," >> sonic_image_links.json
 	echo " \"diff\": \"https://github.com/sonic-net/sonic-buildimage/compare/"${COMMIT_BFT_2}"..."${COMMIT_BFT_1}"\"," >> sonic_image_links.json
 	echo "  \"build\": \"${BUILD_BFT}\"," >> sonic_image_links.json


### PR DESCRIPTION
The supported devices list has invalid image links for:
 - Arista platforms which needs to download `sonic-aboot-*.swi`
 - Broadcom DNX platforms which needs a different image from XGS

To address this issue some changes were made to `generate_sonic_image_links.sh`
 - a new entry for Intel based Arista platforms
   - `sonic-aboot-barefoot.swi`
 - new entries for Broadcom DNX based products
   - `sonic-broadcom-dnx.bin`
   - `sonic-aboot-broadcom-dnx.swi`

Some changes were also necessary on the Supported Devices webpage.
 - a condition for Arista products to use the aboot based image
 - a condition for Jericho* and Qumran* to use the `-dnx` image