### PR TITLE
Update Vxlanid to Vni in VNET_ROUTE_TUNNEL Table

### DIFF
--- a/doc/vxlan/Vxlan_hld.md
+++ b/doc/vxlan/Vxlan_hld.md
@@ -232,7 +232,7 @@ VNET_ROUTE_TABLE:{{vnet_name}}:{{prefix}}
 VNET_ROUTE_TUNNEL_TABLE:{{vnet_name}}:{{prefix}} 
     "endpoint": {{ip_address}} 
     "mac_address":{{mac_address}} (OPTIONAL) 
-    "vxlanid": {{vni}}(OPTIONAL) 
+    "vni": {{vni}}(OPTIONAL) 
 ```
 
 ```
@@ -265,7 +265,7 @@ key                                   = VNET_ROUTE_TUNNEL_TABLE:vnet_name:prefix
 ; field                               = value
 ENDPOINT                              = ipv4                          ; Host VM IP address
 MAC_ADDRESS                           = 12HEXDIG                      ; Inner dest mac in encapsulated packet (Optional)
-VXLANID                               = DIGITS                        ; VNI value in encapsulated packet (Optional)
+VNI                                   = DIGITS                        ; VNI value in encapsulated packet (Optional)
 ```
 
 ```


### PR DESCRIPTION
Follow manager's [suggestion](https://github.com/sonic-net/sonic-swss/blob/master/orchagent/vnetorch.cpp#L2733) mentioned during the [VNET_ROUTE_TUNNEL PR](https://github.com/sonic-net/sonic-buildimage/pull/21939) review.

See original comment: https://github.com/sonic-net/sonic-buildimage/pull/21939#discussion_r1988000862