### PR TITLE
Added 'last_sync_time' field to STORAGE_INFO schema in STATE_DB

### DIFF
--- a/doc/storagemond/storagemond-hld.md
+++ b/doc/storagemond/storagemond-hld.md
@@ -371,19 +371,19 @@ key                     = STORAGE_INFO|<disk_name>  ; This key is for informatio
 
 ; field                 = value
 
-device_model            = STRING                    ; Describes the Vendor information of the disk                                           (Static)
-serial                  = STRING                    ; Describes the Serial number of the disk                                                (Static)
-temperature_celsius     = STRING                    ; Describes the operating temperature of the disk in Celsius                             (Dynamic)
-total_fsio_reads        = STRING                    ; Describes the total number of filesystem reads completed successfully                  (Dynamic)
-total_fsio_writes       = STRING                    ; Describes the total number of filesystem writes completed successfully                 (Dynamic)
-latest_fsio_reads       = STRING                    ; Describes the latest number of filesystem reads completed successfully                 (Dynamic)
-latest_fsio_writes      = STRING                    ; Describes the latest number of filesystem writes completed successfully                (Dynamic)
-disk_io_reads           = STRING                    ; Describes the total number of reads completed successfully from the SSD (Bytes)        (Dynamic)
-disk_io_writes          = STRING                    ; Describes the total number of writes completed on the SSD (Bytes)                      (Dynamic)
-reserved_blocks         = STRING                    ; Describes the reserved blocks count of the SSD                                         (Dynamic)
-firmware                = STRING                    ; Describes the Firmware version of the SSD                                              (Dynamic)
-health                  = STRING                    ; Describes the overall health of the SSD as a % value based on several SMART attrs      (Dynamic)
-last_sync_time          = STRING                    ; The latest successful sync time of disk attribtes to STATE_DB (YYYY:MM:DD HH:MM:SS)    (Dynamic)
+device_model            = STRING                    ; Describes the Vendor information of the disk                                                     (Static)
+serial                  = STRING                    ; Describes the Serial number of the disk                                                          (Static)
+temperature_celsius     = STRING                    ; Describes the operating temperature of the disk in Celsius                                       (Dynamic)
+total_fsio_reads        = STRING                    ; Describes the total number of filesystem reads completed successfully                            (Dynamic)
+total_fsio_writes       = STRING                    ; Describes the total number of filesystem writes completed successfully                           (Dynamic)
+latest_fsio_reads       = STRING                    ; Describes the latest number of filesystem reads completed successfully                           (Dynamic)
+latest_fsio_writes      = STRING                    ; Describes the latest number of filesystem writes completed successfully                          (Dynamic)
+disk_io_reads           = STRING                    ; Describes the total number of reads completed successfully from the SSD (Bytes)                  (Dynamic)
+disk_io_writes          = STRING                    ; Describes the total number of writes completed on the SSD (Bytes)                                (Dynamic)
+reserved_blocks         = STRING                    ; Describes the reserved blocks count of the SSD                                                   (Dynamic)
+firmware                = STRING                    ; Describes the Firmware version of the SSD                                                        (Dynamic)
+health                  = STRING                    ; Describes the overall health of the SSD as a % value based on several SMART attrs                (Dynamic)
+last_sync_time          = STRING                    ; The latest successful sync time (in UTC) of disk attribtes to STATE_DB (YYYY:MM:DD HH:MM:SS)     (Dynamic)
 ```
 
 NOTE: disk_io_reads and disk_io_writes return total LBAs read/written. 'LBA' stands for Logical Block Address. 
@@ -436,7 +436,7 @@ key                     = STORAGE_INFO|FSSTATS_SYNC  ; This key is for informati
 
 ; field                 = value
 
-successful_sync_time    = STRING                     ; The latest successful sync time of FSIO reads and writes to file ("YYYY:MM:DD HH:MM:SS" format)
+successful_sync_time    = STRING                     ; The latest successful sync time (in UTC) of FSIO reads and writes to file ("YYYY:MM:DD HH:MM:SS" format)
 
 ```
 

--- a/doc/storagemond/storagemond-hld.md
+++ b/doc/storagemond/storagemond-hld.md
@@ -3,7 +3,8 @@
 
  | Rev |     Date    |       Author       | Change Description                |
  |:---:|:-----------:|:------------------:|-----------------------------------|
- | 0.1 |             |      Ashwin Srinivasan  | Initial version                   |
+ | 0.1 |             |      Ashwin Srinivasan  | Initial version              |
+ | 0.2 |  2024-23-08 |      Ashwin Srinivasan  | STORAGE_INFO schema change   |
 
 ## 1. Overview
 
@@ -382,6 +383,7 @@ disk_io_writes          = STRING                    ; Describes the total number
 reserved_blocks         = STRING                    ; Describes the reserved blocks count of the SSD                                         (Dynamic)
 firmware                = STRING                    ; Describes the Firmware version of the SSD                                              (Dynamic)
 health                  = STRING                    ; Describes the overall health of the SSD as a % value based on several SMART attrs      (Dynamic)
+last_sync_time          = STRING                    ; The latest successful sync time of disk attribtes to STATE_DB in UNIX timestamp format (Dynamic)
 ```
 
 NOTE: disk_io_reads and disk_io_writes return total LBAs read/written. 'LBA' stands for Logical Block Address. 

--- a/doc/storagemond/storagemond-hld.md
+++ b/doc/storagemond/storagemond-hld.md
@@ -383,7 +383,7 @@ disk_io_writes          = STRING                    ; Describes the total number
 reserved_blocks         = STRING                    ; Describes the reserved blocks count of the SSD                                         (Dynamic)
 firmware                = STRING                    ; Describes the Firmware version of the SSD                                              (Dynamic)
 health                  = STRING                    ; Describes the overall health of the SSD as a % value based on several SMART attrs      (Dynamic)
-last_sync_time          = STRING                    ; The latest successful sync time of disk attribtes to STATE_DB in UNIX timestamp format (Dynamic)
+last_sync_time          = STRING                    ; The latest successful sync time of disk attribtes to STATE_DB (MM:DD:YYYY format)      (Dynamic)
 ```
 
 NOTE: disk_io_reads and disk_io_writes return total LBAs read/written. 'LBA' stands for Logical Block Address. 

--- a/doc/storagemond/storagemond-hld.md
+++ b/doc/storagemond/storagemond-hld.md
@@ -383,7 +383,7 @@ disk_io_writes          = STRING                    ; Describes the total number
 reserved_blocks         = STRING                    ; Describes the reserved blocks count of the SSD                                         (Dynamic)
 firmware                = STRING                    ; Describes the Firmware version of the SSD                                              (Dynamic)
 health                  = STRING                    ; Describes the overall health of the SSD as a % value based on several SMART attrs      (Dynamic)
-last_sync_time          = STRING                    ; The latest successful sync time of disk attribtes to STATE_DB (MM:DD:YYYY format)      (Dynamic)
+last_sync_time          = STRING                    ; The latest successful sync time of disk attribtes to STATE_DB (YYYY:MM:DD HH:MM:SS)    (Dynamic)
 ```
 
 NOTE: disk_io_reads and disk_io_writes return total LBAs read/written. 'LBA' stands for Logical Block Address. 
@@ -422,7 +422,8 @@ admin@str2-dx010-acs-7:~$ redis-cli -n 6
 22) "863702"
 23) "reserved_blocks"
 24) "135"
-
+25) "last_sync_time"
+26) "2024-10-02 23:49:41"
 
 
 ```
@@ -431,11 +432,11 @@ admin@str2-dx010-acs-7:~$ redis-cli -n 6
 ```
 ; Defines information for FS Stats synchronization
 
-key                     = STORAGE_INFO|FSSTATS_SYNC     ; This key is for information pertaining to synchronization of FSIO Reads/Writes
+key                     = STORAGE_INFO|FSSTATS_SYNC  ; This key is for information pertaining to synchronization of FSIO Reads/Writes
 
 ; field                 = value
 
-successful_sync_time    = STRING                        ; The latest successful sync time of FSIO reads and writes to file in UNIX timestamp format
+successful_sync_time    = STRING                     ; The latest successful sync time of FSIO reads and writes to file ("YYYY:MM:DD HH:MM:SS" format)
 
 ```
 


### PR DESCRIPTION
**What I did:**

This change adds a new field `last_sync_time` per storage device to `STORAGE_INFO|<storage_device_name>`
in `STATE_DB`. More context about the schema is [here](https://github.com/sonic-net/SONiC/blob/master/doc/storagemond/storagemond-hld.md#31-storage-info-state_db-schema).

**Why I did it**

This would provide additional context in case of repeated daemon crash scenario which leads to storagemon daemon status =  
`FATAL     Exited too quickly (process log may have details).`

**Signed-off-by:** 
Ashwin Srinivasan [assrinivasan@microsoft.com](mailto:assrinivasan@microsoft.com)