### PR TITLE
Update CMIS diagnostics monitoring HLD with TRANSCEIVER_STATUS_SW table + link event handling changes

### DIFF
--- a/doc/platform_api/CMIS_Diagnostic_Monitoring_Overview_in_SONiC.md
+++ b/doc/platform_api/CMIS_Diagnostic_Monitoring_Overview_in_SONiC.md
@@ -1462,7 +1462,9 @@ lane_num: Represents lane number of the field. The lane number is an integer val
     rxsigpower{lane_num}                                    = STR; rx signal power in dbm (low warning last clear time)
 ```
 
-### 3.3 Transceiver status data
+### 3.3 Transceiver status data (Hardware)
+
+This section describes the tables used to store data primarily retrieved from the transceiver hardware.
 
 #### 3.3.1 Transceiver status data to store module and data path status
 
@@ -1476,9 +1478,6 @@ lane_num: Represents lane number of the field. The lane number is an integer val
     ; field                                 = value
     last_update_time                        = STR               ; last update time for diagnostic data
     diagnostics_update_interval             = INTEGER           ; DOM thread update interval in seconds
-    cmis_state                              = 1*255VCHAR        ; Software CMIS state of the module
-    status                                  = 1*255VCHAR        ; code of the module status (plug in, plug out)
-    error                                   = 1*255VCHAR        ; module error (N/A or a string consisting of error descriptions joined by "|", like "error1 | error2" )
     tx{lane_num}disable                     = BOOLEAN           ; TX disable state on media lane {lane_num}
     tx_disabled_channel                     = INTEGER           ; TX disable field
     module_state                            = 1*255VCHAR        ; current module state (ModuleLowPwr, ModulePwrUp, ModuleReady, ModulePwrDn, Fault)
@@ -1608,7 +1607,26 @@ lane_num: Represents lane number of the field. The lane number is an integer val
     tuning_complete                   = STR           ; tuning complete flag clear time
 ```
 
-### 3.4 Transceiver PM data
+### 3.4 Transceiver Status Data (Software)
+
+#### 3.4.1 Transceiver Status Data Maintained by the `xcvrd` Daemon
+
+The `TRANSCEIVER_STATUS_SW` table stores the status of the transceiver as maintained by the `xcvrd` daemon.
+
+Unlike other tables in the HLD, which are controlled by a single thread, the `TRANSCEIVER_STATUS_SW` table is controlled by multiple threads (`SfpStateUpdateTask` and `CmisManagerTask`). Adding a `last_update_time` field to this table could cause concurrency issues since multiple threads update the same field. To avoid this, the `last_update_time` field is not included in the `TRANSCEIVER_STATUS_SW` table.
+
+Additionally, this table exists for all subports of a port breakout group, unlike other tables which exist only for the first subport of a port breakout group.
+
+```plaintext
+    ; Defines Transceiver Status info for a port
+    key                                     = TRANSCEIVER_STATUS_SW|ifname; 
+    ; field                                 = value
+    cmis_state                              = 1*255VCHAR        ; Software CMIS state of the module
+    status                                  = 1*255VCHAR        ; code of the module status (plug in, plug out)
+    error                                   = 1*255VCHAR        ; module error (N/A or a string consisting of error descriptions joined by "|", like "error1 | error2" )
+```
+
+### 3.5 Transceiver PM data
 
 The `TRANSCEIVER_PM` table stores the performance monitoring data of the transceiver. This table is exists only for C-CMIS transceivers.
 

--- a/doc/platform_api/CMIS_Diagnostic_Monitoring_Overview_in_SONiC.md
+++ b/doc/platform_api/CMIS_Diagnostic_Monitoring_Overview_in_SONiC.md
@@ -2413,12 +2413,12 @@ The transceiver status flags, change count, and their set/clear time for the fol
 - `datapath_firmware_fault`
 - `module_firmware_fault`
 - `module_state_changed`
-- `txfault{lane_num}`
-- `rxlos{lane_num}`
-- `txlos_hostlane{lane_num}`
-- `txcdrlol_hostlane{lane_num}`
-- `tx_eq_fault{lane_num}`
-- `rxcdrlol{lane_num}`
+- `tx{lane_num}fault`
+- `rx{lane_num}los`
+- `tx{lane_num}los_hostlane`
+- `tx{lane_num}cdrlol_hostlane`
+- `tx{lane_num}_eq_fault`
+- `rx{lane_num}cdrlol`
 
 **Example:**
 


### PR DESCRIPTION
Created `TRANSCEIVER_STATUS_SW` table to store information for the following fields (these fields are being moved from `TRANSCEIVER_STATUS` table since these fields are required to be stored for every logical port unlike other diagnostic tables which are required only for the primary subport for a breakout port group)

    - cmis_state
    - status
    - error

Also, link event handling related changes were added to the HLD

MSFT ADO - 32312479