### PR TITLE
Update sff_mgr HLD to include high power class enabling and lpmode off

### DIFF
--- a/doc/xrcvd/Interface-Link-bring-up-sequence-on-sff-modules.md
+++ b/doc/xrcvd/Interface-Link-bring-up-sequence-on-sff-modules.md
@@ -91,7 +91,7 @@ Refer to parent [HLD](https://github.com/sonic-net/SONiC/blob/master/doc/sfp-cmi
   Optics Interface Link bring-up sequence would be enabled on per platform basis.
   There could be cases where vendor(s)/platform(s) may take time to shift from existing codebase to the model (work-flows) described in this document.
 - sff_mgr thread is always spawned, handling lpmode and high power class setting. But by default, sff_mgr doesn't controll module Tx.
-- In order to enable sff_mgr's controlling for module Tx, the platform would set ‘enable_xcvrd_sff_mgr_controlled_tx’ to ‘true’ in their respective pmon_daemon_control.json. Xcvrd would parse ‘enable_sff_mgr_controlled_tx’ and if found 'true', it would launch SFF task manager (sff_mgr).
+- In order to enable sff_mgr's controlling for module Tx, the platform would set ‘enable_xcvrd_sff_mgr_controlled_tx’ to ‘true’ in their respective pmon_daemon_control.json. Xcvrd would parse ‘enable_xcvrd_sff_mgr_controlled_tx’ and if found 'true', it would launch SFF task manager (sff_mgr).
 
 # Pre-requisite
 

--- a/doc/xrcvd/Interface-Link-bring-up-sequence-on-sff-modules.md
+++ b/doc/xrcvd/Interface-Link-bring-up-sequence-on-sff-modules.md
@@ -71,7 +71,7 @@ According to parent [HLD](https://github.com/sonic-net/SONiC/blob/master/doc/sfp
 According to parent [HLD](https://github.com/sonic-net/SONiC/blob/master/doc/sfp-cmis/Interface-Link-bring-up-sequence.md#objective), have a determistic approach for Interface link bring-up sequence for SFF compliant modules (100G/40G) i.e. below sequence to be followed:
   1. Initialize and enable NPU Tx and Rx path
   2. For system with 'External' PHY: Initialize and enable PHY Tx and Rx on both line and host sides; ensure host side link is up
-  3. Enable high power class if module's power class is greater or equal to 5
+  3. Enable high power class if module's power class is greater or equal to 5 (Refer to SFF-8636 spec `6.2.6 Control Functions (Page 00h, Bytes 86-99)` for byte 93 definition)
   4. Turn off lpmode
   5. Then perform optics Tx enable
 


### PR DESCRIPTION
Update sff_mgr HLD to reflect the below changes:

https://github.com/sonic-net/sonic-platform-common/pull/521 add high power class enabling in platform common API
https://github.com/sonic-net/sonic-platform-daemons/pull/574 add high power class enabling in xcvrd/sff_mgr 
https://github.com/sonic-net/sonic-buildimage/pull/21176 rename sff_mgr flag
https://github.com/sonic-net/sonic-platform-daemons/pull/565 add lpmode off in xcvrd/sff_mgr