### PR TITLE
[Dash] Update for PL/PL-NSG and metering for Sonic Dash

### DIFF
--- a/doc/dash/dash-sonic-hld.md
+++ b/doc/dash/dash-sonic-hld.md
@@ -595,8 +595,8 @@ underlay_ip              = ip_address                ; PA address for the CA
 mac_address              = MAC address as string     ; Inner dst mac
 metering_class_or        = uint32                    ; metering class 'or' bits
 use_dst_vni              = bool                      ; if true, use the destination VNET VNI for encap. If false or not specified, use source VNET's VNI
-overlay_sip_prefix       = ip_prefix                 ; overlay src ip prefix if routing_type is {privatelink}, transform last 32 bits from packet if mask is 96
-overlay_dip_prefix       = ip_prefix                 ; overlay dst ip prefix if routing_type is {privatelink} 
+overlay_sip_prefix       = ip_prefix                 ; overlay src ip prefix if routing_type is {privatelink, servicetunnel}, transform last 32 bits from packet if mask is 96
+overlay_dip_prefix       = ip_prefix                 ; overlay dst ip prefix if routing_type is {privatelink, servicetunnel} 
 routing_appliance_id     = uint32                    ; ID of routing appliance to use if routing_type is {privatelinknsg} (OBSOLETED)
 tunnel                   = string                    ; Nexthop tunnel for privatelink nsg for additional encapsulation. 
 ```
@@ -1313,8 +1313,8 @@ For the inbound direction, after Route/ACL lookup, pipeline shall use the "under
     {
         "DASH_ROUTE_TABLE:group_id_2:50.1.2.0/24": {
             "action_type":"servicetunnel",
-            "overlay_sip":"fd00:108:0:d204:0:200::0",
-            "overlay_dip":"2603:10e1:100:2::0",
+            "overlay_sip_prefix":"fd00:108:0:d204:0:200::0/96",
+            "overlay_dip_prefix":"2603:10e1:100:2::0/96",
             "underlay_sip":"40.1.2.1",
             "metering_policy_en":"false",
             "metering_class":"50000"
@@ -1324,8 +1324,8 @@ For the inbound direction, after Route/ACL lookup, pipeline shall use the "under
     {
         "DASH_ROUTE_TABLE:group_id_2:60.1.2.1/32": {
             "action_type":"servicetunnel",
-            "overlay_sip":"fd00:108:0:d204:0:200::0",
-            "overlay_dip":"2603:10e1:100:2::0",
+            "overlay_sip_prefix":"fd00:108:0:d204:0:200::0/96",
+            "overlay_dip_prefix":"2603:10e1:100:2::0/96",
             "underlay_sip":"30.1.2.1",
             "underlay_dip":"25.1.2.1"
         },
@@ -1334,8 +1334,8 @@ For the inbound direction, after Route/ACL lookup, pipeline shall use the "under
     {
         "DASH_ROUTE_TABLE:group_id_2:70.1.2.0/24": {
             "action_type":"servicetunnel",
-            "overlay_sip":"fd00:108:0:d204:0:200::0",
-            "overlay_dip":"2603:10e1:100:2::4601:203",
+            "overlay_sip":"fd00:108:0:d204:0:200::0/96",
+            "overlay_dip":"2603:10e1:100:2::4601:203/128",
             "underlay_sip":"34.1.2.1"
         },
         "OP": "SET"
@@ -1482,8 +1482,8 @@ For the example configuration above, the following is a brief explanation of loo
             "routing_type":"privatelink",
             "mac_address":"F9-22-83-99-22-A2",
             "underlay_ip":"50.2.2.6",
-            "overlay_sip_prefix":"fd41:108:20:d204::200::0",
-            "overlay_dip_prefix":"2603:10e1:100:2::3402:206",
+            "overlay_sip_prefix":"fd41:108:20:d204::200::0/96",
+            "overlay_dip_prefix":"2603:10e1:100:2::3402:206/128",
             "tunnel":"nsg_tunnel_1"
         },
         "OP": "SET"

--- a/doc/dash/dash-sonic-hld.md
+++ b/doc/dash/dash-sonic-hld.md
@@ -365,8 +365,8 @@ underlay_ip              = PA address for Inbound encapsulation to VM
 admin_state              = Enabled after all configurations are applied. 
 vnet                     = Vnet that ENI belongs to
 pl_sip_encoding          = Private Link encoding for IPv6 SIP transpositions; Format "field_value/full_mask" where both field_value and `full_mask` must be given as IPv6 addresses. field_value must be used as a replacement to the
-			   first (128-len(full_mask)) bits of pl_sip. Last 32 bits are reserved for the IPv4 CA. Logic: ((pl_sip & !full_mask) | field_value).
-pl_underlay_sip          = Underlay SIP (ST GW VIP) to be used for all private link transformation for this ENI - (Obsoleted - Will use overlay transpositions from mapping tables)
+			   first (128-len(full_mask)) bits of pl_sip. Last 32 bits are reserved for the IPv4 CA. Logic: ((pl_sip & !full_mask) | field_value). (Obsoleted - Will use overlay transpositions from mapping tables)
+pl_underlay_sip          = Underlay SIP (ST GW VIP) to be used for all private link transformation for this ENI
 v4_meter_policy_id	     = IPv4 meter policy ID
 v6_meter_policy_id	     = IPv6 meter policy ID
 disable_fast_path_icmp_flow_redirection     = Disable handling fast path ICMP flow redirection packets
@@ -520,8 +520,8 @@ DASH_ROUTE_TABLE:{{group_id}}:{{prefix}}
     "vnet":{{vnet_name}} (OPTIONAL)
     "appliance":{{appliance_id}} (OPTIONAL)
     "overlay_ip":{{ip_address}} (OPTIONAL)
-    "overlay_sip":{{ip_address}} (OPTIONAL)
-    "overlay_dip":{{ip_address}} (OPTIONAL)
+    "overlay_sip_prefix":{{ip_prefix}} (OPTIONAL)
+    "overlay_dip_prefix":{{ip_prefix}} (OPTIONAL)
     "underlay_sip":{{ip_address}} (OPTIONAL)
     "underlay_dip":{{ip_address}} (OPTIONAL)
     "metering_policy_en": {{bool}} (OPTIONAL)  (OBSOLETED)
@@ -536,8 +536,8 @@ action_type              = routing_type              ; reference to routing type
 vnet                     = vnet name                 ; destination vnet name if routing_type is {vnet, vnet_direct}, a vnet other than eni's vnet means vnet peering
 appliance                = appliance id              ; appliance id if routing_type is {appliance} 
 overlay_ip               = ip_address                ; overly_ip to lookup if routing_type is {vnet_direct}, use dst ip from packet if not specified
-overlay_sip              = ip_address                ; overlay ipv6 src ip if routing_type is {servicetunnel}, transform last 32 bits from packet (src ip)
-overlay_dip              = ip_address                ; overlay ipv6 dst ip if routing_type is {servicetunnel}, transform last 32 bits from packet (dst ip) 
+overlay_sip_prefix       = ip_prefix                 ; overlay ipv6 src ip if routing_type is {servicetunnel}, transform last 32 bits from packet (src ip)
+overlay_dip_prefix       = ip_prefix                 ; overlay ipv6 dst ip if routing_type is {servicetunnel}, transform last 32 bits from packet (dst ip) 
 underlay_sip             = ip_address                ; underlay ipv4 src ip if routing_type is {servicetunnel,privatelink}; this is the ST GW VIP (for ST traffic) or custom VIP. If specified, overrides pl_underlay_sip from DASH_ENI_TABLE
 underlay_dip             = ip_address                ; underlay ipv4 dst ip to override if routing_type is {servicetunnel}, use dst ip from packet if not specified
 metering_policy_en	 = bool                      ; Metering policy lookup enable (optional), default = false  (OBSOLETED). If aggregated or/and bits is 0, metering policy is applied
@@ -595,8 +595,8 @@ underlay_ip              = ip_address                ; PA address for the CA
 mac_address              = MAC address as string     ; Inner dst mac
 metering_class_or        = uint32                    ; metering class 'or' bits
 use_dst_vni              = bool                      ; if true, use the destination VNET VNI for encap. If false or not specified, use source VNET's VNI
-overlay_sip_prefix       = ip_prefix                 ; overlay src ip prefix if routing_type is {privatelink, servicetunnel}, transform last 32 bits from packet if mask is 96
-overlay_dip_prefix       = ip_prefix                 ; overlay dst ip prefix if routing_type is {privatelink, servicetunnel} 
+overlay_sip_prefix       = ip_prefix                 ; overlay src ip prefix if routing_type is {privatelink}, transform last 32 bits from packet if mask is 96
+overlay_dip_prefix       = ip_prefix                 ; overlay dst ip prefix if routing_type is {privatelink} 
 routing_appliance_id     = uint32                    ; ID of routing appliance to use if routing_type is {privatelinknsg} (OBSOLETED)
 tunnel                   = string                    ; Nexthop tunnel for privatelink nsg for additional encapsulation. 
 ```
@@ -1334,8 +1334,8 @@ For the inbound direction, after Route/ACL lookup, pipeline shall use the "under
     {
         "DASH_ROUTE_TABLE:group_id_2:70.1.2.0/24": {
             "action_type":"servicetunnel",
-            "overlay_sip":"fd00:108:0:d204:0:200::0/96",
-            "overlay_dip":"2603:10e1:100:2::4601:203/128",
+            "overlay_sip_prefix":"fd00:108:0:d204:0:200::0/96",
+            "overlay_dip_prefix":"2603:10e1:100:2::4601:203/128",
             "underlay_sip":"34.1.2.1"
         },
         "OP": "SET"

--- a/doc/dash/dash-sonic-hld.md
+++ b/doc/dash/dash-sonic-hld.md
@@ -366,7 +366,7 @@ admin_state              = Enabled after all configurations are applied.
 vnet                     = Vnet that ENI belongs to
 pl_sip_encoding          = Private Link encoding for IPv6 SIP transpositions; Format "field_value/full_mask" where both field_value and `full_mask` must be given as IPv6 addresses. field_value must be used as a replacement to the
 			   first (128-len(full_mask)) bits of pl_sip. Last 32 bits are reserved for the IPv4 CA. Logic: ((pl_sip & !full_mask) | field_value).
-pl_underlay_sip          = Underlay SIP (ST GW VIP) to be used for all private link transformation for this ENI - Obsoleted - Will use from svc rewrite info in mapping tables
+pl_underlay_sip          = Underlay SIP (ST GW VIP) to be used for all private link transformation for this ENI - (Obsoleted - Will use overlay transpositions from mapping tables)
 v4_meter_policy_id	     = IPv4 meter policy ID
 v6_meter_policy_id	     = IPv6 meter policy ID
 disable_fast_path_icmp_flow_redirection     = Disable handling fast path ICMP flow redirection packets
@@ -580,7 +580,6 @@ DASH_VNET_MAPPING_TABLE:{{vnet}}:{{ip_address}}
     "underlay_ip":{{ip_address}}
     "mac_address":{{mac_address}} (OPTIONAL) 
     "metering_class_or": {{uint32}} (OPTIONAL)
-    "override_meter": {{bool}} (OPTIONAL)
     "use_dst_vni": {{bool}} (OPTIONAL)
     "use_pl_sip_eni": {{bool}} (OPTIONAL)
     "overlay_sip_prefix":{{ip_prefix}} (OPTIONAL)
@@ -595,7 +594,6 @@ action_type              = routing_type              ; reference to routing type
 underlay_ip              = ip_address                ; PA address for the CA
 mac_address              = MAC address as string     ; Inner dst mac
 metering_class_or        = uint32                    ; metering class 'or' bits
-override_meter           = bool                      ; override the metering class-id coming from the route table
 use_dst_vni              = bool                      ; if true, use the destination VNET VNI for encap. If false or not specified, use source VNET's VNI
 overlay_sip_prefix       = ip_prefix                 ; overlay src ip prefix if routing_type is {privatelink}, transform last 32 bits from packet if mask is 96
 overlay_dip_prefix       = ip_prefix                 ; overlay dst ip prefix if routing_type is {privatelink} 


### PR DESCRIPTION
Following are the updates on Dash Sonic HLD:

1. `pl_sip_encoding `from ENI table is obsoleted and overlay sip/dip in mapping tables are changed to `prefix `to that contains the necessary encodings
2. `privatelinknsg `routing type is removed and an addition tunnel nexthop is added to mapping tables for final encapsulation
3. Introduce `DASH_TUNNEL_TABLE`
4. Introduce Metering `OR` and `AND` bits for deriving the metering class, obsoleted 'metering class' overrides. 
5. Example updated for Private Link 
6. TBD - Example updates for other scenarios. 