### PR TITLE
Improve user guide for gnmi client

### DIFF
--- a/doc/dash/dash-sonic-kvm.md
+++ b/doc/dash/dash-sonic-kvm.md
@@ -162,6 +162,8 @@ total 40
 
 Please install gnmi_cli_py from https://github.com/lguohan/gnxi/tree/master/gnmi_cli_py.
 
+We install gnmi_cli_py in the PTF container by default. However, if you attempt to install it in a different environment, you might encounter dependency conflicts. Additionally, please use pip2 and Python 2, as this client requires a Python 2 environment.
+
 Restart GNMI server with server certificates:
 
 ```

--- a/doc/dash/dash-sonic-kvm.md
+++ b/doc/dash/dash-sonic-kvm.md
@@ -129,7 +129,7 @@ ssh -i ~/.ssh/id_rsa_docker_sonic_mgmt zegan@172.17.0.2
 cd /data/sonic-mgmt/tests
 
 # Run testcases
-./run_tests.sh -u -n vms-kvm-dpu -d vlab-01 -m individual -e --skip_sanity -e --disable_loganalyzer  -c dash/test_dash_vnet.py -f vtestbed.yaml -i ../ansible/veos_vtb -e "--skip_dataplane_checking"
+./run_tests.sh -u -n vms-kvm-dpu -d vlab-01 -m individual -e --skip_sanity -e --disable_loganalyzer  -c dash/test_dash_vnet.py -f vtestbed.yaml -i ../ansible/veos_vtb -e --skip_dataplane_checking -e --skip_cert_cleanup
 ```
 
 ## 5.1.2 Connect to the DPU


### PR DESCRIPTION
Update test method to keep gnmi certificates for further testing.
Explain GNMI client environment requirement.