### PR TITLE
TACACSPLUS_PASSKEY_ENCRYPTION.md

### DIFF
--- a/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
+++ b/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
@@ -105,7 +105,12 @@ show tacacs
 
 TACACS passkey encryption adds an extra layer of security to safeguard the passkey on each device throughout the network. Moreover, the utilization of MAC address-based encryption ensures that each network device possesses its distinct encrypted passkey. This strategy effectively mitigates the risk of a major network breach in case one of the devices is compromised.
 
+### Limitation
+We choose MAC address is unique and better for management, however if the MAC address of the device is known, we could decrypt the key. If we want to use any other ciper we should manage / stored it in the DB, it is again defeating the purpose. So for now we are going ahead with mac as network admins can orchestartion system to use mac address for passkey encryption. However we are open to new ideas and thoughts to hardened the security and we should be able to accomodate with later releases.
 
 ### Testing Requirements
 
 Need to add new / update the existing TACACS testcases to incorporate this new feature
+Test cases to unit test encrypt and decrypt fucntions 
+Test cases to add test the TACACS+ functionality with passkey encryption
+Test cases to cover DB migration 

--- a/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
+++ b/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
@@ -1,0 +1,111 @@
+# TACACS+ Passkey Encryption #
+
+
+## Table of Contents
+
+- [Revision](#revision)
+- [Scope](#scope)
+- [Abbreviations](#abbreviations)
+- [Overview](#overview)
+- [Requirements](#requirements)
+- [High-Level Design](#high-level-design)
+- [Implementation Details](#implementation-details)
+        - [Show CLI changes](@show-cli-changes)
+- [Benifits](#benifits)
+- [Testing Requirements](#testing-requirements)
+
+
+
+### Revision
+
+ | Rev |     Date    |       Author         | Change Description                |
+ |:---:|:-----------:|:--------------------:|-----------------------------------|
+ | 0.1 |             | Nikhil Moray (nmoray)| Initial version                   |
+ | 0.1 |             | Madhu Paluru (madhupalu)| Updated                        |
+
+
+ ### Scope
+
+This document describes the High Level Design of "TACACS+ Passkey Encryption" feature support in SONiC. It encompasses design and implementation considerations for enhancing the security of TACACS+ (Terminal Access Controller Access-Control System) authentication by introducing an encrypted passkey.
+
+
+### Abbreviations
+
+ | Term    |     Meaning                                                        |
+ |:-------:|:-------------------------------------------------------|
+ | TACACS  | Terminal Access Controller Access Control System Plus) |
+
+### Overview
+
+This addition constitutes a substantial improvement in bolstering the security of the TACACS+ authentication protocol. TACACS+ has a well-established reputation as a reliable means of managing access to network devices. However, the previous practice of utilising a sensitive passkey in plaintext during the authentication process posed security concerns. With this enhancement, the vulnerability is effectively mitigated by introducing robust passkey encryption mechanisms (on the client side), ensuring the safeguarding of authentication credentials and an overall strengthening of network security."
+
+
+### Requirements
+
+The primary objective of this feature is to safeguard the TACACS passkey, which is stored in its plaintext format within CONFIG_DB.
+
+
+### High-Level Design
+
+In line with the TACACS+ architecture, when a user initiates a SSH connection to a device with TACACS+ authentication enabled, they must utilize the TACACS+ login password. Conversely, the corresponding device must have the passkey provided by the TACACS+ server properly configured within its configDB. Should either of these elements be missing or incorrect, the user will be unable to access the device. Thus to meet the given requirement, passkey will be encrypted is the configuration phase itself.
+
+The current data flow among the various TACACS modules operates in the following manner.
+
+1. When a user configures the TACACS passkey using the SONIC CLI, it is initially stored in the CONFIG_DB.
+2. Subsequently, the same key is retrieved by the HostCfg Enforcer module to update the PAM configuration file(s). This configuration file is inherently included in the authentication processes for login or SSH within the Linux operating system. 
+3. When TACACS+ Authentication is activated on the device, a new PAM configuration file (common-auth-sonic) is generated and substituted in the login and SSH daemons. Importantly, the pre-existing configuration file remains unchanged.
+
+The revised data handling procedure among the modules is outlined as follows:
+
+1. When a user configures the TACACS passkey using the SONIC CLI, it will now be securely stored in encrypted format instead of plaintext.
+2. Subsequently, the HostCfg Enforcer module retrieves this encrypted key. However, before writing it into the PAM configuration file(s), the hostCfgd module decrypts it. 
+```
+       +-------+  +---------+
+       |  SSH  |  | Console |
+       +---+---+  +----+----+
+           |           |   
++----------v-----------v---------+                                      +---------------------+
+| AUTHENTICATION                 |                                      |                     |
+|   +-------------------------+  |  Decrypted passkey                   |  +------------+     |
+|   | PAM Configuration Files <------------------------------------------+ |  AAA Config |    |
+|   +-------------------------+  |                                      |  +------------+     |
+|                                |                                      |                     |
+|         +-------------+        |                                      |  HostCfg Enforcer   |
+|         |     PAM     |        |                                      +----------^----------+
+|         |  Libraries  |        |                                                 |
+|         +-------------+        |                                                 | Encrypted passkey
++---------------+----------------+                                                 |
+                |                                                                  |
+           +----v----+                                                     +-------+--------+
+           |         |             Encrypted passkey                       |                |
+           |   CLI   +---------------------------------------------------->|    ConifgDB    |
+           |         |                                                     |                |
+           +---------+                                                     +----------------+
+```
+This decryption step is crucial because the login or SSH daemon references the PAM config file to verify the TACACS secret / passkey. If it remains encrypted, the SSH daemon will be unable to recognize the passkey, leading to login failures. The depicted block diagram clearly showcase the enhanced capbalities of the existing submodules.
+
+
+### Implementation details
+
+The implementation stands on three key pillars.
+1. OPENSSL toolkit is used for encryption / decryption
+2. aes-128-cbc is the encoding format used for encryption / decryption
+3. Device MAC address is used as a Password for encryption / decryption
+
+
+#### Show CLI changes
+
+Furthermore, aside from encrypting the passkey stored within CONFIG_DB, this infrastructure ensures that the passkey itself remains concealed from any of the displayed CLI outputs. Consequently, the passkey field has been eliminated from the "show tacacs" output, and it will now solely indicate the status whether the passkey is configured or not. For instance.
+
+show tacacs
+["TACPLUS global passkey configured Yes / No"]
+
+
+### Benifits
+
+TACACS passkey encryption adds an extra layer of security to safeguard the passkey on each device throughout the network. Moreover, the utilization of MAC address-based encryption ensures that each network device possesses its distinct encrypted passkey. This strategy effectively mitigates the risk of a major network breach in case one of the devices is compromised.
+
+
+### Testing Requirements
+
+Need to add new / update the existing TACACS testcases to incorporate this new feature

--- a/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
+++ b/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
@@ -90,7 +90,7 @@ This decryption step is crucial because the login or SSH daemon references the P
 The implementation stands on three key pillars.
 1. OPENSSL toolkit is used for encryption / decryption
 2. aes-128-cbc is the encoding format used for encryption / decryption
-3. Device MAC address is used as a Password for encryption / decryption
+3. A unique Device MAC address used as a salt/password to encrypt/decrypt the configured pass key 
 
 
 #### Show CLI changes

--- a/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
+++ b/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
@@ -100,6 +100,8 @@ Furthermore, aside from encrypting the passkey stored within CONFIG_DB, this inf
 show tacacs
 ["TACPLUS global passkey configured Yes / No"]
 
+### DB migration 
+A DB migration script will be added for users to migrate existing config_db to convert tacacs passkey plaintext to encypted. 
 
 ### Benifits
 

--- a/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
+++ b/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
@@ -90,6 +90,7 @@ show tacacs
 
 ### Yang Changes 
 Increase existing passkey leaf length to 256.
+Create a new leaf for newly introduced run time flag 'key_encrypt'.
 
 ### Config DB changes 
 A new run time flag to enable/disable the tacacs passkey encryption feature - "key_encrypt".

--- a/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
+++ b/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
@@ -54,7 +54,7 @@ The revised data handling procedure among the modules is outlined as follows:
                 |                     |    +-------------+    |o |                 |
            +----v----+                |           |           |t |         +-------+--------+
            |         |                |           |            --          |                |
-           |   CLI   +----------------+           +------------------------>    ConifgDB    |
+           |   CLI   +----------------+           +------------------------>    ConfigDB    |
            |         |                                  Encrypted passkey  |                |
            +---------+                                                     +----------------+
 ```

--- a/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
+++ b/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
@@ -74,14 +74,14 @@ The implementation as follows
 4. sonic_utilities extended to passkey encyption using the master key/passwd manager.
 5. User has to enter master key/passwd at the time of configuring the passkey, this is mandatory requirement only if "key_encrypt" run time flag is enabled.
 6. The encrypted passkey stored in config_db 
-7. The master key/paswd used for encryption/decryption and will be stored in the same device with root access previleges.
+7. The master key/paswd used for encryption/decryption and will be stored in the same device with root access previleges (/etc/cipher_pass).
 8. HostCfg will use the master key/passwd to decrypt the encrypted passkey and further store it in PAM configuration files. 
 
 #### CLI Changes 
-config tacacs passkey TEST1
-
+config tacacs passkey TEST1 --encrypt
 Password: 
-Note: It will ask for a master key/password only when the 'key_encrypt' flag is set under respective feature table (ex: TACPLUS) in config_db.
+
+Note: It will ask for a master key/password only when '--encrypt' flag is set.
 
 #### Show CLI changes
 Furthermore, aside from encrypting the passkey stored within CONFIG_DB, this infrastructure ensures that the passkey itself remains concealed from any of the displayed CLI outputs. Consequently, the passkey field has been eliminated from the "show tacacs" output, and it will now solely indicate the status whether the passkey is configured or not. For instance,
@@ -95,6 +95,16 @@ Create a new leaf for newly introduced run time flag 'key_encrypt'.
 ### Config DB changes 
 A new run time flag to enable/disable the tacacs passkey encryption feature - "key_encrypt".
 
+### Schema changes 
+```
+"TACPLUS": {
+        "global": {
+            "auth_type": "login",
+            "key_encrypt": "true",
+            "passkey": "<Entrypted_Passkey>"
+        }
+    }
+```
 ### Benefits
 TACACS passkey encryption adds an extra layer of security to safeguard the passkey on each device throughout the network. Furthermore, the implementation of master key/password manager encryption ensures that encrypted passkeys can be reused across network nodes without any complications. Consequently, there are no obstacles when it comes to utilizing the config_db.json file from one device on another. Additionally, the use of a root protected config file effectively reduces the risk of exposing the encryption/decryption master key/passwd since it is only accessible to root users and remains inaccessible to external entities.
 

--- a/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
+++ b/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
@@ -58,6 +58,17 @@ The revised data handling procedure among the modules is outlined as follows:
            +---------+                                                     +----------------+
 ```
 This decryption step is crucial because the login or SSH daemon references the PAM config file to verify the TACACS secret / passkey. If it remains encrypted, the SSH daemon will be unable to recognize the passkey, leading to login failures. The depicted block diagram clearly showcases the enhanced capabilities of the existing submodules.
+
+### Approach 1:
+1. A runtime flag (via config_db) for Enable / disable feature: "key_encrypt"
+2. Use admin password from shadow file to encrypt the TACACS passkey
+3. Use the same password to decrypt the TACACS paskey
+
+### Approach 2:
+1. A runtime flag (via config_db) for Enable / disable feature: "key_encrypt"
+2. CLI will ask for a encryption password while configuring the TACACS passkey and at the backend it will be stored at /etc/encrypt_pass file
+3. Same file will be read while decrypting the passkey at hostcfgd
+   
 ### Implementation details
 The implementation stands on four key pillars.
 1. OPENSSL toolkit is used for encryption / decryption.
@@ -68,11 +79,13 @@ Following is the snippet captured from a sample shadow file.
 <snip_from_shadow_file>
 admin:$6$YTJ7JKnfsB4esnbS$5XvmYk2.GXVWhDo2TYGN2hCitD/wU9Kov.uZD8xsnleuf1r0ARX3qodIKiDsdoQA444b8IMPMOnUWDmVJVkeg1:19446:0:99999:7:::
 <snip_from_shadow_file>
-Here, "YTJ7JKnfsB4esnbS$5XvmYk2.GXVWhDo2TYGN2hCitD/wU9Kov.uZD8xsnleuf1r0ARX3qodIKiDsdoQA444b8IMPMOnUWDmVJVkeg1" is the encrypted version of the admin level password. 
+Here, "YTJ7JKnfsB4esnbS$5XvmYk2.GXVWhDo2TYGN2hCitD/wU9Kov.uZD8xsnleuf1r0ARX3qodIKiDsdoQA444b8IMPMOnUWDmVJVkeg1" is the encrypted version of the admin level password.
+
 #### Show CLI changes
 Furthermore, aside from encrypting the passkey stored within CONFIG_DB, this infrastructure ensures that the passkey itself remains concealed from any of the displayed CLI outputs. Consequently, the passkey field has been eliminated from the "show tacacs" output, and it will now solely indicate the status whether the passkey is configured or not. For instance,
 show tacacs
 ["TACPLUS global passkey configured Yes / No"]
+
 ### DB migration
 A DB migration script will be added for users to migrate existing config_db to convert tacacs passkey plaintext to encrypted.
 ### Benefits

--- a/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
+++ b/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
@@ -46,13 +46,13 @@ The revised data handling procedure among the modules is outlined as follows:
 |   | PAM Configuration Files    <------------+       +-----------------+  | AAA Config |     |
 |   +-------------------------+  |            |       |                 |  +------------+     |
 |                                |            |       |                 |                     |
-|         +-------------+        |         +-------------+              |  HostCfg Enforcer   |
-|         |     PAM     |        |         |             |   key-store  +----------^----------+
-|         |  Libraries  |        |    +---->  Master key |     __                  |
-|         +-------------+        |    |    |   Manager   |----|r |                 | Encrypted passkey
-+---------------+----------------+    |    |             |    |o |                 |
-                |                     |    +-------------+    |o |                 |
-           +----v----+                |           |           |t |         +-------+--------+
+|         +-------------+        |         +--------------+             |  HostCfg Enforcer   |
+|         |     PAM     |        |         |              |   key-store +----------^----------+
+|         |  Libraries  |        |    +---->  Master key  |    __                 |
+|         +-------------+        |    |    |   Manager    |---|r |                | Encrypted passkey
++---------------+----------------+    |    |securitycipher|   |o |                |
+                |                     |    +-------------+    |o |                |
+           +----v----+                |           |           |t |         +------+--------+
            |         |                |           |            --          |                |
            |   CLI   +----------------+           +------------------------>    ConfigDB    |
            |         |                                  Encrypted passkey  |                |

--- a/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
+++ b/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
@@ -1,8 +1,5 @@
 # TACACS+ Passkey Encryption #
-
-
 ## Table of Contents
-
 - [Revision](#revision)
 - [Scope](#scope)
 - [Abbreviations](#abbreviations)
@@ -11,54 +8,32 @@
 - [High-Level Design](#high-level-design)
 - [Implementation Details](#implementation-details)
         - [Show CLI changes](@show-cli-changes)
-- [Benifits](#benifits)
+- [Benefits](#benefits)
 - [Testing Requirements](#testing-requirements)
-
-
-
 ### Revision
-
- | Rev |     Date    |       Author         | Change Description                |
- |:---:|:-----------:|:--------------------:|-----------------------------------|
- | 0.1 |             | Nikhil Moray (nmoray)| Initial version                   |
- | 0.1 |             | Madhu Paluru (madhupalu)| Updated                        |
-
-
+ | Rev |     Date    |       Author            | Change Description                |
+ |:---:|:-----------:|:-----------------------:|:----------------------------------|
+ | 0.1 |             | Nikhil Moray (nmoray)   | Initial version                   |
+ | 0.1 |             | Madhu Paluru (madhupalu)| Updated                           |
  ### Scope
-
 This document describes the High Level Design of "TACACS+ Passkey Encryption" feature support in SONiC. It encompasses design and implementation considerations for enhancing the security of TACACS+ (Terminal Access Controller Access-Control System) authentication by introducing an encrypted passkey.
-
-
 ### Abbreviations
-
- | Term    |     Meaning                                                        |
+ | Term    |     Meaning                                            |
  |:-------:|:-------------------------------------------------------|
  | TACACS  | Terminal Access Controller Access Control System Plus) |
-
 ### Overview
-
-This addition constitutes a substantial improvement in bolstering the security of the TACACS+ authentication protocol. TACACS+ has a well-established reputation as a reliable means of managing access to network devices. However, the previous practice of utilising a sensitive passkey in plaintext during the authentication process posed security concerns. With this enhancement, the vulnerability is effectively mitigated by introducing robust passkey encryption mechanisms (on the client side), ensuring the safeguarding of authentication credentials and an overall strengthening of network security."
-
-
+This addition constitutes a substantial improvement in bolstering the security of the TACACS+ authentication protocol. TACACS+ has a well-established reputation as a reliable means of managing access to network devices. However, the previous practice of utilising a sensitive passkey in plaintext during the authentication process posed security concerns. With this enhancement, the vulnerability is effectively mitigated by introducing robust passkey encryption mechanisms (on the client side), ensuring the safeguarding of authentication credentials and an overall strengthening of network security.
 ### Requirements
-
 The primary objective of this feature is to safeguard the TACACS passkey, which is stored in its plaintext format within CONFIG_DB.
-
-
 ### High-Level Design
-
-In line with the TACACS+ architecture, when a user initiates a SSH connection to a device with TACACS+ authentication enabled, they must utilize the TACACS+ login password. Conversely, the corresponding device must have the passkey provided by the TACACS+ server properly configured within its configDB. Should either of these elements be missing or incorrect, the user will be unable to access the device. Thus to meet the given requirement, passkey will be encrypted is the configuration phase itself.
-
+In line with the TACACS+ architecture, when a user initiates a SSH connection to a device with TACACS+ authentication enabled, they must utilize the TACACS+ login password. Conversely, the corresponding device must have the passkey provided by the TACACS+ server properly configured within its configDB. Should either of these elements be missing or incorrect, the user will be unable to access the device. Thus to meet the given requirement, the passkey will be encrypted in the configuration phase itself.
 The current data flow among the various TACACS modules operates in the following manner.
-
 1. When a user configures the TACACS passkey using the SONIC CLI, it is initially stored in the CONFIG_DB.
-2. Subsequently, the same key is retrieved by the HostCfg Enforcer module to update the PAM configuration file(s). This configuration file is inherently included in the authentication processes for login or SSH within the Linux operating system. 
+2. Subsequently, the same key is retrieved by the HostCfg Enforcer module to update the PAM configuration file(s). This configuration file is inherently included in the authentication processes for login or SSH within the Linux operating system.
 3. When TACACS+ Authentication is activated on the device, a new PAM configuration file (common-auth-sonic) is generated and substituted in the login and SSH daemons. Importantly, the pre-existing configuration file remains unchanged.
-
 The revised data handling procedure among the modules is outlined as follows:
-
 1. When a user configures the TACACS passkey using the SONIC CLI, it will now be securely stored in encrypted format instead of plaintext.
-2. Subsequently, the HostCfg Enforcer module retrieves this encrypted key. However, before writing it into the PAM configuration file(s), the hostCfgd module decrypts it. 
+2. Subsequently, the HostCfg Enforcer module retrieves this encrypted key. However, before writing it into the PAM configuration file(s), the hostCfgd module decrypts it.
 ```
        +-------+  +---------+
        |  SSH  |  | Console |
@@ -67,7 +42,7 @@ The revised data handling procedure among the modules is outlined as follows:
 +----------v-----------v---------+                                      +---------------------+
 | AUTHENTICATION                 |                                      |                     |
 |   +-------------------------+  |  Decrypted passkey                   |  +------------+     |
-|   | PAM Configuration Files <------------------------------------------+ |  AAA Config |    |
+|   | PAM Configuration Files <-----------------------------------------+  | AAA Config |     |
 |   +-------------------------+  |                                      |  +------------+     |
 |                                |                                      |                     |
 |         +-------------+        |                                      |  HostCfg Enforcer   |
@@ -78,41 +53,35 @@ The revised data handling procedure among the modules is outlined as follows:
                 |                                                                  |
            +----v----+                                                     +-------+--------+
            |         |             Encrypted passkey                       |                |
-           |   CLI   +---------------------------------------------------->|    ConifgDB    |
+           |   CLI   +------------------------------------------------------>    ConifgDB   |
            |         |                                                     |                |
            +---------+                                                     +----------------+
 ```
-This decryption step is crucial because the login or SSH daemon references the PAM config file to verify the TACACS secret / passkey. If it remains encrypted, the SSH daemon will be unable to recognize the passkey, leading to login failures. The depicted block diagram clearly showcase the enhanced capbalities of the existing submodules.
-
-
+This decryption step is crucial because the login or SSH daemon references the PAM config file to verify the TACACS secret / passkey. If it remains encrypted, the SSH daemon will be unable to recognize the passkey, leading to login failures. The depicted block diagram clearly showcases the enhanced capabilities of the existing submodules.
 ### Implementation details
-
-The implementation stands on three key pillars.
-1. OPENSSL toolkit is used for encryption / decryption
-2. aes-128-cbc is the encoding format used for encryption / decryption
-3. A unique Device MAC address used as a salt/password to encrypt/decrypt the configured pass key 
-
-
+The implementation stands on four key pillars.
+1. OPENSSL toolkit is used for encryption / decryption.
+2. aes-128-cbc is the encoding format used for encryption / decryption.
+3. A unique device admin password (encrypted hash from linux shadow file) will be used as a salt/password to encrypt/decrypt the configured pass key in ConfigDB.
+4. In absence of configured admin password (default behaviour), a fixed / hardcoded hash will be used as a salt/password for encryption/decryption and it will be saved locally not in any of the databases.
+Following is the snippet captured from a sample shadow file.
+<snip_from_shadow_file>
+admin:$6$YTJ7JKnfsB4esnbS$5XvmYk2.GXVWhDo2TYGN2hCitD/wU9Kov.uZD8xsnleuf1r0ARX3qodIKiDsdoQA444b8IMPMOnUWDmVJVkeg1:19446:0:99999:7:::
+<snip_from_shadow_file>
+Here, "YTJ7JKnfsB4esnbS$5XvmYk2.GXVWhDo2TYGN2hCitD/wU9Kov.uZD8xsnleuf1r0ARX3qodIKiDsdoQA444b8IMPMOnUWDmVJVkeg1" is the encrypted version of the admin level password. 
 #### Show CLI changes
-
-Furthermore, aside from encrypting the passkey stored within CONFIG_DB, this infrastructure ensures that the passkey itself remains concealed from any of the displayed CLI outputs. Consequently, the passkey field has been eliminated from the "show tacacs" output, and it will now solely indicate the status whether the passkey is configured or not. For instance.
-
+Furthermore, aside from encrypting the passkey stored within CONFIG_DB, this infrastructure ensures that the passkey itself remains concealed from any of the displayed CLI outputs. Consequently, the passkey field has been eliminated from the "show tacacs" output, and it will now solely indicate the status whether the passkey is configured or not. For instance,
 show tacacs
 ["TACPLUS global passkey configured Yes / No"]
-
-### DB migration 
-A DB migration script will be added for users to migrate existing config_db to convert tacacs passkey plaintext to encypted. 
-
-### Benifits
-
-TACACS passkey encryption adds an extra layer of security to safeguard the passkey on each device throughout the network. Moreover, the utilization of MAC address-based encryption ensures that each network device possesses its distinct encrypted passkey. This strategy effectively mitigates the risk of a major network breach in case one of the devices is compromised.
-
+### DB migration
+A DB migration script will be added for users to migrate existing config_db to convert tacacs passkey plaintext to encrypted.
+### Benefits
+TACACS passkey encryption adds an extra layer of security to safeguard the passkey on each device throughout the network. Furthermore, the implementation of shadow file-based encryption ensures that encrypted passkeys can be reused across network nodes without any complications. Consequently, there are no obstacles when it comes to utilizing the config_db.json file from one device on another. Additionally, the use of a shadow file effectively reduces the risk of exposing the encryption/decryption salt since it is only accessible to root users and remains inaccessible to external entities.
 ### Limitation
-We choose MAC address is unique and better for management, however if the MAC address of the device is known, we could decrypt the key. If we want to use any other ciper we should manage / stored it in the DB, it is again defeating the purpose. So for now we are going ahead with mac as network admins can orchestartion system to use mac address for passkey encryption. However we are open to new ideas and thoughts to hardened the security and we should be able to accomodate with later releases.
-
+The chosen way to encrypt the passkey is using an already encrypted admin password from the shadow file. Thus, the network admin needs to regenerate the encrypted passkey in ConfigDB only if there is a change in the admin password of the network.
+For now we are planning to go ahead with this approach. However we are open to new ideas and thoughts to harden the security and we should be able to accommodate that with later releases.
 ### Testing Requirements
-
-Need to add new / update the existing TACACS testcases to incorporate this new feature
-Test cases to unit test encrypt and decrypt fucntions 
+Need to add new / update the existing TACACS test cases to incorporate this new feature
+Test cases to unit test encrypt and decrypt functions
 Test cases to add test the TACACS+ functionality with passkey encryption
-Test cases to cover DB migration 
+Test cases to cover DB migration

--- a/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
+++ b/doc/TACACSPLUS_PASSKEY_ENCRYPTION.md
@@ -81,6 +81,7 @@ The implementation as follows
 config tacacs passkey TEST1
 
 Password: 
+Note: It will ask for a master key/password only when the 'key_encrypt' flag is set under respective feature table (ex: TACPLUS) in config_db.
 
 #### Show CLI changes
 Furthermore, aside from encrypting the passkey stored within CONFIG_DB, this infrastructure ensures that the passkey itself remains concealed from any of the displayed CLI outputs. Consequently, the passkey field has been eliminated from the "show tacacs" output, and it will now solely indicate the status whether the passkey is configured or not. For instance,


### PR DESCRIPTION
Adding support for TACACS+ passkey encryption for SONiC deployments.

Related PRs:
+++++++++
1. Security Cipher module - https://github.com/sonic-net/sonic-buildimage/pull/17201
2. Encryption using security cipher module - https://github.com/sonic-net/sonic-utilities/pull/3027
3. Decryption using security cipher module - https://github.com/sonic-net/sonic-host-services/pull/81
