### PR TITLE
[PDDF] HLD Add multifpgapci module

### DIFF
--- a/doc/platform/brcm_pdk_pddf.md
+++ b/doc/platform/brcm_pdk_pddf.md
@@ -1309,17 +1309,17 @@ See [3.4.13.1.1 Base FPGA Module Sysfs Controls](#341311-base-fpga-module-sysfs-
 
 Description of the fields inside *dev_info*
 
-> **device_type**: Must be set to `MULTIFPGAPCIESYSTEM`
+> **device_type**: Must be set to `MULTIFPGAPCIESYSTEM`.
 
-> **device_name**: Must be set to `MULTIFPGAPCIESYSTEM0`
+> **device_name**: Must be set to `MULTIFPGAPCIESYSTEM0`.
 
-> **device_parent**: Must be set to `null`
+> **device_parent**: Must be set to `null`.
 
 Description of the fields within elements inside *PCI_VENDOR_IDS*
 
-> **vendor**: 16 bit hexadecimal which matches the FPGA's PCIe Vendor ID
+> **vendor**: 16 bit hexadecimal which matches the FPGA's PCIe Vendor ID.
 
-> **device**: 16 bit hexadecimal which matches the FPGA's PCIe Device ID
+> **device**: 16 bit hexadecimal which matches the FPGA's PCIe Device ID.
 
 ##### 3.4.12.3 Multi-FPGAPCIe (per FPGA) JSON Design
 
@@ -1354,9 +1354,9 @@ See [3.4.13.1.2 I2C Module Sysfs Controls (Per-FPGA)](#341312-i2c-module-sysfs-c
 
 Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#34121-fpgapcie-json-design) for description of i2c related fields.
 
-> **device_type**: Must be set to `MULTIFPGAPCIE`
+> **device_type**: Must be set to `MULTIFPGAPCIE`.
 
-> **device_name**: Each FPGA must have a unique `device_name`
+> **device_name**: Each FPGA must have a unique `device_name`.
 
 > **device_bdf**: The FPGA's address in BDF (Domain:Bus:Device.Function) format.
 
@@ -1394,7 +1394,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
       ...
 ```
 
-> **dev_type**: Must be set to `multifpgapci_mux`
+> **dev_type**: Must be set to `multifpgapci_mux`.
 
 > **cpld_name**:  Must match the `device_name` of the FPGA which controls the mux channel selection.
 
@@ -1424,7 +1424,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
       ...
 ```
 
-> **attr_devtype**: Must be set to `multifpgapci`
+> **attr_devtype**: Must be set to `multifpgapci`.
 
 > **attr_devnam**: Must match the `device_name` of the FPGA which controls the LED's color.
 
@@ -1458,7 +1458,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
       ...
 ```
 
-> **attr_devtype**: Must be set to `multifpgapci`
+> **attr_devtype**: Must be set to `multifpgapci`.
 
 > **attr_devnam**: Must match the `device_name` of the FPGA which controls the xcvr.
 
@@ -1491,7 +1491,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
       ...
 ```
 
-> **attr_devtype**: Must be set to `multifpgapci`
+> **attr_devtype**: Must be set to `multifpgapci`.
 
 > **attr_devnam**: Must match the `device_name` of the FPGA which reads the PSU's status.
 
@@ -1527,7 +1527,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
       ...
 ```
 
-> **attr_devtype**: Must be set to `multifpgapci`
+> **attr_devtype**: Must be set to `multifpgapci`.
 
 > **attr_devnam**: Must match the `device_name` of the FPGA which controls the fan.
 

--- a/doc/platform/brcm_pdk_pddf.md
+++ b/doc/platform/brcm_pdk_pddf.md
@@ -1142,7 +1142,7 @@ Description of the fields inside *dev_attr*
 
 #### 3.4.13 Multi-FPGAPCIe Component
 
-This can be a drop in replacement for [FPGAPCIe Component](#3412-pfgapcie-component). Multi-FPGAPCIe supports systems containing one or more PCIe FPGAs, where as [FPGAPCIe Component](#3412-pfgapcie-component) supported systems with a single PCIe FPGA only. With Multi-FPGAPCIe, each FPGA can be uniquely identified by its `BDF` in `Domain:Bus:Device.Function` format. For components (e.g LED, PSU, XCVR) managed by the Multi-FPGAPCIe system, `attr_devtype` must be set to `multifpgapci`, and `attr_bdf` must be set to the `BDF` of the associated FPGA.
+This can be a drop in replacement for [FPGAPCIe Component](#3412-pfgapcie-component). Multi-FPGAPCIe supports systems containing one or more PCIe FPGAs, where as [FPGAPCIe Component](#3412-pfgapcie-component) supported systems with a single PCIe FPGA only. With Multi-FPGAPCIe, each FPGA can be uniquely identified by its `BDF` in `Domain:Bus:Device.Function` format. For components (e.g LED, PSU, XCVR) managed by the Multi-FPGAPCIe system, `attr_devtype` must be set to `multifpgapci`, and `attr_devname` must match the `device_name` of the associated FPGA.
 
 Multi-FPGAPCIe support the following PDDF components:
  - CPLDMUX
@@ -1426,7 +1426,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
 
 > **attr_devtype**: Must be set to `multifpgapci`.
 
-> **attr_devnam**: Must match the `device_name` of the FPGA which controls the LED's color.
+> **attr_devname**: Must match the `device_name` of the FPGA which controls the LED's color.
 
 ###### Multi-FPGAPCIe XCVR JSON
 
@@ -1460,7 +1460,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
 
 > **attr_devtype**: Must be set to `multifpgapci`.
 
-> **attr_devnam**: Must match the `device_name` of the FPGA which controls the xcvr.
+> **attr_devname**: Must match the `device_name` of the FPGA which controls the xcvr.
 
 ###### Multi-FPGAPCIe PSU JSON
 
@@ -1493,7 +1493,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
 
 > **attr_devtype**: Must be set to `multifpgapci`.
 
-> **attr_devnam**: Must match the `device_name` of the FPGA which reads the PSU's status.
+> **attr_devname**: Must match the `device_name` of the FPGA which reads the PSU's status.
 
 ###### Multi-FPGAPCIe PSU JSON
 
@@ -1529,7 +1529,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
 
 > **attr_devtype**: Must be set to `multifpgapci`.
 
-> **attr_devnam**: Must match the `device_name` of the FPGA which controls the fan.
+> **attr_devname**: Must match the `device_name` of the FPGA which controls the fan.
 
 ### 3.6 PDDF BMC Component Design
 

--- a/doc/platform/brcm_pdk_pddf.md
+++ b/doc/platform/brcm_pdk_pddf.md
@@ -1172,6 +1172,7 @@ $ tree --filesfirst /sys/kernel/pddf/devices/multifpgapci
 │       ├── ch_size
 │       ├── del_i2c_adapter
 │       ├── new_i2c_adapter
+│       ├── num_virt_ch
 │       └── virt_bus
 └── 0000:04:00.0
     ├── dev_ops
@@ -1180,6 +1181,7 @@ $ tree --filesfirst /sys/kernel/pddf/devices/multifpgapci
         ├── ch_size
         ├── del_i2c_adapter
         ├── new_i2c_adapter
+        ├── num_virt_ch
         └── virt_bus
 ```
 This structure shows:
@@ -1248,7 +1250,15 @@ echo '0x200' > /sys/kernel/pddf/devices/multifpgapci/0000:04:00.0/i2c/ch_base_of
 echo '0x200' > /sys/kernel/pddf/devices/multifpgapci/0000:04:00.0/i2c/ch_size
 ```
 
-4.  **`new_i2c_adapter` (Write-only)**:
+4.  **`num_virt_ch`**:
+    * **Purpose**: Specifies the number of I2C buses controlled by this FPGA.
+    * **Usage**: Write a hexadecimal value.
+    * **Example**:
+```bash
+echo '0x8' > /sys/kernel/pddf/devices/multifpgapci/0000:04:00.0/i2c/num_virt_ch
+```
+
+5.  **`new_i2c_adapter` (Write-only)**:
     * **Purpose**: Creates a new I2C bus adapter managed by the FPGA's I2C IP.
     * **Usage**: Write a decimal `$INDEX` value. The new I2C bus will be numbered `virt_bus + $INDEX`. Its control block will be located at `ch_base_offset + $INDEX * ch_size`.
     * **Result**: A new I2C bus entry (e.g. `i2c-19`, `i2c-20`, etc.) will appear under `/sys/bus/i2c/devices/`, and I2C client devices can then be instantiated on this bus.
@@ -1259,7 +1269,7 @@ echo 1 > /sys/kernel/pddf/devices/multifpgapci/0000:04:00.0/i2c/new_i2c_adapter
 # ... and so on for all desired channels
 ```
 
-5.  **`del_i2c_adapter` (Write-only)**:
+6.  **`del_i2c_adapter` (Write-only)**:
     * **Purpose**: Deletes an existing I2C bus adapter previously created by this FPGA.
     * **Usage**: Write the `$INDEX` of the I2C adapter to be removed.
     * **Example**:

--- a/doc/platform/brcm_pdk_pddf.md
+++ b/doc/platform/brcm_pdk_pddf.md
@@ -39,6 +39,7 @@
 		 * [Optics Component](#optics-component)
 		 * [lm-sensors](#lm-sensors-tools)
 	     * [FPGAPCIe Component](#pddf-fpgapcie-component)
+		 * [Multi-FPGAPCIe Component](#3413-multi-fpgapcie-component)
 	 * [PDDF BMC Component Design](#pddf-bmc-component-design)
 		 * [PSU JSON](#psu-json)
 		 * [FAN JSON](#fan-json)
@@ -77,6 +78,7 @@
 | 0.6 | 10/01/2020  |  Fuzail Khan, Precy Lee     | FPGAI2C component support         |
 | 0.7 | 01/05/2023  |  Fuzail Khan, Precy Lee     | FPGAPCIe component support        |
 | 0.8 | 03/17/2023  |  Fuzail Khan, Precy Lee     | S3IP SysFS support        |
+| 0.9 | 05/31/2025  |  Nexthop AI                 | Multi-FPGAPCIe component support  |
 
 # About this Manual
 Platform Driver Development Framework (PDDF) is part of SONiC Platform Development Kit (PDK), which enables rapid development of platform drivers and APIs for SONiC platforms. PDK consists of
@@ -736,13 +738,13 @@ Description of the objects inside *attr_list* which are very specific to Fan com
 
 
 #### 3.4.5 LED Component
-Network switches have a variety of LED lights, system LEDs, Fan Tray LEDs, and port LEDs, used to act as indicators of switch status and network port status.  The system LEDs are used to indicate the status of power and the system. The fan tray LEDs indicate each fan-tray status. The port LEDs are used to indicate the state of the links such as link up, Tx/RX activity and speed. The Port LEDs are in general managed by the LED controller provided by switch vendors. The scope of this LED section is for system LEDs and fan-tray LED.
+Network switches have a variety of LED lights, system LEDs, Fan Tray LEDs, and port LEDs, used to act as indicators of switch status and network port status.  The system LEDs are used to indicate the status of power and the system. The fan tray LEDs indicate each fan-tray status. The port LEDs are used to indicate the state of the links such as link up, Tx/RX activity and speed. The Port LEDs may be managed by the LED controller provided by switch vendors or PDDF. The scope of this LED section is for system LEDs and fan-tray LED.
 
 ##### 3.4.5.1 LED Driver Design
 LEDs are controlled via CPLDs. LEDs status can be read and set via I2C interfaces. A platform-independent driver is designed to access CPLDs via I2c interfaces. CPLD/register address data is stored in platform-specific JSON file. User python platform APIs trigger drivers to read/write LED statuses via SysFS. This generic LED driver is implemented to control System LED and Fan Tray LED.
 
 ##### 3.4.5.2 JSON Design
-   This section provides examples of configuring platform, System LED and Fantray LED.  They consist of key/value pairs. Each pair has a unique name. The table describes the naming convention for each unique key.
+   This section provides examples of configuring platform, System LED, Fantray LED, and Port LED.  They consist of key/value pairs. Each pair has a unique name. The table describes the naming convention for each unique key.
 
 
 | **Key**                  | **Description**                         |
@@ -754,6 +756,7 @@ LEDs are controlled via CPLDs. LEDs status can be read and set via I2C interface
 | FAN_LED                  | Fan Status LED for all fans |
 | DIAG_LED                 | System self-diagnostic test status LED |
 | FANTRAY\<x\>_LED         | Status LED for individual fan. X is an integer starting with 1 Example: FANTRAY1_LED, FANTRAY2_LED |
+| PORT_LED_\<x\>           | Status LED for a front panel port. X is an integer starting with 1 Example: PORT_LED_1, PORT_LED_2 |
 
 Samples:
 
@@ -1137,6 +1140,399 @@ Description of the fields inside *dev_attr*
 
 > **virt_i2c_ch**: The total numbers of logical I2C channels
 
+#### 3.4.13 Multi-FPGAPCIe Component
+
+This can be a drop in replacement for [FPGAPCIe Component](#3412-pfgapcie-component). Multi-FPGAPCIe supports systems containing one or more PCIe FPGAs, where as [FPGAPCIe Component](#3412-pfgapcie-component) supported systems with a single PCIe FPGA only. With Multi-FPGAPCIe, each FPGA can be uniquely identified by its `BDF` in `Domain:Bus:Device.Function` format. For components (e.g LED, PSU, XCVR) managed by the Multi-FPGAPCIe system, `attr_devtype` must be set to `multifpgapci`, and `attr_bdf` must be set to the `BDF` of the associated FPGA.
+
+Multi-FPGAPCIe support the following PDDF components:
+ - CPLDMUX
+ - LED
+ - XCVR
+ - PSU
+ - FAN
+
+Multi-FPGAPCIe supports the following IP blocks:
+ - I2C (Assumes Xilinx I2C, like [FPGAPCIe Component](#3412-pfgapcie-component))
+ - GPIO (TODO)
+ - SPI (TODO)
+
+##### 3.4.13.1 Multi-FPGAPCIe Sysfs Design
+
+Here is an example sysfs PDDF multifpgapcie hierarchy with two FPGAs as seen on the NH-4010.
+
+```
+$ tree --filesfirst /sys/kernel/pddf/devices/multifpgapci
+/sys/kernel/pddf/devices/multifpgapci
+├── dev_ops
+├── register_pci_device_id
+├── 0000:03:00.0
+│   ├── dev_ops
+│   └── i2c
+│       ├── ch_base_offset
+│       ├── ch_size
+│       ├── del_i2c_adapter
+│       ├── new_i2c_adapter
+│       └── virt_bus
+└── 0000:04:00.0
+    ├── dev_ops
+    └── i2c
+        ├── ch_base_offset
+        ├── ch_size
+        ├── del_i2c_adapter
+        ├── new_i2c_adapter
+        └── virt_bus
+```
+This structure shows:
+* A top-level directory `/sys/kernel/pddf/devices/multifpgapci`.
+* Directories for each discovered FPGA, named by its PCI BDF (e.g., `0000:03:00.0`, `0000:04:00.0`).
+* Control files for the base FPGA module and individual FPGA instances.
+* An `i2c` subdirectory for each FPGA, containing controls for its I2C master capabilities.
+
+#### 3.4.13.1.1 Base FPGA Module Sysfs Controls
+
+These controls manage the discovery and initial setup of the PCIe FPGAs.
+
+1.  **`register_pci_device_id` (Write-only)**:
+    * **Purpose**: Informs the `multifpgapci` driver about which PCI devices to bind to.
+    * **Usage**: Write the Vendor ID and Device ID, separated by a space, to this file. This step must be repeated for each unique FPGA Vendor ID/Device ID combination present in the system.
+    * **Example**:
+```bash
+echo '0x10ee 0x7011' > /sys/kernel/pddf/devices/multifpgapci/register_pci_device_id
+echo '0x10ee 0x7012' > /sys/kernel/pddf/devices/multifpgapci/register_pci_device_id
+```
+
+2.  **`/sys/kernel/pddf/devices/multifpgapci/dev_ops` (Write-only)**:
+    * **Purpose**: Initializes the overall `multifpgapci` driver. This command instructs the driver to scan the PCIe bus using the previously registered device IDs and create corresponding BDF directories for discovered FPGAs.
+    * **Usage**: Write the string `'multifpgapci_init'` to this file.
+    * **Result**: Directories named after the FPGA's PCI BDF (e.g., `0000:03:00.0`, `0000:04:00.0`) will appear under `/sys/kernel/pddf/devices/multifpgapci/`.
+    * **Example**:
+```bash
+echo 'multifpgapci_init' > /sys/kernel/pddf/devices/multifpgapci/dev_ops
+```
+
+3.  **`/sys/kernel/pddf/devices/multifpgapci/<BDF>/dev_ops` (Write-only)**:
+    * **Purpose**: Performs a per-FPGA initialization. Involves ioremapping the FPGA's Base Address Registers (BARs) into kernel virtual memory, allowing PDDF drivers to access the FPGA memory.
+    * **Usage**: Write the string `fpgapci_init` to the `dev_ops` file within the specific FPGA's BDF directory.
+    * **Note**: In the future, this `dev_ops` file may support additional initialization options specific to individual FPGAs.
+    * **Example**:
+ ```bash
+ echo 'fpgapci_init' > /sys/kernel/pddf/devices/multifpgapci/0000:04:00.0/dev_ops
+ ```
+
+#### 3.4.13.1.2 I2C Module Sysfs Controls (Per-FPGA)
+
+These controls are located within each FPGA's BDF directory under the `i2c` subdirectory (e.g., `/sys/kernel/pddf/devices/multifpgapci/0000:04:00.0/i2c`). They manage the creation and deletion of I2C buses.
+
+1.  **`virt_bus`**:
+    * **Purpose**: Sets the starting virtual I2C bus number for adapters created by this FPGA.
+    * **Usage**: Write a hexadecimal value representing the desired starting bus number.
+    * **Example**:
+```bash
+# I2C buses from FPGA 0000:04:00.0 will start from i2c-19
+echo '0x13' > /sys/kernel/pddf/devices/multifpgapci/0000:04:00.0/i2c/virt_bus
+```
+
+2.  **`ch_base_offset`**:
+    * **Purpose**: Defines the memory offset within the FPGA's mapped BAR where the control registers for the first I2C block are located.
+    * **Usage**: Write a hexadecimal value.
+    * **Example**:
+```bash
+echo '0x200' > /sys/kernel/pddf/devices/multifpgapci/0000:04:00.0/i2c/ch_base_offset
+```
+
+3.  **`ch_size`**:
+    * **Purpose**: Specifies the size (in bytes) of each I2C block's control registers. This is used to calculate the memory location for subsequent I2C channels.
+    * **Usage**: Write a hexadecimal value.
+    * **Example**:
+```bash
+echo '0x200' > /sys/kernel/pddf/devices/multifpgapci/0000:04:00.0/i2c/ch_size
+```
+
+4.  **`new_i2c_adapter` (Write-only)**:
+    * **Purpose**: Creates a new I2C bus adapter managed by the FPGA's I2C IP.
+    * **Usage**: Write a decimal `$INDEX` value. The new I2C bus will be numbered `virt_bus + $INDEX`. Its control block will be located at `ch_base_offset + $INDEX * ch_size`.
+    * **Result**: A new I2C bus entry (e.g. `i2c-19`, `i2c-20`, etc.) will appear under `/sys/bus/i2c/devices/`, and I2C client devices can then be instantiated on this bus.
+    * **Example**:
+```bash
+echo 0 > /sys/kernel/pddf/devices/multifpgapci/0000:04:00.0/i2c/new_i2c_adapter
+echo 1 > /sys/kernel/pddf/devices/multifpgapci/0000:04:00.0/i2c/new_i2c_adapter
+# ... and so on for all desired channels
+```
+
+5.  **`del_i2c_adapter` (Write-only)**:
+    * **Purpose**: Deletes an existing I2C bus adapter previously created by this FPGA.
+    * **Usage**: Write the `$INDEX` of the I2C adapter to be removed.
+    * **Example**:
+```bash
+# delete the first I2C bus of FPGA 0000:04:00.0
+echo 0 > /sys/kernel/pddf/devices/multifpgapci/0000:04:00.0/i2c/del_i2c_adapter
+```
+
+##### 3.4.13.2 Multi-FPGAPCIe System JSON Design
+
+To inform the `multifpgapci` driver about the PCI Vendor ID and Device ID tuples it should look for on the PCIe bus.
+Must be named `MULTIFPGAPCIESYSTEM0` (cannot have more than one instance of the `MULTIFPGAPCIESYSTEM` device type in JSON).
+
+See [3.4.13.1.1 Base FPGA Module Sysfs Controls](#341311-base-fpga-module-sysfs-controls) for the corresponding sysfs backend.
+
+```
+"MULTIFPGAPCIESYSTEM0": {
+  "dev_info": {
+    "device_type": "MULTIFPGAPCIESYSTEM",
+    "device_name": "MULTIFPGAPCIESYSTEM0",
+    "device_parent": null
+  },
+  "i2c": {
+    "PCI_DEVICE_IDS": [
+      {
+        "vendor": "0x10ee",
+        "device": "0x7011"
+      },
+      {
+        "vendor": "0x10ee",
+        "device": "0x7012"
+      }
+    ]
+  }
+},
+```
+
+Description of the fields inside *dev_info*
+
+> **device_type**: Must be set to `MULTIFPGAPCIESYSTEM`
+
+> **device_name**: Must be set to `MULTIFPGAPCIESYSTEM0`
+
+> **device_parent**: Must be set to `null`
+
+Description of the fields within elements inside *PCI_VENDOR_IDS*
+
+> **vendor**: 16 bit hexadecimal which matches the FPGA's PCIe Vendor ID
+
+> **device**: 16 bit hexadecimal which matches the FPGA's PCIe Device ID
+
+##### 3.4.12.3 Multi-FPGAPCIe (per FPGA) JSON Design
+
+Each FPGA must have their PCIe Device ID and Vendor ID matching those specified in the the [Multi-FPGAPCIe System JSON](#34132-multi-fpgapcie-system-json-design). There can any number of `multifpgapci` FPGAs in the system.
+
+See [3.4.13.1.2 I2C Module Sysfs Controls (Per-FPGA)](#341312-i2c-module-sysfs-controls-per-fpga) for the corresponding sysfs backend.
+
+```
+"MULTIFPGAPCIE0": {
+  "dev_info": {
+    "device_type": "MULTIFPGAPCIE",
+    "device_name": "CPU_FPGA",
+    "device_parent": "PCIE0",
+    "device_bdf": "0000:03:00.0",
+    "dev_attr": {}
+  },
+  "i2c": {
+    "dev_attr": {
+      "virt_bus": "0x4",
+      "ch_base_offset": "0x40000",
+      "ch_size": "0x200",
+      "num_virt_ch": "0x8"
+    },
+    "channel": [
+      {
+        "chn": "3",
+        "dev": "DPM1"
+      },
+      {
+        "chn": "6",
+        "dev": "EEPROM1"
+      },
+      {
+        "chn": "6",
+        "dev": "CPUTEMP1"
+      }
+    ]
+  }
+},
+```
+
+Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#34121-fpgapcie-json-design) for description of i2c related fields.
+
+> **device_type**: Must be set to `MULTIFPGAPCIE`
+
+> **device_name**: Must be set to `MULTIFPGAPCIESYSTEM0`
+
+> **device_bdf**: The FPGA's address in BDF (Domain:Bus:Device.Function) format.
+
+##### 3.4.12.4 Multi-FPGAPCIe controlled component JSON Examples
+
+###### Multi-FPGAPCIe CPLDMUX JSON
+
+```
+"CPLDMUX0": {
+  "dev_info": {
+    "device_type": "CPLDMUX",
+    "device_name": "CPLDMUX0",
+    "device_parent": "MULTIFPGAPCIE1"
+  },
+  "i2c": {
+    "topo_info": {
+      "parent_bus": "0x13",
+      "dev_type": "multifpgapci_mux",
+      "dev_id": "0"
+    },
+    "dev_attr": {
+      "base_chan": "0x57",
+      "num_chan": "4",
+      "bdf": "0000:04:00.0"
+    },
+    "channel": [
+      {
+        "chan": "0",
+        "dev": [
+          "PSU1"
+        ],
+        "cpld_offset": "0x10",
+        "cpld_sel": "0x0"
+      },
+      ...
+```
+
+> **dev_type**: Must be set to `multifpgapci_mux`
+
+> **bdf**: The FPGA's address in BDF (Domain:Bus:Device.Function) format.
+
+###### Multi-FPGAPCIe LED JSON
+
+```
+"PORT_LED_1": {
+  "dev_info": {
+    "device_type": "LED",
+    "device_name": "PORT_LED_1"
+  },
+  "dev_attr": {
+    "index": "0"
+  },
+  "i2c": {
+    "attr_list": [
+      {
+        "attr_name": "yellow",
+        "attr_devtype": "multifpgapci",
+        "attr_devname": "MULTIFPGAPCIE1",
+        "attr_bdf": "0000:04:00.0",
+        "bits": "3:0",
+        "descr": "yellow",
+        "value": "0x1",
+        "swpld_addr": "0x60",
+        "swpld_addr_offset": "0x0"
+      },
+      ...
+```
+
+> **attr_devtype**: Must be set to `multifpgapci`
+
+> **attr_bdf**: The FPGA's address in BDF (Domain:Bus:Device.Function) format.
+
+###### Multi-FPGAPCIe XCVR JSON
+
+```
+"PORT1-CTRL": {
+  "dev_info": {
+    "device_type": "",
+    "device_name": "PORT1-CTRL",
+    "device_parent": "MULTIFPGAPCIE1",
+    "virt_parent": "PORT1"
+  },
+  "i2c": {
+    "topo_info": {
+      "parent_bus": "0x17",
+      "dev_addr": "0x8",
+      "dev_type": "pddf_xcvr"
+    },
+    "attr_list": [
+      {
+        "attr_name": "xcvr_reset",
+        "attr_devaddr": "0x0",
+        "attr_devtype": "multifpgapci",
+        "attr_devname": "MULTIFPGAPCIE1",
+        "attr_bdf": "0000:04:00.0",
+        "attr_offset": "0x34",
+        "attr_mask": "0x0",
+        "attr_cmpval": "0x0",
+        "attr_len": "1"
+      },
+      ...
+```
+
+> **attr_devtype**: Must be set to `multifpgapci`
+
+> **attr_bdf**: The FPGA's address in BDF (Domain:Bus:Device.Function) format.
+
+###### Multi-FPGAPCIe PSU JSON
+
+```
+"PSU1-PMBUS": {
+  "dev_info": {
+    "device_type": "PSU-PMBUS",
+    "device_name": "PSU1-PMBUS",
+    "device_parent": "CPLDMUX0",
+    "virt_parent": "PSU1"
+  },
+  "i2c": {
+    "topo_info": {
+      "parent_bus": "0x57",
+      "dev_addr": "0x58",
+      "dev_type": "psu_pmbus"
+    },
+    "attr_list": [
+      {
+        "attr_name": "psu_present",
+        "attr_devtype": "multifpgapci",
+        "attr_devname": "MULTIFPGAPCIE1",
+        "attr_bdf": "0000:04:00.0",
+        "attr_offset": "0x98",
+        "attr_mask": "0x400",
+        "attr_cmpval": "0x400",
+        "attr_len": "1"
+      },
+```
+
+> **attr_devtype**: Must be set to `multifpgapci`
+
+> **attr_bdf**: The FPGA's address in BDF (Domain:Bus:Device.Function) format.
+
+###### Multi-FPGAPCIe PSU JSON
+
+```
+"FAN-CTRL": {
+  "dev_info": {
+    "device_type": "FAN",
+    "device_name": "FAN-CTRL",
+    "device_parent": "MULTIFPGAPCIE1"
+  },
+  "i2c": {
+    "topo_info": {
+      "parent_bus": "0x13",
+      "dev_addr": "0x8",
+      "dev_type": "fan_multifpgapci"
+    },
+    "dev_attr": {
+      "num_fantrays": "4"
+    },
+    "attr_list": [
+      {
+        "attr_name": "fan1_present",
+        "attr_devaddr": "0x0",
+        "attr_devtype": "multifpgapci",
+        "attr_devname": "MULTIFPGAPCIE1",
+        "attr_bdf": "0000:04:00.0",
+        "attr_offset": "0xa4",
+        "attr_mask": "0x000000f0",
+        "attr_cmpval": "0x00000070",
+        "attr_len": "1"
+      },
+      ...
+
+```
+
+> **attr_devtype**: Must be set to `multifpgapci`
+
+> **attr_bdf**: The FPGA's address in BDF (Domain:Bus:Device.Function) format.
 
 ### 3.6 PDDF BMC Component Design
 

--- a/doc/platform/brcm_pdk_pddf.md
+++ b/doc/platform/brcm_pdk_pddf.md
@@ -1292,7 +1292,7 @@ See [3.4.13.1.1 Base FPGA Module Sysfs Controls](#341311-base-fpga-module-sysfs-
     "device_name": "MULTIFPGAPCIESYSTEM0",
     "device_parent": null
   },
-  "i2c": {
+  "dev_attr": {
     "PCI_DEVICE_IDS": [
       {
         "vendor": "0x10ee",
@@ -1328,44 +1328,35 @@ Each FPGA must have their PCIe Device ID and Vendor ID matching those specified 
 See [3.4.13.1.2 I2C Module Sysfs Controls (Per-FPGA)](#341312-i2c-module-sysfs-controls-per-fpga) for the corresponding sysfs backend.
 
 ```
-"MULTIFPGAPCIE0": {
+"MULTIFPGAPCIE1": {
   "dev_info": {
     "device_type": "MULTIFPGAPCIE",
-    "device_name": "CPU_FPGA",
+    "device_name": "SWITCHCARD_FPGA",
     "device_parent": "PCIE0",
-    "device_bdf": "0000:03:00.0",
+    "device_bdf": "0000:04:00.0",
     "dev_attr": {}
   },
   "i2c": {
     "dev_attr": {
-      "virt_bus": "0x4",
+      "virt_bus": "0x13",
       "ch_base_offset": "0x40000",
       "ch_size": "0x200",
-      "num_virt_ch": "0x8"
+      "num_virt_ch": "0x44"
     },
     "channel": [
-      {
-        "chn": "3",
-        "dev": "DPM1"
-      },
-      {
-        "chn": "6",
-        "dev": "EEPROM1"
-      },
-      {
-        "chn": "6",
-        "dev": "CPUTEMP1"
-      }
-    ]
-  }
-},
+      { "chn": "0", "dev": "FAN-CTRL" },
+      { "chn": "0", "dev": "CPLDMUX0" },
+      { "chn": "1", "dev": "CPLDMUX1" },
+      { "chn": "3", "dev": "CPLDMUX2" },
+      { "chn": "4", "dev": "PORT1" },
+      ...
 ```
 
 Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#34121-fpgapcie-json-design) for description of i2c related fields.
 
 > **device_type**: Must be set to `MULTIFPGAPCIE`
 
-> **device_name**: Must be set to `MULTIFPGAPCIESYSTEM0`
+> **device_name**: Each FPGA must have a unique `device_name`
 
 > **device_bdf**: The FPGA's address in BDF (Domain:Bus:Device.Function) format.
 
@@ -1389,7 +1380,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
     "dev_attr": {
       "base_chan": "0x57",
       "num_chan": "4",
-      "bdf": "0000:04:00.0"
+      "cpld_name": "SWITCHCARD_FPGA"
     },
     "channel": [
       {
@@ -1405,7 +1396,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
 
 > **dev_type**: Must be set to `multifpgapci_mux`
 
-> **bdf**: The FPGA's address in BDF (Domain:Bus:Device.Function) format.
+> **cpld_name**:  Must match the `device_name` of the FPGA which controls the mux channel selection.
 
 ###### Multi-FPGAPCIe LED JSON
 
@@ -1423,8 +1414,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
       {
         "attr_name": "yellow",
         "attr_devtype": "multifpgapci",
-        "attr_devname": "MULTIFPGAPCIE1",
-        "attr_bdf": "0000:04:00.0",
+        "attr_devname": "SWITCHCARD_FPGA",
         "bits": "3:0",
         "descr": "yellow",
         "value": "0x1",
@@ -1436,7 +1426,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
 
 > **attr_devtype**: Must be set to `multifpgapci`
 
-> **attr_bdf**: The FPGA's address in BDF (Domain:Bus:Device.Function) format.
+> **attr_devnam**: Must match the `device_name` of the FPGA which controls the LED's color.
 
 ###### Multi-FPGAPCIe XCVR JSON
 
@@ -1459,8 +1449,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
         "attr_name": "xcvr_reset",
         "attr_devaddr": "0x0",
         "attr_devtype": "multifpgapci",
-        "attr_devname": "MULTIFPGAPCIE1",
-        "attr_bdf": "0000:04:00.0",
+        "attr_devname": "SWITCHCARD_FPGA",
         "attr_offset": "0x34",
         "attr_mask": "0x0",
         "attr_cmpval": "0x0",
@@ -1471,7 +1460,7 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
 
 > **attr_devtype**: Must be set to `multifpgapci`
 
-> **attr_bdf**: The FPGA's address in BDF (Domain:Bus:Device.Function) format.
+> **attr_devnam**: Must match the `device_name` of the FPGA which controls the xcvr.
 
 ###### Multi-FPGAPCIe PSU JSON
 
@@ -1493,18 +1482,18 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
       {
         "attr_name": "psu_present",
         "attr_devtype": "multifpgapci",
-        "attr_devname": "MULTIFPGAPCIE1",
-        "attr_bdf": "0000:04:00.0",
+        "attr_devname": "SWITCHCARD_FPGA",
         "attr_offset": "0x98",
         "attr_mask": "0x400",
         "attr_cmpval": "0x400",
         "attr_len": "1"
       },
+      ...
 ```
 
 > **attr_devtype**: Must be set to `multifpgapci`
 
-> **attr_bdf**: The FPGA's address in BDF (Domain:Bus:Device.Function) format.
+> **attr_devnam**: Must match the `device_name` of the FPGA which reads the PSU's status.
 
 ###### Multi-FPGAPCIe PSU JSON
 
@@ -1529,20 +1518,18 @@ Description of fields unique to Multi-FPGAPCIe, see [FPGAPCIe JSON Design](#3412
         "attr_name": "fan1_present",
         "attr_devaddr": "0x0",
         "attr_devtype": "multifpgapci",
-        "attr_devname": "MULTIFPGAPCIE1",
-        "attr_bdf": "0000:04:00.0",
+        "attr_devname": "SWITCHCARD_FPGA",
         "attr_offset": "0xa4",
         "attr_mask": "0x000000f0",
         "attr_cmpval": "0x00000070",
         "attr_len": "1"
       },
       ...
-
 ```
 
 > **attr_devtype**: Must be set to `multifpgapci`
 
-> **attr_bdf**: The FPGA's address in BDF (Domain:Bus:Device.Function) format.
+> **attr_devnam**: Must match the `device_name` of the FPGA which controls the fan.
 
 ### 3.6 PDDF BMC Component Design
 


### PR DESCRIPTION
# Purpose

The existing PDDF framework supports a single PCIE FPGA in the system.

This HLD and series of changes adds PDDF support for multiple PCIE FPGAs in the system.

Fixes https://github.com/sonic-net/sonic-buildimage/issues/22838

---

# Changes

Note: changes 2-6 depend on 1 to build.
Please ignore commits described like `IGNORE THIS COMMIT: Multiple FPGAs w/ I2C IP block (PR sonic-net#22748)` which are commits from 1 cherry-picked into other PRs.

| # | Change | Master PR Link | Depends on
|---|---|---|---|
| 1 | [PDDF] Multiple FPGAs w/ I2C IP blocks | https://github.com/sonic-net/sonic-buildimage/pull/22748 | None
| 2 | [PDDF] Add multi PCIE FPGA controlled fans | https://github.com/sonic-net/sonic-buildimage/pull/22764 | 1
| 3 | [PDDF] Add multi PCIE FPGA controlled XCVR | https://github.com/sonic-net/sonic-buildimage/pull/22765 | 1
| 4 | [PDDF] Add multi PCIE FPGA controlled PSU | https://github.com/sonic-net/sonic-buildimage/pull/22767 | 1
| 5 | [PDDF] Add multi PCIE FPGA controlled LED | https://github.com/sonic-net/sonic-buildimage/pull/22766 | 1
| 6 | [PDDF] Add multi PCIE fpga controlled i2c mux | https://github.com/sonic-net/sonic-buildimage/pull/22768 | 1

---

# Example usage

The multifpgapci module is used by the Nexthop NH-4010 platform directory PR:
https://github.com/sonic-net/sonic-buildimage/pull/22666
