### PR TITLE
Update sflow HLD to reflect the dependency on system ready feature

### DIFF
--- a/doc/sflow/sflow_hld.md
+++ b/doc/sflow/sflow_hld.md
@@ -887,6 +887,7 @@ On the SONiC VS, SAI calls would map to the tc_sample commands on the switchport
 ## 11 **Restrictions**
 * /etc/hsflowd.conf should not be modified manually. While it should be possible to change /etc/hsflowd.conf manually and restart the sflow container, it is not recommended.
 * configuration updates will necessitate hsflowd service restart
+* hsflowd daemon will initialize only after receiving the SYSTEM_READY|SYSTEM_STATE Status=Up from SONiC. The system ready state however depends on all daemons to be ready and all components like PSU and fan to be functional. Failure on any of these, will result in system state to be down. In such scenarios, sflow will wait until 180 seconds and if system ready is not up will proceed with initialization. For more details please refer to https://github.com/sonic-net/sonic-buildimage/issues/13407#issuecomment-1575257797
 
 ## 12 **Unit Test cases**
 Unit test case one-liners are given below:

--- a/doc/sflow/sflow_hld.md
+++ b/doc/sflow/sflow_hld.md
@@ -887,7 +887,7 @@ On the SONiC VS, SAI calls would map to the tc_sample commands on the switchport
 ## 11 **Restrictions**
 * /etc/hsflowd.conf should not be modified manually. While it should be possible to change /etc/hsflowd.conf manually and restart the sflow container, it is not recommended.
 * configuration updates will necessitate hsflowd service restart
-* hsflowd daemon will initialize only after receiving the SYSTEM_READY|SYSTEM_STATE Status=Up from SONiC. The system ready state however depends on all daemons to be ready and all components like PSU and fan to be functional. Failure on any of these, will result in system state to be down. In such scenarios, sflow will wait until 180 seconds and if system ready is not up will proceed with initialization. For more details please refer to https://github.com/sonic-net/sonic-buildimage/issues/13407#issuecomment-1575257797
+* hsflowd daemon will initialize only after receiving the SYSTEM_READY|SYSTEM_STATE Status=Up from SONiC. The system ready state however depends on all the monitored daemons to be ready. Failure on any of these, will result in system state to be down. In such scenarios, sflow will wait until 180 seconds and if system ready is not up will proceed with initialization. For more details please refer to https://github.com/sonic-net/sonic-buildimage/issues/13407#issuecomment-1575257797 . For system ready feature please visit https://github.com/sonic-net/SONiC/blob/master/doc/system_health_monitoring/system-ready-HLD.md
 
 ## 12 **Unit Test cases**
 Unit test case one-liners are given below:

--- a/doc/sflow/sflow_hld.md
+++ b/doc/sflow/sflow_hld.md
@@ -887,7 +887,7 @@ On the SONiC VS, SAI calls would map to the tc_sample commands on the switchport
 ## 11 **Restrictions**
 * /etc/hsflowd.conf should not be modified manually. While it should be possible to change /etc/hsflowd.conf manually and restart the sflow container, it is not recommended.
 * configuration updates will necessitate hsflowd service restart
-* hsflowd daemon will initialize only after receiving the SYSTEM_READY|SYSTEM_STATE Status=Up from SONiC. The system ready state however depends on all the monitored daemons to be ready. Failure on any of these, will result in system state to be down. In such scenarios, sflow will wait until 180 seconds and if system ready is not up will proceed with initialization. For more details please refer to . For system ready feature please visit https://github.com/sonic-net/SONiC/blob/master/doc/system_health_monitoring/system-ready-HLD.md
+* hsflowd daemon will initialize only after receiving the SYSTEM_READY|SYSTEM_STATE Status=Up from SONiC. The system ready state however depends on all the monitored daemons to be ready. Failure on any of these, will result in system state to be down. In such scenarios, sflow will wait until 180 seconds and if system ready is not up will proceed with initialization. For system ready feature please visit https://github.com/sonic-net/SONiC/blob/master/doc/system_health_monitoring/system-ready-HLD.md
 
 ## 12 **Unit Test cases**
 Unit test case one-liners are given below:

--- a/doc/sflow/sflow_hld.md
+++ b/doc/sflow/sflow_hld.md
@@ -887,7 +887,7 @@ On the SONiC VS, SAI calls would map to the tc_sample commands on the switchport
 ## 11 **Restrictions**
 * /etc/hsflowd.conf should not be modified manually. While it should be possible to change /etc/hsflowd.conf manually and restart the sflow container, it is not recommended.
 * configuration updates will necessitate hsflowd service restart
-* hsflowd daemon will initialize only after receiving the SYSTEM_READY|SYSTEM_STATE Status=Up from SONiC. The system ready state however depends on all the monitored daemons to be ready. Failure on any of these, will result in system state to be down. In such scenarios, sflow will wait until 180 seconds and if system ready is not up will proceed with initialization. For more details please refer to https://github.com/sonic-net/sonic-buildimage/issues/13407#issuecomment-1575257797 . For system ready feature please visit https://github.com/sonic-net/SONiC/blob/master/doc/system_health_monitoring/system-ready-HLD.md
+* hsflowd daemon will initialize only after receiving the SYSTEM_READY|SYSTEM_STATE Status=Up from SONiC. The system ready state however depends on all the monitored daemons to be ready. Failure on any of these, will result in system state to be down. In such scenarios, sflow will wait until 180 seconds and if system ready is not up will proceed with initialization. For more details please refer to . For system ready feature please visit https://github.com/sonic-net/SONiC/blob/master/doc/system_health_monitoring/system-ready-HLD.md
 
 ## 12 **Unit Test cases**
 Unit test case one-liners are given below:


### PR DESCRIPTION
This is to update the discussion captured in the bug https://github.com/sonic-net/sonic-buildimage/issues/13407#issuecomment-1575257797. Sflow depends on system ready and if it is not received, sflow will be functional only after 180 seconds