### PR TITLE
Support collecting module EEPROM pages in show techsupport command

### DIFF
--- a/doc/sfputil/dump_sfp_eeprom.md
+++ b/doc/sfputil/dump_sfp_eeprom.md
@@ -1,0 +1,181 @@
+# Dump SFP EEPROM page data in show techsupport command #
+
+## Table of Content
+
+### Revision
+
+### Scope
+
+SONiC show techsupport command provides the ability to collect system dump for debug purpose. Module EEPROM data is important information for PHY issue debugging, but it is not part of show techsupport command. This design will enhance show techsupport command to contain module EEPROM data.
+
+### Definitions/Abbreviations
+
+N/A
+
+### Overview
+
+1. A new CLI `sfputil show eeprom-hexdump-all` shall dump EEPROM pages in a single call.
+2. Show techsupport command shall be extended to call `sfputil show eeprom-hexdump-all` command to collect module EEPROM data.
+
+### Requirements
+
+1. Show techsupport command shall collect module EEPROM raw data
+2. All existing cable types shall be supported except RJ45
+3. Vendor specific implementation is not required but still possible.
+
+### Architecture Design
+
+The current architecture is not changed
+
+### High-Level Design
+
+Submodule sonic-platform-common and sonic-utilities shall be changed. By default, vendor platform API implementation is not required.
+
+#### sonic-platform-common
+
+##### sfp_base change
+
+A new API `dump_eeprom` shall be added to `sfp_base.SfpBase`. This API shall be used by `sfputil show eeprom-hexdump-all` command to collect module EEPROM data.
+
+```python
+def dump_eeprom(self, page=None):
+    """
+    Dump all EEPROM data for this SFP
+
+    Args:
+        page: EEPROM page number, dump all pages if page is None
+
+    Returns:
+        A string contains the hex format EEPROM data
+    """
+    raise NotImplementedError
+```
+
+##### sfp_optoe_base change
+
+`sfp_optoe_base.SfpOptoeBase` shall implement the new API `dump_eeprom` so that vendor does not have to implement it (Vendor specific implementation is also possible).
+
+```python
+def dump_eeprom(self, page=None):
+    api = self.get_xcvr_api()
+    return api.dump_eeprom(page) if api is not None else None
+```
+
+##### sonic_xcvr change
+
+Following sonic_xcvr API implementation shall implement the new API `dump_eeprom`:
+
+- sonic_xcvr.api.public.cmis
+  - copper: page 0h (0-255)
+  - optical: pages 0h (0-255), 1h, 2h, 10h, 11h (128-255)
+- sonic_xcvr.api.public.sff8436
+  - copper: page 0h (0-255)
+  - optical: pages 0h (0-255), 1h, 2h, 3h (128-255)
+- sonic_xcvr.api.public.sff8472
+  - copper: page A0h (0-128)
+  - optical: page A0h (0-255), A2h (0-255)
+- sonic_xcvr.api.public.sff8636
+  - copper: page 0h (0-255)
+  - optical: pages 0h (0-255), 1h, 2h, 3h (128-255)
+
+#### sonic-utilities
+
+##### generate_dump change
+
+1. New subcommand `sfputil show eeprom-hexdump-all` shall be used to dump module EEPROM data
+2. EEPROM data shall be saved to path `$TARDIR/dump/`
+
+Sample code:
+```
+save_cmd "sfputil show eeprom-hexdump-all" "interface.xcvrs.eeprom.raw" &
+```
+
+Note: dumping EEPROM data might cause firmware busy, the command shall not be run parallel with save_saidump to avoid hardware access conflict.
+
+##### sfputil change
+
+A new subcommand `eeprom_hexdump_all` shall be added to `sfputil show` command group. The comamnd shall dump eeprom data for all existing cables except RJ45.
+
+Sample output:
+
+```
+EEPROM hexdump for module 1
+        Lower page 0h
+        00000000 11 08 06 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000010 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000020 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000030 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000040 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000050 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000060 00 00 00 00 00 00 00 00  00 00 00 00 00 01 08 00 |................|
+        00000070 00 10 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+
+        Upper page 0h
+        00000000 11 08 06 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000010 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000020 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000030 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000040 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000050 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000060 00 00 00 00 00 00 00 00  00 00 00 00 00 01 08 00 |................|
+        00000070 00 10 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+
+        Page 1h
+        00000000 11 08 06 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000010 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000020 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000030 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000040 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000050 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+        00000060 00 00 00 00 00 00 00 00  00 00 00 00 00 01 08 00 |................|
+        00000070 00 10 00 00 00 00 00 00  00 00 00 00 00 00 00 00 |................|
+
+...
+
+EEPROM hexdump for module 2
+
+...
+```
+
+####
+
+### SAI API
+
+N/A
+
+### Configuration and management
+
+#### Manifest (if the feature is an Application Extension)
+
+N/A
+
+#### CLI/YANG model Enhancements
+
+No YANG model changes. CLI changes has been described in section #### sfputil change
+
+#### Config DB Enhancements
+
+N/A
+
+### Warmboot and Fastboot Design Impact
+
+N/A
+
+### Memory Consumption
+
+No memory consumption is expected when the feature is disabled via compilation and no growing memory consumption while feature is disabled by configuration.
+
+### Restrictions/Limitations
+
+Vendor should support platform API `sfp.read_eeprom` to support this feature.
+
+### Testing Requirements/Design
+
+#### Unit Test cases
+
+sonic-utilities unit test shall be extended to cover new subcommand `sfputil show eeprom-dump-all`
+sonic-platform-common unit test shall be extended to cover new API `sfp.dump_eeprom`
+
+#### System Test cases
+
+### Open/Action items - if any

--- a/doc/sfputil/dump_sfp_eeprom.md
+++ b/doc/sfputil/dump_sfp_eeprom.md
@@ -73,7 +73,7 @@ Following sonic_xcvr API implementation shall implement the new API `dump_eeprom
   - optical: pages 0h (0-255), 1h, 2h, 3h (128-255)
 - sonic_xcvr.api.public.sff8472
   - copper: page A0h (0-128)
-  - optical: page A0h (0-255), A2h (0-255)
+  - optical: page A0h (0-255), A2h (0-128)
 - sonic_xcvr.api.public.sff8636
   - copper: page 0h (0-255)
   - optical: pages 0h (0-255), 1h, 2h, 3h (128-255)
@@ -94,7 +94,7 @@ Note: dumping EEPROM data might cause firmware busy, the command shall not be ru
 
 ##### sfputil change
 
-A new subcommand `eeprom_hexdump_all` shall be added to `sfputil show` command group. The comamnd shall dump eeprom data for all existing cables except RJ45.
+A new subcommand `eeprom_hexdump_all` shall be added to `sfputil show` command group. The command shall dump eeprom data for all existing cables except RJ45.
 
 Sample output:
 
@@ -173,8 +173,8 @@ Vendor should support platform API `sfp.read_eeprom` to support this feature.
 
 #### Unit Test cases
 
-sonic-utilities unit test shall be extended to cover new subcommand `sfputil show eeprom-dump-all`
-sonic-platform-common unit test shall be extended to cover new API `sfp.dump_eeprom`
+- sonic-utilities unit test shall be extended to cover new subcommand `sfputil show eeprom-dump-all`
+- sonic-platform-common unit test shall be extended to cover new API `sfp.dump_eeprom`
 
 #### System Test cases
 

--- a/doc/sfputil/dump_sfp_eeprom.md
+++ b/doc/sfputil/dump_sfp_eeprom.md
@@ -58,7 +58,7 @@ Existing subcommand `eeprom-hexdump` shall be extended to dump eeprom data for a
 
 - CMIS
   - copper: page 0h (0-255)
-  - optical: pages 0h (0-255), 1h, 2h, 10h, 11h (128-255), CDB pages if available (128-255), 400G ZR pages if available (128-255)
+  - optical: pages 0h (0-255), 1h, 2h, 10h, 11h (128-255), CDB page 0x9f if available (128-255), 400G ZR pages 30h, 31h, 32h, 33h, 34h, 35h, 38h, 39h, 3ah, 3bh if available (128-255)
 - sff8436
   - copper: page 0h (0-255)
   - optical: pages 0h (0-255), 1h, 2h, 3h (128-255)

--- a/doc/sfputil/dump_sfp_eeprom.md
+++ b/doc/sfputil/dump_sfp_eeprom.md
@@ -43,8 +43,6 @@ Sample code:
 save_cmd "sfputil show eeprom-hexdump" "interface.xcvrs.eeprom.raw" &
 ```
 
-Note: dumping EEPROM data might cause firmware busy, the command shall not be run parallel with save_saidump to avoid hardware access conflict.
-
 ##### sfputil change
 
 Existing subcommand `eeprom-hexdump` shall be extended to dump eeprom data for all existing cables except RJ45. Currently, `sfputil show eeprom-hexdump` accept two options `--port` and `--page`. It shall be extended like this:
@@ -139,7 +137,7 @@ N/A
 
 ### Memory Consumption
 
-No memory consumption is expected when the feature is disabled via compilation and no growing memory consumption while feature is disabled by configuration.
+Dumping module EEPROM pages takes memory which shall be freed after finishing the command.
 
 ### Restrictions/Limitations
 

--- a/doc/sfputil/dump_sfp_eeprom.md
+++ b/doc/sfputil/dump_sfp_eeprom.md
@@ -51,8 +51,8 @@ Existing subcommand `eeprom-hexdump` shall be extended to dump eeprom data for a
 
 1. `sfputil show eeprom-hexdump --port <port> --page <page>`: dump given page for given port
 2. `sfputil show eeprom-hexdump --port <port>`: dump page 0 for given port (to keep backwardcompatible)
-3. `sfputil show eeprom-hexdump --page <page>`: dump given page for all ports, fail if any port does not support the page
-4. `sfputil show eeprom-hexdump`: dump available pages for all ports.
+3. `sfputil show eeprom-hexdump --page <page>`: dump given page for all ports, validate that page must be in range [0,255]. User is repsonsible for making sure the page existence.
+4. `sfputil show eeprom-hexdump`: dump available pages for all ports. Available pages for different cable types are described below.
 
 `sfputil show eeprom-hexdump` shall dump pages based on cable type:
 
@@ -63,8 +63,8 @@ Existing subcommand `eeprom-hexdump` shall be extended to dump eeprom data for a
   - copper: page 0h (0-255)
   - optical: pages 0h (0-255), 1h, 2h, 3h (128-255)
 - sff8472
-  - copper: page A0h (0-128)
-  - optical: page A0h (0-255), A2h (0-128)
+  - passive: page 0h (0-127) if flat memory else (0-255) 
+  - active: page 0h (0-127) if flat memory else (0-255), 1h, 2h (128-255)
 - sff8636
   - copper: page 0h (0-255)
   - optical: pages 0h (0-255), 1h, 2h, 3h (128-255)

--- a/doc/sfputil/dump_sfp_eeprom.md
+++ b/doc/sfputil/dump_sfp_eeprom.md
@@ -31,25 +31,6 @@ The current architecture is not changed
 
 Submodule sonic-utilities shall be changed. By default, vendor platform API implementation is not required.
 
-#### sonic-platform-common
-
-##### sonic_xcvr change
-
-Following sonic_xcvr API implementation shall implement the new API `dump_eeprom`:
-
-- sonic_xcvr.api.public.cmis
-  - copper: page 0h (0-255)
-  - optical: pages 0h (0-255), 1h, 2h, 10h, 11h (128-255)
-- sonic_xcvr.api.public.sff8436
-  - copper: page 0h (0-255)
-  - optical: pages 0h (0-255), 1h, 2h, 3h (128-255)
-- sonic_xcvr.api.public.sff8472
-  - copper: page A0h (0-128)
-  - optical: page A0h (0-255), A2h (0-128)
-- sonic_xcvr.api.public.sff8636
-  - copper: page 0h (0-255)
-  - optical: pages 0h (0-255), 1h, 2h, 3h (128-255)
-
 #### sonic-utilities
 
 ##### generate_dump change
@@ -73,7 +54,7 @@ Existing subcommand `eeprom-hexdump` shall be extended to dump eeprom data for a
 3. `sfputil show eeprom-hexdump --page <page>`: dump given page for all ports, fail if any port does not support the page
 4. `sfputil show eeprom-hexdump`: dump available pages for all ports.
 
-For current phase, `sfputil show eeprom-hexdump` shall dump pages based on cable type:
+`sfputil show eeprom-hexdump` shall dump pages based on cable type:
 
 - CMIS
   - copper: page 0h (0-255)
@@ -87,6 +68,8 @@ For current phase, `sfputil show eeprom-hexdump` shall dump pages based on cable
 - sff8636
   - copper: page 0h (0-255)
   - optical: pages 0h (0-255), 1h, 2h, 3h (128-255)
+
+> Note: it is very complicated to dump all possible pages. So, only basic pages shall be dumped in the current implementation.  
 
 Sample output:
 


### PR DESCRIPTION
# Overview

SONiC show techsupport command provides the ability to collect system dump for debug purpose. Module EEPROM data is important information for PHY issue debugging, but it is not part of show techsupport command. This design will enhance show techsupport command to contain module EEPROM data.

# PR

| PR title | state | context |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| [[sonic-utilities] Collect module EEPROM data in dump](https://github.com/Azure/sonic-utilities/pull/3009) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-utilities/3009) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-utilities/3009) |