### PR TITLE
[wol HLD] Extend wol to support sending magic pattern in udp payload

### DIFF
--- a/doc/wol/Wake-on-LAN-HLD.md
+++ b/doc/wol/Wake-on-LAN-HLD.md
@@ -83,7 +83,7 @@ packet-beta
 6-11: "Source MAC"
 12-13: "Ethertype"
 14-19: "Repetitions of 0xff"
-20-115: "Repetitions of target MAC(16 bytes in total)"
+20-115: "Repetitions of target MAC(16 times in total)"
 116-121: "Password(0, 4 or 6 bytes)"
 ```
 
@@ -109,7 +109,7 @@ packet-beta
 4-5: "Length"
 6-7: "Checksum"
 8-13: "Repetitions of 0xff"
-14-109: "Repetitions of target MAC(16 bytes in total)"
+14-109: "Repetitions of target MAC(16 times in total)"
 110-115: "Password(0, 4 or 6 bytes)"
 ```
 

--- a/doc/wol/Wake-on-LAN-HLD.md
+++ b/doc/wol/Wake-on-LAN-HLD.md
@@ -104,17 +104,17 @@ Offset   |0     |1     |2     |3     |4     |5     |
   * Sixteen repetitions of the target device's MAC address. [96 bytes]
   * (Optional) A four or six byte password. [4 or 6 bytes]
 
-```
-Packet in bytes:
-0 ~ X: Ethernet Header
-...
-(IPv4:Y ~ Y+31)/(IPv6:Z ~ Z+127): Destination IP address
-...
-J ~ J+1: UDP Destination Port
-...
-K ~ K+5: Six repetitions of `0xff`
-K+6 ~ K+101: Sixteen repetitions of the target device's MAC address.
-[Optional, K+102 ~ END: A four or six byte password.]
+```mermaid
+---
+title: UDP packet in bits
+---
+packet-beta
+0-15: "Source Port"
+16-31: "Destination Port"
+32-63: "Length and Checksum"
+64-69: "Six repetitions of `0xff`"
+70-165: "Sixteen repetitions of the target device's MAC address"
+166-171: "Password (optional, 0, 4 or 6 bytes.)"
 ```
 
 ## CLI Design

--- a/doc/wol/Wake-on-LAN-HLD.md
+++ b/doc/wol/Wake-on-LAN-HLD.md
@@ -112,9 +112,9 @@ packet-beta
 0-15: "Source Port"
 16-31: "Destination Port"
 32-63: "Length and Checksum"
-64-69: "Six repetitions of `0xff`"
-70-165: "Sixteen repetitions of the target device's MAC address"
-166-171: "Password (optional, 0, 4 or 6 bytes.)"
+64-111: "Repetitions of 1"
+112-879: "Sixteen repetitions of target MAC"
+880-927: "Password (optional 0, 4 or 6 bytes)"
 ```
 
 ## CLI Design

--- a/doc/wol/Wake-on-LAN-HLD.md
+++ b/doc/wol/Wake-on-LAN-HLD.md
@@ -96,9 +96,9 @@ Offset   |0     |1     |2     |3     |4     |5     |
 **Magic Packet** is a Ethernet frame with structure:
 
 * **IP Header**:
-  * **Destination IP**: user provided target IP address, cloud be IPv4 address or IPv6 address, default is `255.255.255.255`.
+  * **Destination IP**: User provided target IP address, cloud be IPv4 address or IPv6 address.
 * **UDP Header**:
-  * **Destination Port**: user provided target port, default is 9.
+  * **Destination Port**: User provided target port.
 * **UDP Payload**:
   * Six bytes of all `0xff`. [6 bytes]
   * Sixteen repetitions of the target device's MAC address. [96 bytes]
@@ -138,10 +138,10 @@ wol <interface> <target_mac> [-b] [-u] [-a ip-address] [-t udp-port] [-p passwor
 
 - `interface`: SONiC interface name.
 - `target_mac`: a list of target devices' MAC address, separated by comma.
-- `-b`: Use broadcast MAC address instead of target device's MAC address as **Destination MAC Address in Ethernet Frame Header**.
-- `-u`: Let device send magic pattern in udp payload, when this flag was used, -b won't work and destination mac is set by device's networking stack.
-- `-a ip-address`: This parameter only work when -u flag was used. Let device send packet to the ip address, this ip address cloud IPv4 address or IPv6 address.
-- `-t udp-port`: This parameter only work when -u flag was used. Let device send packet to the udp port.
+- `-b`: Use broadcast MAC address instead of target device's MAC address as **Destination MAC Address in Ethernet Frame Header**. This parameter can't use with `-u`.
+- `-u`: Let device send magic pattern in udp payload, when this flag was used, -b won't work and destination mac is set by device's networking stack. This parameter can't use with `-b`.
+- `-a ip-address`: This parameter only work when -u flag was used. Let device send packet to the ip address, this ip address cloud IPv4 address or IPv6 address. Default value is `255.255.255.255`.
+- `-t udp-port`: This parameter only work when -u flag was used. Let device send packet to the udp port. Default value is 9.
 - `-p password`: An optional 4 or 6 byte password, in ethernet hex format or quad-dotted decimal[^3].
 - `-c count`: For each target MAC address, the `count` of magic packets to send. `count` must between 1 and 5. Default value is 1. This param must use with `-i`.
 - `-i interval`: Wait `interval` milliseconds between sending each magic packet. `interval` must between 0 and 2000. Default value is 0. This param must use with `-c`.
@@ -153,7 +153,7 @@ admin@sonic:~$ wol Ethernet10 00:11:22:33:44:55
 admin@sonic:~$ wol Ethernet10 00:11:22:33:44:55 -b
 admin@sonic:~$ wol Vlan1000 00:11:22:33:44:55,11:33:55:77:99:bb -p 00:22:44:66:88:aa
 admin@sonic:~$ wol Vlan1000 00:11:22:33:44:55,11:33:55:77:99:bb -p 192.168.1.1 -c 3 -i 2000
-admin@sonic:~$ wol Vlan1000 00:11:22:33:44:55,11:33:55:77:99:bb -u
+admin@sonic:~$ wol Ethernet10 00:11:22:33:44:55,11:33:55:77:99:bb -u
 admin@sonic:~$ wol Vlan1000 00:11:22:33:44:55,11:33:55:77:99:bb -u -c 3 -i 2000
 admin@sonic:~$ wol Vlan1000 00:11:22:33:44:55,11:33:55:77:99:bb -u -a 192.168.255.255
 admin@sonic:~$ wol Vlan1000 00:11:22:33:44:55,11:33:55:77:99:bb -u -a 192.168.255.255 -t 7
@@ -161,7 +161,7 @@ admin@sonic:~$ wol Vlan1000 00:11:22:33:44:55,11:33:55:77:99:bb -u -a 192.168.25
 
 For the 4th example, it specifise 2 target MAC addresses and `count` is 3. So it'll send 6 magic packets in total.
 
-## gNOI Design ( gNOI only support magic pattern in ethernet payload. )
+## gNOI Design
 
 The gNOI service `SONiCWolService` will provide a `Wol` interface to user, which can be called to send magic packet to target device:
 

--- a/doc/wol/Wake-on-LAN-HLD.md
+++ b/doc/wol/Wake-on-LAN-HLD.md
@@ -106,15 +106,17 @@ Offset   |0     |1     |2     |3     |4     |5     |
 
 ```mermaid
 ---
-title: UDP packet in bits
+config:
+    bitsPerRow: 64
+title: UDP packet in bytes
 ---
 packet-beta
-0-15: "Source Port"
-16-31: "Destination Port"
-32-63: "Length and Checksum"
-64-111: "Repetitions of 1"
-112-879: "Sixteen repetitions of target MAC"
-880-927: "Password (optional 0, 4 or 6 bytes)"
+0-1: "Src Port"
+2-3: "Dst Port"
+4-7: "Length and Checksum"
+8-13: "Repetitions of 0xff"
+14-109: "Repetitions of target MAC"
+110-115: "Password(0, 4 or 6 bytes)"
 ```
 
 ## CLI Design

--- a/doc/wol/Wake-on-LAN-HLD.md
+++ b/doc/wol/Wake-on-LAN-HLD.md
@@ -16,6 +16,7 @@
 | Revision | Date       | Author     | Change Description |
 | -------- | ---------- | ---------- | ------------------ |
 | 1.0      | Nov 7 2023 | Zhijian Li | Initial proposal   |
+| 1.1      | Oct 11 2024 | Wenda Chu | extend wol by udp packet|
 
 ## Definitions/Abbreviations 
 
@@ -59,6 +60,9 @@ A new gNOI service `SONiCWolService` will be implemented in sonic-gnmi container
 
 ## Magic Packet
 
+Although the magic pattern is fixed which is a frame has 6 bytes of 0xFF, 16 repetitions of target mac and optional password bytes, we provide two flavours for uses, one is magic pattern in ethernet payload, another is magic pattern in UDP payload.
+
+### Magic Pattern in Ethernet Payload
 **Magic Packet** is a Ethernet frame with structure:
 
 * **Ethernet Frame Header**:
@@ -88,6 +92,40 @@ Offset   |0     |1     |2     |3     |4     |5     |
          +-----------------------------------------+
 ```
 
+### Magic Pattern in UDP Payload
+**Magic Packet** is a Ethernet frame with structure:
+
+* **IP Header**:
+  * **Destination IP**: user provided target IP address, cloud be IPv4 address or IPv6 address, default is `255.255.255.255`.
+* **UDP Header**:
+  * **Destination Port**: user provided target port, default is 9.
+* **UDP Payload**:
+  * Six bytes of all `0xff`. [6 bytes]
+  * Sixteen repetitions of the target device's MAC address. [96 bytes]
+  * (Optional) A four or six byte password. [4 or 6 bytes]
+
+```
+Byte     |
+Offset   |0     |1     |2     |3     |4     |5     |
+---------+------+------+------+------+------+------+
+           \      \      \      \      \      \     
+         +------+------+------+------+------+------+
+         |.. Destination IP(4 bytes or 16 bytes) ..|
+         +------+------+------+------+------+------+      
+           \      \      \      \      \      \      
+         +------+------+---------------------------+
+         |  ... Destination Port(2 bytes) ...      |   
+         +------+------+---------------------------+
+           \      \      \      \      \      \      
+         +------+------+------+------+------+------+------------------------------
+       N | 0xFF | 0xFF | 0xFF | 0xFF | 0xFF | 0xFF |
+         +------+------+------+------+------+------+           UDP
+     N+6 | Target MAC (repeat 16 times, 96 bytes)  |           PAYLOAD
+         +-----------------------------------------+
+   N+102 |    Password (optional, 4 or 6 bytes)    |
+         +-----------------------------------------+
+```
+
 ## CLI Design
 
 The `wol` command is used to send magic packet to target device.
@@ -95,12 +133,15 @@ The `wol` command is used to send magic packet to target device.
 ### Usage
 
 ```
-wol <interface> <target_mac> [-b] [-p password] [-c count] [-i interval]
+wol <interface> <target_mac> [-b] [-u] [-a ip-address] [-t udp-port] [-p password] [-c count] [-i interval]
 ```
 
 - `interface`: SONiC interface name.
 - `target_mac`: a list of target devices' MAC address, separated by comma.
 - `-b`: Use broadcast MAC address instead of target device's MAC address as **Destination MAC Address in Ethernet Frame Header**.
+- `-u`: Let device send magic pattern in udp payload, when this flag was used, -b won't work and destination mac is set by device's networking stack.
+- `-a ip-address`: This parameter only work when -u flag was used. Let device send packet to the ip address, this ip address cloud IPv4 address or IPv6 address.
+- `-t udp-port`: This parameter only work when -u flag was used. Let device send packet to the udp port.
 - `-p password`: An optional 4 or 6 byte password, in ethernet hex format or quad-dotted decimal[^3].
 - `-c count`: For each target MAC address, the `count` of magic packets to send. `count` must between 1 and 5. Default value is 1. This param must use with `-i`.
 - `-i interval`: Wait `interval` milliseconds between sending each magic packet. `interval` must between 0 and 2000. Default value is 0. This param must use with `-c`.
@@ -112,11 +153,15 @@ admin@sonic:~$ wol Ethernet10 00:11:22:33:44:55
 admin@sonic:~$ wol Ethernet10 00:11:22:33:44:55 -b
 admin@sonic:~$ wol Vlan1000 00:11:22:33:44:55,11:33:55:77:99:bb -p 00:22:44:66:88:aa
 admin@sonic:~$ wol Vlan1000 00:11:22:33:44:55,11:33:55:77:99:bb -p 192.168.1.1 -c 3 -i 2000
+admin@sonic:~$ wol Vlan1000 00:11:22:33:44:55,11:33:55:77:99:bb -u
+admin@sonic:~$ wol Vlan1000 00:11:22:33:44:55,11:33:55:77:99:bb -u -c 3 -i 2000
+admin@sonic:~$ wol Vlan1000 00:11:22:33:44:55,11:33:55:77:99:bb -u -a 192.168.255.255
+admin@sonic:~$ wol Vlan1000 00:11:22:33:44:55,11:33:55:77:99:bb -u -a 192.168.255.255 -t 7
 ```
 
 For the 4th example, it specifise 2 target MAC addresses and `count` is 3. So it'll send 6 magic packets in total.
 
-## gNOI Design
+## gNOI Design ( gNOI only support magic pattern in ethernet payload. )
 
 The gNOI service `SONiCWolService` will provide a `Wol` interface to user, which can be called to send magic packet to target device:
 
@@ -161,6 +206,8 @@ message WolResponse {
 | Input valid `count` and `interval`. | Parameter validation pass, send magic packet |
 | Input value of `count` or `interval` is out of range. | Parameter validation Fail |
 | Param `count` and `interval` not appear in input together. | Parameter validation Fail |
+| Param `-b` and `-u` not appear in input together. | Parameter validation Fail |
+| Param `-u` is required when using `-a ip-address` or `-t udp-port`. | Parameter validation Fail |
 | Mock a send magic packet failure (e.g., socket error) | Return user friendly error message |
 
 ### Functional Test

--- a/doc/wol/Wake-on-LAN-HLD.md
+++ b/doc/wol/Wake-on-LAN-HLD.md
@@ -74,22 +74,17 @@ Although the magic pattern is fixed which is a frame has 6 bytes of 0xFF, 16 rep
   * Sixteen repetitions of the target device's MAC address. [96 bytes]
   * (Optional) A four or six byte password. [4 or 6 bytes]
 
-```
-Byte     |
-Offset   |0     |1     |2     |3     |4     |5     |
----------+------+------+------+------+------+------+
-       0 |             Destination MAC             |
-         +------+------+------+------+------+------+        ETHERNET FRAME
-       6 |               Source MAC                |           HEADER
-         +------+------+---------------------------+
-      12 | 0x08 | 0x42 |   \      \      \      \
-         +------+------+------+------+------+------+------------------------------
-      14 | 0xFF | 0xFF | 0xFF | 0xFF | 0xFF | 0xFF |
-         +------+------+------+------+------+------+        ETHERNET FRAME
-      20 | Target MAC (repeat 16 times, 96 bytes)  |           PAYLOAD
-         +-----------------------------------------+
-     116 |    Password (optional, 4 or 6 bytes)    |
-         +-----------------------------------------+
+```mermaid
+---
+title: Ethernet packet in bytes
+---
+packet-beta
+0-5: "Destination MAC"
+6-11: "Source MAC"
+12-13: "Ethertype"
+14-19: "Repetitions of 0xff"
+20-115: "Repetitions of target MAC(16 bytes in total)"
+116-121: "Password(0, 4 or 6 bytes)"
 ```
 
 ### Magic Pattern in UDP Payload
@@ -106,16 +101,15 @@ Offset   |0     |1     |2     |3     |4     |5     |
 
 ```mermaid
 ---
-config:
-    bitsPerRow: 64
 title: UDP packet in bytes
 ---
 packet-beta
 0-1: "Src Port"
 2-3: "Dst Port"
-4-7: "Length and Checksum"
+4-5: "Length"
+6-7: "Checksum"
 8-13: "Repetitions of 0xff"
-14-109: "Repetitions of target MAC"
+14-109: "Repetitions of target MAC(16 bytes in total)"
 110-115: "Password(0, 4 or 6 bytes)"
 ```
 


### PR DESCRIPTION
Although the magic pattern is fixed, we can send the magic pattern in UDP payload to leverage the benefits UDP.