### PR TITLE
Fix doc build issue

### DIFF
--- a/doc/smart-switch/BFD/SmartSwitchDpuLivenessUsingBfd.md
+++ b/doc/smart-switch/BFD/SmartSwitchDpuLivenessUsingBfd.md
@@ -79,6 +79,7 @@ Existing VNET_ROUTE_TUNNEL_TABLE is updated to include BFD Rx and Tx timers. Ove
 
 Existing
 ```
+{% raw %} # ignore this line please
 VNET_ROUTE_TUNNEL_TABLE:{{vnet_name}}:{{prefix}}  
     "endpoint": {{ip_address1},{ip_address2},...} 
     "endpoint_monitor": {{ip_address1},{ip_address2},...} (OPTIONAL) 
@@ -86,10 +87,12 @@ VNET_ROUTE_TUNNEL_TABLE:{{vnet_name}}:{{prefix}}
     "vni": {{vni1},{vni2},...} (OPTIONAL) 
     "weight": {{w1},{w2},...} (OPTIONAL) 
     “profile”: {{profile_name}} (OPTIONAL) 
+{% raw %} # ignore this line please
 ```
 
 Proposed changes
 ```
+{% raw %} # ignore this line please
 VNET_ROUTE_TUNNEL_TABLE:{{vnet_name}}:{{prefix}}  
     "endpoint": {{ip_address1},{ip_address2},...} 
     "endpoint_monitor": {{ip_address1},{ip_address2},...} (OPTIONAL) 
@@ -99,6 +102,7 @@ VNET_ROUTE_TUNNEL_TABLE:{{vnet_name}}:{{prefix}}
     “profile”: {{profile_name}} (OPTIONAL) 
     "rx_monitor_timer": {time in milliseconds}
     "tx_monitor_timer": {time in milliseconds}
+{% raw %} # ignore this line please
 ```
 
 ## 2.2 SmartSwitch NPU-DPU BFD sessions

--- a/doc/smart-switch/BFD/SmartSwitchDpuLivenessUsingBfd.md
+++ b/doc/smart-switch/BFD/SmartSwitchDpuLivenessUsingBfd.md
@@ -87,7 +87,7 @@ VNET_ROUTE_TUNNEL_TABLE:{{vnet_name}}:{{prefix}}
     "vni": {{vni1},{vni2},...} (OPTIONAL) 
     "weight": {{w1},{w2},...} (OPTIONAL) 
     “profile”: {{profile_name}} (OPTIONAL) 
-{% raw %} # ignore this line please
+{% endraw %} # ignore this line please
 ```
 
 Proposed changes
@@ -102,7 +102,7 @@ VNET_ROUTE_TUNNEL_TABLE:{{vnet_name}}:{{prefix}}
     “profile”: {{profile_name}} (OPTIONAL) 
     "rx_monitor_timer": {time in milliseconds}
     "tx_monitor_timer": {time in milliseconds}
-{% raw %} # ignore this line please
+{% endraw %} # ignore this line please
 ```
 
 ## 2.2 SmartSwitch NPU-DPU BFD sessions


### PR DESCRIPTION
To fix page build issue

https://github.com/sonic-net/SONiC/actions/runs/9407700419/job/25914054345

  Liquid Exception: Liquid syntax error (line 83): Variable '{{ip_address1}' was not properly terminated with regexp: /\}\}/ in doc/smart-switch/BFD/SmartSwitchDpuLivenessUsingBfd.md
/usr/local/bundle/gems/liquid-4.0.4/lib/liquid/block_body.rb:136:in `raise_missing_variable_terminator': Liquid syntax error (line 83): Variable '{{ip_address1}' was not properly terminated with regexp: /\\}\\}/ (Liquid::SyntaxError)
	from /usr/local/bundle/gems/liquid-4.0.4/lib/liquid/block_body.rb:128:in `create_variable'