### PR TITLE
[Smartswitch] Changed bridge midplane yang model reference

### DIFF
--- a/doc/smart-switch/ip-address-assigment/smart-switch-ip-address-assignment.md
+++ b/doc/smart-switch/ip-address-assigment/smart-switch-ip-address-assignment.md
@@ -364,7 +364,7 @@ The YANG model shown in this section is provided as a reference. The complete mo
             container GLOBAL {
                 leaf bridge {
                     type string {
-                        pattern "bridge_midplane";
+                        pattern "bridge-midplane";
                     }
                     description "Name of the midplane bridge";
 


### PR DESCRIPTION
This PR is to align the yang model to change `bridge_midplane` to `bridge-midplane` since this is the value used in the `systemd-networkd` in CONFIG_DB so that the yang validation does not fail
Related to PRs:
https://github.com/sonic-net/sonic-buildimage/pull/19819