### PR TITLE
Updated YANG guidelines to use sonic-net instead of Azure in namespace

### DIFF
--- a/doc/mgmt/SONiC_YANG_Model_Guidelines.md
+++ b/doc/mgmt/SONiC_YANG_Model_Guidelines.md
@@ -54,13 +54,13 @@ module sonic-acl {
 }
 ```
 
-### 3. Define namespace as "http://github.com/Azure/{model-name}".
+### 3. Define namespace as "http://github.com/sonic-net/{model-name}".
 
 Example :
 ####  YANG
 ```yang
 module sonic-acl {
-	namespace "http://github.com/Azure/sonic-acl";
+	namespace "http://github.com/sonic-net/sonic-acl";
 	.....
 	.....
 }
@@ -783,7 +783,7 @@ module sonic-port {
 
 ```yang
 module sonic-acl {
-	namespace "http://github.com/Azure/sonic-acl";
+	namespace "http://github.com/sonic-net/sonic-acl";
 	prefix sacl;
 	yang-version 1.1;
 


### PR DESCRIPTION
I was adding a yang model and noticed that we now use "sonic-net" instead of "Azure" in the namespace field of a yang model. However, this conflicted with the guidelines posted in the documentation. This PR aims to make the doc consistent with the conventions in place.