### PR TITLE
Special Character fix

### DIFF
--- a/doc/fpmsyncd/hld_fpmsyncd-NTT.md
+++ b/doc/fpmsyncd/hld_fpmsyncd-NTT.md
@@ -299,19 +299,19 @@ As shown in below diff code, the template will generate config following below l
 ```
 > zebra.conf.j2
 
- {% endblock banner %}
+ {/% endblock banner /%}
  !
- {% block fpm %}
-+{% if ( ('localhost' in DEVICE_METADATA) and ('nexthop_group' in  DEVICE_METADATA['localhost']) and
-+        (DEVICE_METADATA['localhost']['nexthop_group'] == 'enabled') ) %}
+ {/% block fpm /%}
++{/% if ( ('localhost' in DEVICE_METADATA) and ('nexthop_group' in  DEVICE_METADATA['localhost']) and
++        (DEVICE_METADATA['localhost']['nexthop_group'] == 'enabled') ) /%}
 +fpm use-next-hop-groups
-+{% else %}
++{/% else /%}
  ! Uses the old known FPM behavior of including next hop information in the route (e.g. RTM_NEWROUTE) messages
  no fpm use-next-hop-groups
-+{% endif %}
++{/% endif /%}
  !
  fpm address 127.0.0.1
- {% endblock fpm %}
+ {/% endblock fpm /%}
 ```
 
 #### CLI/YANG model Enhancements 


### PR DESCRIPTION
page deployment error has been seen in one more file now due to special character present in one of the checked in HLD (hld_fpmsyncd-NTT.md). The same has been fixed in this PR. Kindly review and approve.