### PR TITLE
Update link up sequence with SI settings sync between OA and xcvrd

### DIFF
--- a/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
+++ b/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
@@ -36,7 +36,7 @@ Deterministic Approach for Interface Link bring-up sequence
 | 0.8 | 02/16/2022  | Shyam Kumar                        | Updated feature-enablement workflow
 | 0.9 | 04/05/2022  | Shyam Kumar                        | Addressed review comments           |
 | 1.0 | 10/20/2023  | Mihir Patel                        | Added Port re-initialization during syncd/swss/orchagent crash section           |
-| 1.1 | 04/19/2026  | Arpit                              | Updated SI settings sync: two-field protocol (APPL_DB si_settings_notification + STATE_DB si_settings_ack), monotonic counter, CMIS_STATE_SI_SETTINGS_WAIT rename, timeout behavior |
+| 1.1 | 04/28/2026  | Arpit Kumar                        | Redesigned SI settings sync: two-field protocol (APPL_DB si_settings_notification + STATE_DB si_settings_ack), monotonic counter, CMIS_STATE_SI_SETTINGS_WAIT state; notification moved to CMIS_STATE_INSERTED and SffManagerTask gated by notify_si_settings flag; SI_SETTINGS_WAIT timeout triggers force_cmis_reinit |
 
 
 # About this Manual
@@ -225,7 +225,7 @@ A transceiver is classified as CMIS SM driven transceiver if its module type is 
 | Value                        | Written by                                                                                                                                                                          | Purpose                                                                                   |
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | `SI_SETTINGS_DEFAULT:<N>`    | 1\. SfpStateUpdateTask during transceiver removal (increments N)<br>2. xcvrd during boot-up initialization                                                                          | Signals to OA that transceiver was removed or SI settings are in default state             |
-| `SI_SETTINGS_NOTIFIED:<N>`   | 1\. SfpStateUpdateTask for non-CMIS SM driven transceivers<br>2. CmisManagerTask for CMIS SM driven transceivers (written in CMIS_STATE_AP_CONF)                                   | Signals to OA that SI settings have been written to PORT_TABLE (APPL_DB) for sequence N   |
+| `SI_SETTINGS_NOTIFIED:<N>`   | 1\. SffManagerTask for non-CMIS SM driven transceivers (on module insertion)<br>2. CmisManagerTask for CMIS SM driven transceivers (written in CMIS_STATE_INSERTED when `notify_si_settings=True`) | Signals to OA that SI settings have been written to PORT_TABLE (APPL_DB) for sequence N   |
 
 **STATE_DB PORT_TABLE `si_settings_ack`** — written by Orchagent, read by xcvrd  
 
@@ -239,10 +239,13 @@ A transceiver is classified as CMIS SM driven transceiver if its module type is 
 2. Update and notify SI settings to OA  
       The API `is_npu_si_settings_update_required` will return true if a module requires SI settings and `si_settings_notification` in PORT_TABLE (APPL_DB) is absent or equals `SI_SETTINGS_DEFAULT:<N>`. It will return false if `si_settings_notification == SI_SETTINGS_NOTIFIED:<N>` (i.e., already notified in this session).  
 
-      For non-CMIS SM driven transceivers, if `is_npu_si_settings_update_required` returns true, SfpStateUpdateTask will update SI settings in PORT_TABLE (APPL_DB) and write `si_settings_notification = SI_SETTINGS_NOTIFIED:<N>` to PORT_TABLE (APPL_DB). OA will be notified via the ConsumerStateTable mechanism.  
+      For non-CMIS SM driven transceivers, if `is_npu_si_settings_update_required` returns true, SffManagerTask will update SI settings in PORT_TABLE (APPL_DB) and write `si_settings_notification = SI_SETTINGS_NOTIFIED:<N>` to PORT_TABLE (APPL_DB) on module insertion. OA will be notified via the ConsumerStateTable mechanism.
 
-      For CMIS SM driven transceivers, if `is_npu_si_settings_update_required` returns true, CmisManagerTask will update SI settings in PORT_TABLE (APPL_DB) and write `si_settings_notification = SI_SETTINGS_NOTIFIED:<N>` to PORT_TABLE (APPL_DB) during CMIS_STATE_AP_CONF.  
-      The CMIS SM will then transition from CMIS_STATE_AP_CONF to CMIS_STATE_SI_SETTINGS_WAIT. If port doesn't require SI settings, CMIS SM will transition to CMIS_STATE_DP_INIT state directly.  
+      For CMIS SM driven transceivers, if `is_npu_si_settings_update_required` returns true, CmisManagerTask will update SI settings in PORT_TABLE (APPL_DB) and write `si_settings_notification = SI_SETTINGS_NOTIFIED:<N>` to PORT_TABLE (APPL_DB) during CMIS_STATE_INSERTED. This notification is gated by a `notify_si_settings` boolean flag in port_dict, which is set to True only on two events:
+      - Module insertion (TRANSCEIVER_INFO SET event from STATE_DB)
+      - SI_SETTINGS_WAIT timeout failure (force reinit after failed ack)
+
+      The flag is reset to False immediately after the notification fires, preventing re-notification on config-change reinits or state-machine retries. The CMIS SM will then transition through CMIS_STATE_DP_DEINIT → CMIS_STATE_AP_CONF → CMIS_STATE_SI_SETTINGS_WAIT. If SI settings were not notified (flag was False), CMIS SM will transition to CMIS_STATE_DP_INIT state directly from CMIS_STATE_AP_CONF.
 
 
 
@@ -253,8 +256,8 @@ A transceiver is classified as CMIS SM driven transceiver if its module type is 
 		- In case of failure, OA will log an error message and proceed to handling the next port
 	- If `si_settings_notification == SI_SETTINGS_DEFAULT:<N>` is received (transceiver removed), OA writes `si_settings_ack = SI_SETTINGS_DEFAULT:<N>` to STATE_DB (no serdes programming)
 
-4. CMIS_STATE_SI_SETTINGS_WAIT state will wait for `SI_SYNC_DONE:<N>` in STATE_DB `si_settings_ack`, where N must match the notification number sent. Upon match, CMIS SM transitions to CMIS_STATE_DP_INIT state.  
-There will be a timeout of 10s; upon timeout, CMIS SM proceeds to CMIS_STATE_DP_INIT with a warning (no reinit)
+4. CMIS_STATE_SI_SETTINGS_WAIT state will wait for `SI_SYNC_DONE:<N>` in STATE_DB `si_settings_ack`, where N must match the notification number sent. Upon match, CMIS SM transitions to CMIS_STATE_DP_INIT state.
+There will be a timeout of 10s; upon timeout, CmisManagerTask resets `si_settings_notification` to `SI_SETTINGS_DEFAULT:<N+1>` in APPL_DB, sets `notify_si_settings=True`, and calls `force_cmis_reinit(retries+1)`, transitioning back to CMIS_STATE_INSERTED. This consumes a retry (max 3) and causes re-notification on the next INSERTED entry. After exhausting retries, the SM transitions to CMIS_STATE_FAILED.
 
 5. The CmisManagerTask thread will set “CMIS_REINIT_REQUIRED” to false after CMIS SM reaches to a steady state (CMIS_STATE_UNKNOWN, CMIS_STATE_FAILED, CMIS_STATE_READY and CMIS_STATE_REMOVED) for the corresponding port
 
@@ -312,11 +315,14 @@ sequenceDiagram
     end
 ```
 
-## SfpStateUpdateTask's role to notify SI settings to OA during xcvrd boot-up
+## SI settings notification during xcvrd boot-up
+
+SI settings notification is no longer performed by SfpStateUpdateTask. It is now split between CmisManagerTask (for CMIS SM driven transceivers) and SffManagerTask (for non-CMIS transceivers), triggered on module insertion events rather than during boot-up initialization.
+
+SfpStateUpdateTask is responsible only for posting transceiver info and DOM thresholds to the DB during boot-up:
 
 ```mermaid
 sequenceDiagram
-    participant OA
     participant APPL_DB as APPL_DB@asic_n
     participant STATE_DB as STATE_DB@asic_n
     participant SfpStateUpdateTask
@@ -325,14 +331,7 @@ sequenceDiagram
     Note over SfpStateUpdateTask: Following loop represents _post_port_sfp_info_and_dom_thr_to_db_once
     loop lport in logical_port_list
         alt post_port_sfp_info_to_db != SFP_EEPROM_NOT_READY
-             Note over SfpStateUpdateTask: post_port_dom_threshold_info_to_db
-            opt if not is_module_cmis_sm_driven and is_npu_si_settings_update_required
-                SfpStateUpdateTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_settings_notification = SI_SETTINGS_NOTIFIED:<N>
-                APPL_DB -->> OA: Notify SI settings for ports (via ConsumerStateTable)
-                Note over OA: Disable admin status (update_host_tx_ready=false)<br>setPortSerdesAttribute
-                OA ->> STATE_DB: PORT_TABLE|<lport>.si_settings_ack = SI_SYNC_DONE:<N>
-                Note over OA: initHostTxReadyState
-            end
+            Note over SfpStateUpdateTask: post_port_dom_threshold_info_to_db
         else
             Note over SfpStateUpdateTask: retry_eeprom_set.add(lport)
         end
@@ -340,6 +339,34 @@ sequenceDiagram
     Note over SfpStateUpdateTask: _init_port_sfp_status_tbl<br>Subscribe to CONFIG_DB
     loop Wait for stop_event
         SfpStateUpdateTask ->> SfpStateUpdateTask: Handle config change event<br>retry_eeprom_reading()<br>_wrapper_get_transceiver_change_event
+    end
+```
+
+## SffManagerTask's role to notify SI settings to OA (non-CMIS modules)
+
+For non-CMIS SM driven transceivers, SffManagerTask notifies SI settings to OA upon module insertion:
+
+```mermaid
+sequenceDiagram
+    participant OA
+    participant APPL_DB as APPL_DB@asic_n
+    participant STATE_DB as STATE_DB@asic_n
+    participant SffManagerTask
+
+    Note over SffManagerTask: Subscribe to CONFIG_DB:PORT,<br>STATE_DB:TRANSCEIVER_INFO and STATE_DB:PORT_TABLE
+    loop Wait for stop_event
+        SffManagerTask ->> SffManagerTask: handle_port_update_event
+        opt xcvr_inserted (TRANSCEIVER_INFO SET) and not is_cmis_api
+            SffManagerTask ->> SffManagerTask: sfp.get_transceiver_info()
+            opt is_npu_si_settings_update_required
+                SffManagerTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_settings_notification = SI_SETTINGS_NOTIFIED:<N>
+                APPL_DB -->> OA: Notify SI settings (via ConsumerStateTable)
+                Note over OA: Disable admin status (update_host_tx_ready=false)<br>setPortSerdesAttribute
+                OA ->> STATE_DB: PORT_TABLE|<lport>.si_settings_ack = SI_SYNC_DONE:<N>
+                Note over OA: initHostTxReadyState
+            end
+        end
+        Note over SffManagerTask: TX enable/disable based on host_tx_ready and admin_status
     end
 ```
 
@@ -355,6 +382,12 @@ stateDiagram-v2
     state if_state3 <<choice>>
     state if_state4 <<choice>>
     CMIS_STATE_INSERTED --> if_state
+    note right of CMIS_STATE_INSERTED
+        If notify_si_settings=True (module insertion or SI failure reinit):
+          Read transceiver info via api
+          Write SI params + si_settings_notification = SI_SETTINGS_NOTIFIED[N] to APPL_DB
+          Reset notify_si_settings = False
+    end note
     if_state --> CMIS_STATE_READY : if host_tx_ready != True or admin_status != up - Action disable TX
     if_state --> if_state2 : if host_tx_ready == True and admin_status == up
     if_state2 --> if_state4 : if appl >= 1 and host_lanes_mask > 0 and SI_lanes_mask > 0
@@ -369,19 +402,20 @@ stateDiagram-v2
     note left of CMIS_STATE_AP_CONF
         Ensure ModuleReady and DataPathDeactivated
         Configure ZR laser frequency
-        Apply SI settings from media_settings.json
-        Write si_settings_notification = SI_SETTINGS_NOTIFIED[N] to APPL_DB PORT_TABLE
+        Apply optics SI settings (optics_si_settings.json) via stage_custom_si_settings
         Call set_application
     end note
     CMIS_STATE_AP_CONF --> if_state3
-    if_state3 --> CMIS_STATE_SI_SETTINGS_WAIT : si_settings_notification == SI_SETTINGS_NOTIFIED[N]
+    if_state3 --> CMIS_STATE_SI_SETTINGS_WAIT : si_settings_notification == SI_SETTINGS_NOTIFIED[N] in APPL_DB
     if_state3 --> CMIS_STATE_DP_INIT : si_settings_notification not set or == SI_SETTINGS_DEFAULT
     CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_DP_INIT : STATE_DB si_settings_ack == SI_SYNC_DONE[N]
-    CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_DP_INIT : 10s timeout - proceed to DP_INIT with warning
+    CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_INSERTED : 10s timeout - reset si_settings_notification to DEFAULT,\nset notify_si_settings=True, force_cmis_reinit(retries+1)
     note right of CMIS_STATE_SI_SETTINGS_WAIT
         Polls STATE_DB si_settings_ack for SI_SYNC_DONE[N]
         N must match the notification number sent in APPL_DB
-        On 10s timeout proceed to DP_INIT with warning
+        On 10s timeout: reset APPL_DB to SI_SETTINGS_DEFAULT[N+1],
+        set notify_si_settings=True, reinit with retries++
+        After CMIS_MAX_RETRIES exhausted: transition to CMIS_STATE_FAILED
     end note
     CMIS_STATE_DP_INIT --> CMIS_STATE_DP_TXON
     CMIS_STATE_DP_TXON --> CMIS_STATE_DP_ACTIVATE
@@ -396,11 +430,12 @@ sequenceDiagram
     participant OA
     participant APPL_DB as APPL_DB@asic_n
     participant CmisManagerTask
+    participant SffManagerTask
     participant SfpStateUpdateTask
 
     SfpStateUpdateTask ->> SfpStateUpdateTask : event = SFP_STATUS_REMOVED
     SfpStateUpdateTask -x STATE_DB : Delete TRANSCEIVER_INFO table for the port
-    par         CmisManagerTask, SfpStateUpdateTask
+    par CmisManagerTask, SfpStateUpdateTask
         CmisManagerTask ->> CmisManagerTask : Transition CMIS SM to CMIS_STATE_REMOVED
         SfpStateUpdateTask ->> APPL_DB : PORT_TABLE|<lport>.si_settings_notification = <br> SI_SETTINGS_DEFAULT:<N+1>
     end
@@ -409,15 +444,17 @@ sequenceDiagram
 
     SfpStateUpdateTask ->> SfpStateUpdateTask : event = SFP_STATUS_INSERTED
     SfpStateUpdateTask ->> STATE_DB : Create TRANSCEIVER_INFO table for the port
-    par CmisManagerTask, SfpStateUpdateTask
-        CmisManagerTask ->> CmisManagerTask : Transition CMIS SM to CMIS_STATE_INSERTED
-        CmisManagerTask ->> CmisManagerTask : Eventually, CMIS SM transitions to CMIS_STATE_AP_CONF
-        opt not is_module_cmis_sm_driven and is_npu_si_settings_update_required
-          SfpStateUpdateTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_settings_notification = SI_SETTINGS_NOTIFIED:<M>
+    par CmisManagerTask, SffManagerTask
+        Note over CmisManagerTask: TRANSCEIVER_INFO SET → notify_si_settings=True<br>Transition CMIS SM to CMIS_STATE_INSERTED
+        opt is_module_cmis_sm_driven and notify_si_settings=True
+          CmisManagerTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_settings_notification = SI_SETTINGS_NOTIFIED:<M><br>notify_si_settings reset to False
         end
-        opt is_module_cmis_sm_driven and is_npu_si_settings_update_required
-          CmisManagerTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_settings_notification = SI_SETTINGS_NOTIFIED:<M>
+        CmisManagerTask ->> CmisManagerTask : CMIS SM proceeds through DP_DEINIT → AP_CONF
+        opt si_settings_notification == SI_SETTINGS_NOTIFIED:<M>
           CmisManagerTask ->> CmisManagerTask : Transition CMIS SM to CMIS_STATE_SI_SETTINGS_WAIT
+        end
+        opt not is_module_cmis_sm_driven and xcvr_inserted
+          SffManagerTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_settings_notification = SI_SETTINGS_NOTIFIED:<M>
         end
         activate OA
         APPL_DB -->> OA: si_settings_notification = SI_SETTINGS_NOTIFIED:<M> (via ConsumerStateTable)

--- a/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
+++ b/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
@@ -36,6 +36,7 @@ Deterministic Approach for Interface Link bring-up sequence
 | 0.8 | 02/16/2022  | Shyam Kumar                        | Updated feature-enablement workflow
 | 0.9 | 04/05/2022  | Shyam Kumar                        | Addressed review comments           |
 | 1.0 | 10/20/2023  | Mihir Patel                        | Added Port re-initialization during syncd/swss/orchagent crash section           |
+| 1.1 | 04/19/2026  | Arpit                              | Updated SI settings sync: two-field protocol (APPL_DB si_sync_status + STATE_DB si_settings_sync_status), monotonic counter, CMIS_STATE_SI_SETTINGS_WAIT rename, timeout behavior |
 
 
 # About this Manual
@@ -193,10 +194,13 @@ if transceiver is not present:
 
 When syncd/swss/orchagent crashes, all ports in the corresponding namespace will be reinitialized by xcvrd irrespective of the current state of the port. All the corresponding ports are expected to experience link down until the initialization is complete.  
 If just xcvrd crashes and restarts, then forced re-initialization (CMIS reinit + NPU SI settings notification) of ports will not be performed. Hence, the ports will not experience link downtime during this scenario.
-CMIS_REINIT_REQUIRED and NPU_SI_SETTINGS_SYNC_STATUS keys in PORT_TABLE|\<port\> (STATE_DB) are used to determine if port re-initialization is required or not.  
+CMIS_REINIT_REQUIRED in PORT_TABLE|\<port\> (STATE_DB) and two SI-settings fields are used to determine if port re-initialization is required or not.  
   - CMIS_REINIT_REQUIRED key states if CMIS re-initialization is required for a port after xcvrd is spawned. CMIS_REINIT_REQUIRED helps in mainly driving CMIS re-initialization after syncd/swss/orchagent crash since it will allow reinitializing ports belonging to the relevant namespace of the crashing process. This key is not planned to drive CMIS initialization after transceiver insertion.  
-  - NPU_SI_SETTINGS_SYNC_STATUS key is used as a means to communicate the status of applying NPU SI settings for a transceiver requiring NPU SI settings. This key is used to update the NPU SI settings application status between SfpStateUpdateTask, CmisManagerTask and Orchagent. In case of warm reboot or xcvrd restart, this key will prevent application of NPU SI settings on the port if the settings are already applied. In case of transceiver insertion, NPU SI settings will be applied irrespective of the NPU SI settings application status for the port.  
-  Also, this key helps in preventing additional link flap which can happen if CMIS state machine initializes a port before NPU SI settings are applied (since application of NPU SI settings involves disable followed by enable of it).  
+  - SI settings synchronization uses a two-field protocol to communicate between xcvrd and Orchagent (OA):
+    - `si_sync_status` in PORT_TABLE (APPL_DB): written by xcvrd to signal SI settings state. OA reads this via its normal ConsumerStateTable flow. Values: `SI_SETTINGS_NOTIFIED:<N>` (xcvrd has notified SI settings for sequence N), `SI_SETTINGS_DEFAULT:<N>` (transceiver removed or no SI settings needed for sequence N).
+    - `si_settings_sync_status` in PORT_TABLE (STATE_DB): written by OA to acknowledge SI settings state. xcvrd polls this field. Values: `SI_SETTINGS_DEFAULT:<N>` (OA acknowledged removal/reset), `SI_SYNC_DONE:<N>` (OA successfully applied SI settings for sequence N).  
+    A monotonically increasing counter `<N>` embedded in both fields ensures xcvrd can distinguish stale acknowledgments from prior insertions. In case of warm reboot or xcvrd restart, these fields prevent re-application of SI settings if the settings are already applied. In case of transceiver insertion, SI settings will be applied irrespective of the current status.  
+  Also, this protocol prevents the additional link flap that would occur if CMIS state machine initialized a port before SI settings are applied (since applying SI settings involves disabling then re-enabling admin state, but without updating host_tx_ready).  
 In case of continuous restart of xcvrd, both the keys will still hold the same value as before the restart. This would ensure that the port re-initialization is resumed from the last known state.  
 
 Following infra will ensure port re-initialization by xcvrd in case of syncd/swss/orchagent crash  
@@ -207,46 +211,56 @@ Pre-requisites for the infra to work:
     - xcvrd crash/restart (does not apply to xcvrd restart triggered due to a different docker container crash/restart)
     - warm reboot
 
-1. XCVRD main thread init
+1. XCVRD main thread init / Orchagent port init
 	- XCVRD main thread creates the key CMIS_REINIT_REQUIRED in PORT_TABLE|\<port\> (STATE_DB) with value as true for ports which do NOT have this key present 
-	- XCVRD main thread creates the key NPU_SI_SETTINGS_SYNC_STATUS in PORT_TABLE|\<port\> (STATE_DB) with value NPU_SI_SETTINGS_DEFAULT for ports which do NOT have this key present.  
-      - For transceivers which do not require NPU SI settings, NPU_SI_SETTINGS_SYNC_STATUS will stay with value NPU_SI_SETTINGS_DEFAULT  
+	- Orchagent initializes `si_settings_sync_status = SI_SETTINGS_DEFAULT:0` in PORT_TABLE|\<port\> (STATE_DB) for all ports during port initialization.  
+      - For transceivers which do not require NPU SI settings, `si_settings_sync_status` will remain at `SI_SETTINGS_DEFAULT:<N>`  
 
-    Following table describes the various values for NPU_SI_SETTINGS_SYNC_STATUS  
+    The following tables describe the values for each SI settings field.  
 A transceiver is classified as CMIS SM driven transceiver if its module type is CMIS and it does not have flat memory  
 
-| Value                    | Modifier thread and event                                                                                                                                                                                           | Consumer thread and purpose                                                                     |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| NPU_SI_SETTINGS_DEFAULT  | 1\. XCVRD main thread during cold start of XCVRD<br>2. SfpStateUpdateTask during transceiver removal                                                                                                                | XCVRD main thread during boot-up for deciding to notify NPU SI settings                         |
-| NPU_SI_SETTINGS_NOTIFIED | 1\. SfpStateUpdateTask while updating and notifying the NPU SI settings for non-CMIS SM driven transceivers (this approach was chosen to preserve the existing behavior for non-CMIS SM driven transceivers)<br> 2. CmisManagerTask while updating and notifying the NPU SI settings for CMIS SM driven transceivers | Not being used currently                                                                        |
-| NPU_SI_SETTINGS_DONE     | Orchagent after applying the SI settings                                                                                                                                                                            | CmisManagerTask for proceeding from CMIS_STATE_NPU_SI_SETTINGS_WAIT to CMIS_STATE_DP_INIT state |
+**APPL_DB PORT_TABLE `si_sync_status`** — written by xcvrd, read by Orchagent via ConsumerStateTable  
+
+| Value                        | Written by                                                                                                                                                                          | Purpose                                                                                   |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `SI_SETTINGS_DEFAULT:<N>`    | 1\. SfpStateUpdateTask during transceiver removal (increments N)<br>2. xcvrd during boot-up initialization                                                                          | Signals to OA that transceiver was removed or SI settings are in default state             |
+| `SI_SETTINGS_NOTIFIED:<N>`   | 1\. SfpStateUpdateTask for non-CMIS SM driven transceivers<br>2. CmisManagerTask for CMIS SM driven transceivers (written in CMIS_STATE_AP_CONF)                                   | Signals to OA that SI settings have been written to PORT_TABLE (APPL_DB) for sequence N   |
+
+**STATE_DB PORT_TABLE `si_settings_sync_status`** — written by Orchagent, read by xcvrd  
+
+| Value                   | Written by                                                                          | Purpose                                                                                                       |
+| ----------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `SI_SETTINGS_DEFAULT:0` | Orchagent during port initialization                                                 | Initial state; indicates SI settings have not been applied                                                    |
+| `SI_SETTINGS_DEFAULT:<N>` | Orchagent upon receiving `SI_SETTINGS_DEFAULT:<N>` from xcvrd via APPL_DB         | Acknowledges transceiver removal; used by xcvrd on restart to determine update is needed                      |
+| `SI_SYNC_DONE:<N>`      | Orchagent after successfully applying serdes settings for sequence N                | CmisManagerTask checks this in CMIS_STATE_SI_SETTINGS_WAIT to proceed to CMIS_STATE_DP_INIT; also used by `can_skip_cmis_init_after_restart` to verify SI settings are already applied |
 
 
-2. Update and notify NPU SI settings to OA  
-      The API is_npu_si_settings_update_required will return true if a module requires NPU SI settings and PORT_TABLE|\<port\>.NPU_SI_SETTINGS_SYNC_STATUS == NPU_SI_SETTINGS_DEFAULT. It will return false in other cases  
+2. Update and notify SI settings to OA  
+      The API `is_npu_si_settings_update_required` will return true if a module requires SI settings and `si_sync_status` in PORT_TABLE (APPL_DB) is absent or equals `SI_SETTINGS_DEFAULT:<N>`. It will return false if `si_sync_status == SI_SETTINGS_NOTIFIED:<N>` (i.e., already notified in this session).  
 
-      For non-CMIS SM driven transceivers, if is_npu_si_settings_update_required returns true, SfpStateUpdateTask thread will update NPU SI settings in the PORT_TABLE (APPL_DB) and OA will be notified eventually. Also, NPU_SI_SETTINGS_SYNC_STATUS will be set to NPU_SI_SETTINGS_NOTIFIED in PORT_TABLE (STATE_DB).  
+      For non-CMIS SM driven transceivers, if `is_npu_si_settings_update_required` returns true, SfpStateUpdateTask will update SI settings in PORT_TABLE (APPL_DB) and write `si_sync_status = SI_SETTINGS_NOTIFIED:<N>` to PORT_TABLE (APPL_DB). OA will be notified via the ConsumerStateTable mechanism.  
 
-      For CMIS SM driven transceivers, if is_npu_si_settings_update_required returns true, CmisManagerTask thread will update NPU SI settings in the PORT_TABLE (APPL_DB) and OA will be notified eventually.  Also, NPU_SI_SETTINGS_SYNC_STATUS will be set to NPU_SI_SETTINGS_NOTIFIED in PORT_TABLE (STATE_DB).  
-      The CMIS SM will then transition from CMIS_STATE_AP_CONF to CMIS_STATE_NPU_SI_SETTINGS_WAIT. If port doesn't require NPU SI settings, CMIS SM will transition to CMIS_STATE_DP_INIT state.  
+      For CMIS SM driven transceivers, if `is_npu_si_settings_update_required` returns true, CmisManagerTask will update SI settings in PORT_TABLE (APPL_DB) and write `si_sync_status = SI_SETTINGS_NOTIFIED:<N>` to PORT_TABLE (APPL_DB) during CMIS_STATE_AP_CONF.  
+      The CMIS SM will then transition from CMIS_STATE_AP_CONF to CMIS_STATE_SI_SETTINGS_WAIT. If port doesn't require SI settings, CMIS SM will transition to CMIS_STATE_DP_INIT state directly.  
 
 
 
-3. The OA upon receiving NPU SI settings will  
-	- Disable port admin status
-	- Request SAI-SDK to apply the NPU SI settings via syncd
-		- If SAI-SDK returns success, OA will update the PORT_TABLE|\<port\>.NPU_SI_SETTINGS_SYNC_STATUS to NPU_SI_SETTINGS_DONE in STATE_DB
+3. The OA upon receiving SI settings (via `si_sync_status` update in APPL_DB) will  
+	- Disable port admin status (without updating host_tx_ready, to avoid triggering xcvrd)
+	- Request SAI-SDK to apply the SI settings via syncd
+		- If SAI-SDK returns success, OA will write `si_settings_sync_status = SI_SYNC_DONE:<N>` to PORT_TABLE|\<port\> (STATE_DB), where N matches the notification number received
 		- In case of failure, OA will log an error message and proceed to handling the next port
+	- If `si_sync_status == SI_SETTINGS_DEFAULT:<N>` is received (transceiver removed), OA writes `si_settings_sync_status = SI_SETTINGS_DEFAULT:<N>` to STATE_DB (no serdes programming)
 
-4. CMIS_STATE_NPU_SI_SETTINGS_WAIT state will wait for NPU_SI_SETTINGS_DONE and upon reaching to NPU_SI_SETTINGS_DONE, CMIS SM will transition to CMIS_STATE_DP_INIT state.  
-There will be a timeout of 5s for every retry
+4. CMIS_STATE_SI_SETTINGS_WAIT state will wait for `SI_SYNC_DONE:<N>` in STATE_DB `si_settings_sync_status`, where N must match the notification number sent. Upon match, CMIS SM transitions to CMIS_STATE_DP_INIT state.  
+There will be a timeout of 10s; upon timeout, CMIS SM proceeds to CMIS_STATE_DP_INIT with a warning (no reinit)
 
 5. The CmisManagerTask thread will set “CMIS_REINIT_REQUIRED" to false after CMIS SM reaches to a steady state (CMIS_STATE_UNKNOWN, CMIS_STATE_FAILED, CMIS_STATE_READY and CMIS_STATE_REMOVED) for the corresponding port
 
 6. XCVRD will subscribe to PORT_TABLE in STATE_DB and trigger self-restart if the PORT_TABLE|Ethernet* is deleted for the namespace.  
-All threads will be gracefully terminated and xcvrd deinit will be performed followed by issuing a SIGABRT to ensure XCVRD is restarted automatically by supervisord. After respawn, CMIS re-init and NPU_SI_SETTINGS notified is triggered for the ports belonging to the affected namespace
+All threads will be gracefully terminated and xcvrd deinit will be performed followed by issuing a SIGABRT to ensure XCVRD is restarted automatically by supervisord. After respawn, CMIS re-init and SI settings notification is triggered for the ports belonging to the affected namespace
 
-7. syncd/swss/orchagent restart (restart triggered due to docker container crash) clears the entire APPL-DB and PORT_TABLE|Ethernet* of STATE_DB (including “NPU_SI_SETTINGS_SYNC_STATUS” and "CMIS_REINIT_REQUIRED" keys in PORT_TABLE of STATE_DB)
+7. syncd/swss/orchagent restart (restart triggered due to docker container crash) clears the entire APPL-DB and PORT_TABLE|Ethernet* of STATE_DB (including “si_settings_sync_status”, “si_sync_status” and “CMIS_REINIT_REQUIRED” keys in PORT_TABLE)
 
 8. In case of warm reboot, the PORT_TABLE in STATE_DB is not cleared. Hence, once xcvrd is spawned after the device reboot, the ports are not initialized again.
 
@@ -266,11 +280,8 @@ sequenceDiagram
         alt if CMIS_REINIT_REQUIRED not in PORT_TABLE|<lport>
             XCVRDMT ->> STATE_DB: PORT_TABLE|<lport>.CMIS_REINIT_REQUIRED = true
         end
-        alt if NPU_SI_SETTINGS_SYNC_STATUS not in PORT_TABLE|<lport>
-            XCVRDMT ->> STATE_DB: PORT_TABLE|<lport>.NPU_SI_SETTINGS_SYNC_STATUS = NPU_SI_SETTINGS_DEFAULT
-        end
     end
-    Note over STATE_DB: PORT_TABLE|<lport><br>CMIS_REINIT_REQUIRED : true/false<br>NPU_SI_SETTINGS_SYNC_STATUS : NPU_SI_SETTINGS_DEFAULT/NPU_SI_SETTINGS_NOTIFIED/NPU_SI_SETTINGS_DONE
+    Note over STATE_DB: PORT_TABLE|<lport><br>CMIS_REINIT_REQUIRED : true/false<br>si_settings_sync_status : SI_SETTINGS_DEFAULT:<N>/SI_SYNC_DONE:<N><br>(si_settings_sync_status initialized to SI_SETTINGS_DEFAULT:0 by Orchagent during port init)
     XCVRDMT ->> CmisManagerTask: Spawns
     XCVRDMT ->> DomInfoUpdateTask: Spawns
     XCVRDMT ->> SfpStateUpdateTask: Spawns
@@ -292,7 +303,7 @@ sequenceDiagram
     end
 ```
 
-## SfpStateUpdateTask's role to notify NPU SI settings to OA during xcvrd boot-up
+## SfpStateUpdateTask's role to notify SI settings to OA during xcvrd boot-up
 
 ```mermaid
 sequenceDiagram
@@ -307,11 +318,10 @@ sequenceDiagram
         alt post_port_sfp_info_to_db != SFP_EEPROM_NOT_READY
              Note over SfpStateUpdateTask: post_port_dom_threshold_info_to_db
             opt if not is_module_cmis_sm_driven and is_npu_si_settings_update_required
-                SfpStateUpdateTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport>
-                SfpStateUpdateTask ->> STATE_DB: PORT_TABLE|<lport>.NPU_SI_SETTINGS_SYNC_STATUS = NPU_SI_SETTINGS_NOTIFIED
-                APPL_DB -->> OA: Notify NPU SI settings for ports
-                Note over OA: Disable admin status<br>setPortSerdesAttribute
-                OA ->> STATE_DB: PORT_TABLE|<lport>.NPU_SI_SETTINGS_SYNC_STATUS = NPU_SI_SETTINGS_DONE
+                SfpStateUpdateTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_sync_status = SI_SETTINGS_NOTIFIED:<N>
+                APPL_DB -->> OA: Notify SI settings for ports (via ConsumerStateTable)
+                Note over OA: Disable admin status (update_host_tx_ready=false)<br>setPortSerdesAttribute
+                OA ->> STATE_DB: PORT_TABLE|<lport>.si_settings_sync_status = SI_SYNC_DONE:<N>
                 Note over OA: initHostTxReadyState
             end
         else
@@ -324,9 +334,9 @@ sequenceDiagram
     end
 ```
 
-## CMIS State machine with introduction of CMIS_STATE_NPU_SI_SETTINGS_WAIT states
+## CMIS State machine with introduction of CMIS_STATE_SI_SETTINGS_WAIT state
 
-The below state machine is a high level flow and doesn't capture details for states other than CMIS_STATE_AP_CONF and CMIS_STATE_NPU_SI_SETTINGS_WAIT  
+The below state machine is a high level flow and doesn't capture details for states other than CMIS_STATE_AP_CONF and CMIS_STATE_SI_SETTINGS_WAIT  
 
 ```mermaid
 stateDiagram
@@ -334,25 +344,29 @@ stateDiagram
     state if_state <<choice>>
     state if_state2 <<choice>>
     state if_state3 <<choice>>
+    state if_state4 <<choice>>
     CMIS_STATE_INSERTED --> if_state
     if_state --> CMIS_STATE_READY : if host_tx_ready != True or<br>admin_status != up<br> Action - disable TX
     if_state --> if_state2 : if host_tx_ready == True and<br>admin_status == up
-    if_state2 --> CMIS_STATE_DP_DEINIT : if PORT_TABLE.port.CMIS_REINIT_REQUIRED == true or<br>is_cmis_application_update_required
-    note left of CMIS_STATE_READY : PORT_TABLE.port.CMIS_REINIT_REQUIRED = false
-    if_state2 --> CMIS_STATE_FAILED : if appl < 1 or <br>host_lanes_mask <= 0 or <br>NPU SI_lanes_mask <= 0
+    if_state2 --> if_state4 : if appl >= 1 and host_lanes_mask > 0 and SI_lanes_mask > 0
+    if_state2 --> CMIS_STATE_FAILED : if appl < 1 or <br>host_lanes_mask <= 0 or <br>SI_lanes_mask <= 0
     note left of CMIS_STATE_FAILED : PORT_TABLE.port.CMIS_REINIT_REQUIRED = false
+    if_state4 --> CMIS_STATE_READY : if can_skip_cmis_init_after_restart<br>(app matches, SI synced, ConfigSuccess, DataPathActivated)
+    note left of CMIS_STATE_READY : PORT_TABLE.port.CMIS_REINIT_REQUIRED = false
+    if_state4 --> CMIS_STATE_DP_DEINIT : if PORT_TABLE.port.CMIS_REINIT_REQUIRED == true or<br>is_cmis_application_update_required
 
     CMIS_STATE_DP_DEINIT --> CMIS_STATE_AP_CONF
 
-    note left of CMIS_STATE_AP_CONF : Ensure current states are ModuleReady and DataPathDeactivated<br>Configure laser frequency for ZR module<br>Apply module SI settings<br>Update NPU SI settings to PORT_TABLE (APPL_DB) and notify to OA<br>Set PORT_TABLE|lport.NPU_SI_SETTINGS_SYNC_STATUS = NPU_SI_SETTINGS_DONE (STATE_DB)<br>set_application
+    note left of CMIS_STATE_AP_CONF : Ensure current states are ModuleReady and DataPathDeactivated<br>Configure laser frequency for ZR module<br>Apply module SI settings<br>Write si_sync_status = SI_SETTINGS_NOTIFIED:<N> to PORT_TABLE (APPL_DB)<br>set_application
     CMIS_STATE_AP_CONF --> if_state3
-    if_state3 --> CMIS_STATE_NPU_SI_SETTINGS_WAIT : if is_npu_si_settings_update_required
-    if_state3 --> CMIS_STATE_DP_INIT : if not is_npu_si_settings_update_required
-    CMIS_STATE_NPU_SI_SETTINGS_WAIT --> CMIS_STATE_DP_INIT : if PORT_TABLE&ltport&gt.NPU_SI_SETTINGS_SYNC_STATUS == NPU_SI_SETTINGS_DONE
-    CMIS_STATE_NPU_SI_SETTINGS_WAIT --> CMIS_STATE_INSERTED : Through force_cmis_reinit upon reaching timeout
-    note right of CMIS_STATE_NPU_SI_SETTINGS_WAIT
-        Checks if PORT_TABLE&ltport&gt.NPU_SI_SETTINGS_SYNC_STATUS == NPU_SI_SETTINGS_DONE
-        After 5s timeout, force_cmis_reinit will be called
+    if_state3 --> CMIS_STATE_SI_SETTINGS_WAIT : if SI_SETTINGS_NOTIFIED:<N> was written to APPL_DB
+    if_state3 --> CMIS_STATE_DP_INIT : if SI settings not notified (no si_sync_status or SI_SETTINGS_DEFAULT)
+    CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_DP_INIT : if STATE_DB PORT_TABLE&ltport&gt.si_settings_sync_status == SI_SYNC_DONE:<N>
+    CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_DP_INIT : Upon 10s timeout, proceed to DP_INIT with warning
+    note right of CMIS_STATE_SI_SETTINGS_WAIT
+        Polls STATE_DB PORT_TABLE&ltport&gt.si_settings_sync_status for SI_SYNC_DONE:<N>
+        where N must match the notification number sent in APPL_DB
+        After 10s timeout, proceeds to CMIS_STATE_DP_INIT with a warning (no reinit)
     end note
     CMIS_STATE_DP_INIT --> CMIS_STATE_DP_TXON
     CMIS_STATE_DP_TXON --> CMIS_STATE_DP_ACTIVATE
@@ -373,8 +387,10 @@ sequenceDiagram
     SfpStateUpdateTask -x STATE_DB : Delete TRANSCEIVER_INFO table for the port
     par         CmisManagerTask, SfpStateUpdateTask
         CmisManagerTask ->> CmisManagerTask : Transition CMIS SM to CMIS_STATE_REMOVED
-        SfpStateUpdateTask ->> STATE_DB : PORT_TABLE|<lport>.NPU_SI_SETTINGS_SYNC_STATUS = <br> NPU_SI_SETTINGS_DEFAULT
+        SfpStateUpdateTask ->> APPL_DB : PORT_TABLE|<lport>.si_sync_status = <br> SI_SETTINGS_DEFAULT:<N+1>
     end
+    APPL_DB -->> OA: si_sync_status = SI_SETTINGS_DEFAULT:<N+1> (via ConsumerStateTable)
+    OA ->> STATE_DB : PORT_TABLE|<lport>.si_settings_sync_status = <br> SI_SETTINGS_DEFAULT:<N+1>
 
     SfpStateUpdateTask ->> SfpStateUpdateTask : event = SFP_STATUS_INSERTED
     SfpStateUpdateTask ->> STATE_DB : Create TRANSCEIVER_INFO table for the port
@@ -382,22 +398,19 @@ sequenceDiagram
         CmisManagerTask ->> CmisManagerTask : Transition CMIS SM to CMIS_STATE_INSERTED
         CmisManagerTask ->> CmisManagerTask : Eventually, CMIS SM transitions to CMIS_STATE_AP_CONF
         opt not is_module_cmis_sm_driven and is_npu_si_settings_update_required
-          SfpStateUpdateTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport>
-          SfpStateUpdateTask ->> STATE_DB: PORT_TABLE|<lport>.NPU_SI_SETTINGS_SYNC_STATUS = <br> NPU_SI_SETTINGS_NOTIFIED
+          SfpStateUpdateTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_sync_status = SI_SETTINGS_NOTIFIED:<M>
         end
         opt is_module_cmis_sm_driven and is_npu_si_settings_update_required
-          CmisManagerTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport>
-          CmisManagerTask ->> STATE_DB: PORT_TABLE|<lport>.NPU_SI_SETTINGS_SYNC_STATUS = <br> NPU_SI_SETTINGS_NOTIFIED
-          CmisManagerTask ->> CmisManagerTask : Transition CMIS SM to CMIS_STATE_NPU_SI_SETTINGS_WAIT
+          CmisManagerTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_sync_status = SI_SETTINGS_NOTIFIED:<M>
+          CmisManagerTask ->> CmisManagerTask : Transition CMIS SM to CMIS_STATE_SI_SETTINGS_WAIT
         end
         activate OA
-        APPL_DB -->> OA: Notify NPU SI settings for ports
-        Note over OA: Disable admin status<br>setPortSerdesAttribute
-        OA ->> STATE_DB: PORT_TABLE|<lport>.NPU_SI_SETTINGS_SYNC_STATUS = NPU_SI_SETTINGS_DONE
-        STATE_DB --> CmisManagerTask: PORT_TABLE|<lport>.NPU_SI_SETTINGS_SYNC_STATUS = NPU_SI_SETTINGS_DONE
+        APPL_DB -->> OA: si_sync_status = SI_SETTINGS_NOTIFIED:<M> (via ConsumerStateTable)
+        Note over OA: Disable admin status (update_host_tx_ready=false)<br>setPortSerdesAttribute
+        OA ->> STATE_DB: PORT_TABLE|<lport>.si_settings_sync_status = SI_SYNC_DONE:<M>
         Note over OA: initHostTxReadyState
         deactivate OA
-        CmisManagerTask ->> CmisManagerTask : Transition CMIS SM to CMIS_STATE_DP_INIT
+        CmisManagerTask ->> CmisManagerTask : Poll STATE_DB si_settings_sync_status == SI_SYNC_DONE:<M><br>Transition CMIS SM to CMIS_STATE_DP_INIT
     end
 ```
 
@@ -450,24 +463,24 @@ sequenceDiagram
 ## Test plan and expectation
 
 **Process and device crash/restart and interface config command handling testplan**  
-| Event          | STATE_DB_<asic_n> cleared | Xcvrd restarted | NPU SI settings renotify | NPU_SI_SETTINGS_SYNC_STATUS value on xcvrd boot-up for initialized transceiver | CMIS re-init triggered | Link flap |
-| -------------- | ------------------------ | --------------- | ------------------------ | ------------------------------------------------------------------------------ | ---------------------- | --------- |
-| Xcvrd restart | N | Y | N | NPU_SI_SETTINGS_DONE | N | N |
-| Pmon restart | N | Y | N | NPU_SI_SETTINGS_DONE | N | N |
-| orchagent restart | Y | Y | Y | NPU_SI_SETTINGS_DEFAULT | Y | N/A |
-| Swss restart | Y | Y | Y | NPU_SI_SETTINGS_DEFAULT | Y | N/A |
-| Syncd restart | Y | Y | Y | NPU_SI_SETTINGS_DEFAULT | Y | N/A |
-| config reload | Y | Y | Y | NPU_SI_SETTINGS_DEFAULT | Y | N/A |
-| Cold reboot | Y | Y | Y | NPU_SI_SETTINGS_DEFAULT | Y | N/A |
-| Warm reboot | N | Y | N | NPU_SI_SETTINGS_DONE | N | N |  
-| config interface shutdown | N | N | N | NPU_SI_SETTINGS_DONE | N | N/A |
-| config interface startup | N | N | N | NPU_SI_SETTINGS_DONE | N | N/A |
+| Event          | STATE_DB_<asic_n> cleared | Xcvrd restarted | SI settings renotify | si_settings_sync_status (STATE_DB) on xcvrd boot-up for initialized transceiver | CMIS re-init triggered | Link flap |
+| -------------- | ------------------------ | --------------- | -------------------- | -------------------------------------------------------------------------------- | ---------------------- | --------- |
+| Xcvrd restart | N | Y | N | SI_SYNC_DONE:<N> | N | N |
+| Pmon restart | N | Y | N | SI_SYNC_DONE:<N> | N | N |
+| orchagent restart | Y | Y | Y | SI_SETTINGS_DEFAULT:0 | Y | N/A |
+| Swss restart | Y | Y | Y | SI_SETTINGS_DEFAULT:0 | Y | N/A |
+| Syncd restart | Y | Y | Y | SI_SETTINGS_DEFAULT:0 | Y | N/A |
+| config reload | Y | Y | Y | SI_SETTINGS_DEFAULT:0 | Y | N/A |
+| Cold reboot | Y | Y | Y | SI_SETTINGS_DEFAULT:0 | Y | N/A |
+| Warm reboot | N | Y | N | SI_SYNC_DONE:<N> | N | N |  
+| config interface shutdown | N | N | N | SI_SYNC_DONE:<N> | N | N/A |
+| config interface startup | N | N | N | SI_SYNC_DONE:<N> | N | N/A |
 
 **Transceiver OIR testplan**  
-| Event | STATE_DB_<asic_n> cleared | Xcvrd restarted | NPU SI settings notified | NPU_SI_SETTINGS_SYNC_STATUS value upon event completion | CMIS init triggered |
-| -------------- | ------------------------ | --------------- | ------------------------ | ------------------------------------------------------------------------------ | ---------------------- |
-| Transceiver Removal | N | N | Y | NPU_SI_SETTINGS_DEFAULT | N/A |
-| Transceiver Insertion | N | N | Y | NPU_SI_SETTINGS_DONE | Y |
+| Event | STATE_DB_<asic_n> cleared | Xcvrd restarted | SI settings notified | si_settings_sync_status (STATE_DB) upon event completion | CMIS init triggered |
+| -------------- | ------------------------ | --------------- | -------------------- | --------------------------------------------------------- | ---------------------- |
+| Transceiver Removal | N | N | N (resets to DEFAULT) | SI_SETTINGS_DEFAULT:<N+1> | N/A |
+| Transceiver Insertion | N | N | Y | SI_SYNC_DONE:<M> | Y |
 # Out of Scope 
 Following items are not in the scope of this document. They would be taken up separately
 1. CMIS API feature is not part of this design and the APIs will be used in this design. For CMIS HLD, Please refer to:

--- a/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
+++ b/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
@@ -36,7 +36,7 @@ Deterministic Approach for Interface Link bring-up sequence
 | 0.8 | 02/16/2022  | Shyam Kumar                        | Updated feature-enablement workflow
 | 0.9 | 04/05/2022  | Shyam Kumar                        | Addressed review comments           |
 | 1.0 | 10/20/2023  | Mihir Patel                        | Added Port re-initialization during syncd/swss/orchagent crash section           |
-| 1.1 | 04/19/2026  | Arpit                              | Updated SI settings sync: two-field protocol (APPL_DB si_sync_status + STATE_DB si_settings_sync_status), monotonic counter, CMIS_STATE_SI_SETTINGS_WAIT rename, timeout behavior |
+| 1.1 | 04/19/2026  | Arpit                              | Updated SI settings sync: two-field protocol (APPL_DB si_settings_notification + STATE_DB si_settings_ack), monotonic counter, CMIS_STATE_SI_SETTINGS_WAIT rename, timeout behavior |
 
 
 # About this Manual
@@ -193,15 +193,16 @@ if transceiver is not present:
 ## Overview
 
 When syncd/swss/orchagent crashes, all ports in the corresponding namespace will be reinitialized by xcvrd irrespective of the current state of the port. All the corresponding ports are expected to experience link down until the initialization is complete.  
-If just xcvrd crashes and restarts, then forced re-initialization (CMIS reinit + NPU SI settings notification) of ports will not be performed. Hence, the ports will not experience link downtime during this scenario.
+If just xcvrd crashes and restarts, then forced re-initialization (CMIS reinit + SI settings sync via `si_settings_notification`/`si_settings_ack`) of ports will not be performed. Hence, the ports will not experience link downtime during this scenario.
 CMIS_REINIT_REQUIRED in PORT_TABLE|\<port\> (STATE_DB) and two SI-settings fields are used to determine if port re-initialization is required or not.  
   - CMIS_REINIT_REQUIRED key states if CMIS re-initialization is required for a port after xcvrd is spawned. CMIS_REINIT_REQUIRED helps in mainly driving CMIS re-initialization after syncd/swss/orchagent crash since it will allow reinitializing ports belonging to the relevant namespace of the crashing process. This key is not planned to drive CMIS initialization after transceiver insertion.  
   - SI settings synchronization uses a two-field protocol to communicate between xcvrd and Orchagent (OA):
-    - `si_sync_status` in PORT_TABLE (APPL_DB): written by xcvrd to signal SI settings state. OA reads this via its normal ConsumerStateTable flow. Values: `SI_SETTINGS_NOTIFIED:<N>` (xcvrd has notified SI settings for sequence N), `SI_SETTINGS_DEFAULT:<N>` (transceiver removed or no SI settings needed for sequence N).
-    - `si_settings_sync_status` in PORT_TABLE (STATE_DB): written by OA to acknowledge SI settings state. xcvrd polls this field. Values: `SI_SETTINGS_DEFAULT:<N>` (OA acknowledged removal/reset), `SI_SYNC_DONE:<N>` (OA successfully applied SI settings for sequence N).  
-    A monotonically increasing counter `<N>` embedded in both fields ensures xcvrd can distinguish stale acknowledgments from prior insertions. In case of warm reboot or xcvrd restart, these fields prevent re-application of SI settings if the settings are already applied. In case of transceiver insertion, SI settings will be applied irrespective of the current status.  
+    - `si_settings_notification` in PORT_TABLE (APPL_DB): written by xcvrd to signal SI settings state. OA reads this via its normal ConsumerStateTable flow. Values: `SI_SETTINGS_NOTIFIED:<N>` (xcvrd has notified SI settings for sequence N), `SI_SETTINGS_DEFAULT:<N>` (transceiver removed or no SI settings needed for sequence N).
+    - `si_settings_ack` in PORT_TABLE (STATE_DB): written by OA to acknowledge SI settings state. xcvrd polls this field. Values: `SI_SETTINGS_DEFAULT:<N>` (OA acknowledged removal/reset), `SI_SYNC_DONE:<N>` (OA successfully applied SI settings for sequence N).  
+    A monotonically increasing counter `<N>` embedded in both fields ensures xcvrd can distinguish stale acknowledgments from prior insertions. In case of warm reboot or xcvrd restart, these fields prevent re-application of SI settings if the settings are already applied. In case of transceiver insertion, SI settings will be applied irrespective of the current status.
+    > **Note:** The counter `<N>` in `si_settings_notification` is used exclusively by xcvrd for restart-skip logic (`can_skip_cmis_init_after_restart`). Orchagent does not make any decisions based on the counter value — it simply echoes the same `<N>` back in `si_settings_ack` (e.g. `SI_SYNC_DONE:<N>`) to confirm it processed that specific notification. OA has no other use of the counter.  
   Also, this protocol prevents the additional link flap that would occur if CMIS state machine initialized a port before SI settings are applied (since applying SI settings involves disabling then re-enabling admin state, but without updating host_tx_ready).  
-In case of continuous restart of xcvrd, both the keys will still hold the same value as before the restart. This would ensure that the port re-initialization is resumed from the last known state.  
+In case of continuous restart of xcvrd, `CMIS_REINIT_REQUIRED`, `si_settings_notification` and `si_settings_ack` will still hold the same values as before the restart. This ensures that port re-initialization is resumed from the last known state.  
 
 Following infra will ensure port re-initialization by xcvrd in case of syncd/swss/orchagent crash  
 Pre-requisites for the infra to work:
@@ -213,20 +214,20 @@ Pre-requisites for the infra to work:
 
 1. XCVRD main thread init / Orchagent port init
 	- XCVRD main thread creates the key CMIS_REINIT_REQUIRED in PORT_TABLE|\<port\> (STATE_DB) with value as true for ports which do NOT have this key present 
-	- Orchagent initializes `si_settings_sync_status = SI_SETTINGS_DEFAULT:0` in PORT_TABLE|\<port\> (STATE_DB) for all ports during port initialization.  
-      - For transceivers which do not require NPU SI settings, `si_settings_sync_status` will remain at `SI_SETTINGS_DEFAULT:<N>`  
+	- Orchagent initializes `si_settings_ack = SI_SETTINGS_DEFAULT:0` in PORT_TABLE|\<port\> (STATE_DB) for all ports during port initialization.  
+      - For transceivers which do not require SI settings, `si_settings_ack` will remain at `SI_SETTINGS_DEFAULT:<N>`  
 
     The following tables describe the values for each SI settings field.  
 A transceiver is classified as CMIS SM driven transceiver if its module type is CMIS and it does not have flat memory  
 
-**APPL_DB PORT_TABLE `si_sync_status`** — written by xcvrd, read by Orchagent via ConsumerStateTable  
+**APPL_DB PORT_TABLE `si_settings_notification`** — written by xcvrd, read by Orchagent via ConsumerStateTable  
 
 | Value                        | Written by                                                                                                                                                                          | Purpose                                                                                   |
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | `SI_SETTINGS_DEFAULT:<N>`    | 1\. SfpStateUpdateTask during transceiver removal (increments N)<br>2. xcvrd during boot-up initialization                                                                          | Signals to OA that transceiver was removed or SI settings are in default state             |
 | `SI_SETTINGS_NOTIFIED:<N>`   | 1\. SfpStateUpdateTask for non-CMIS SM driven transceivers<br>2. CmisManagerTask for CMIS SM driven transceivers (written in CMIS_STATE_AP_CONF)                                   | Signals to OA that SI settings have been written to PORT_TABLE (APPL_DB) for sequence N   |
 
-**STATE_DB PORT_TABLE `si_settings_sync_status`** — written by Orchagent, read by xcvrd  
+**STATE_DB PORT_TABLE `si_settings_ack`** — written by Orchagent, read by xcvrd  
 
 | Value                   | Written by                                                                          | Purpose                                                                                                       |
 | ----------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
@@ -236,31 +237,39 @@ A transceiver is classified as CMIS SM driven transceiver if its module type is 
 
 
 2. Update and notify SI settings to OA  
-      The API `is_npu_si_settings_update_required` will return true if a module requires SI settings and `si_sync_status` in PORT_TABLE (APPL_DB) is absent or equals `SI_SETTINGS_DEFAULT:<N>`. It will return false if `si_sync_status == SI_SETTINGS_NOTIFIED:<N>` (i.e., already notified in this session).  
+      The API `is_npu_si_settings_update_required` will return true if a module requires SI settings and `si_settings_notification` in PORT_TABLE (APPL_DB) is absent or equals `SI_SETTINGS_DEFAULT:<N>`. It will return false if `si_settings_notification == SI_SETTINGS_NOTIFIED:<N>` (i.e., already notified in this session).  
 
-      For non-CMIS SM driven transceivers, if `is_npu_si_settings_update_required` returns true, SfpStateUpdateTask will update SI settings in PORT_TABLE (APPL_DB) and write `si_sync_status = SI_SETTINGS_NOTIFIED:<N>` to PORT_TABLE (APPL_DB). OA will be notified via the ConsumerStateTable mechanism.  
+      For non-CMIS SM driven transceivers, if `is_npu_si_settings_update_required` returns true, SfpStateUpdateTask will update SI settings in PORT_TABLE (APPL_DB) and write `si_settings_notification = SI_SETTINGS_NOTIFIED:<N>` to PORT_TABLE (APPL_DB). OA will be notified via the ConsumerStateTable mechanism.  
 
-      For CMIS SM driven transceivers, if `is_npu_si_settings_update_required` returns true, CmisManagerTask will update SI settings in PORT_TABLE (APPL_DB) and write `si_sync_status = SI_SETTINGS_NOTIFIED:<N>` to PORT_TABLE (APPL_DB) during CMIS_STATE_AP_CONF.  
+      For CMIS SM driven transceivers, if `is_npu_si_settings_update_required` returns true, CmisManagerTask will update SI settings in PORT_TABLE (APPL_DB) and write `si_settings_notification = SI_SETTINGS_NOTIFIED:<N>` to PORT_TABLE (APPL_DB) during CMIS_STATE_AP_CONF.  
       The CMIS SM will then transition from CMIS_STATE_AP_CONF to CMIS_STATE_SI_SETTINGS_WAIT. If port doesn't require SI settings, CMIS SM will transition to CMIS_STATE_DP_INIT state directly.  
 
 
 
-3. The OA upon receiving SI settings (via `si_sync_status` update in APPL_DB) will  
+3. The OA upon receiving SI settings (via `si_settings_notification` update in APPL_DB) will  
 	- Disable port admin status (without updating host_tx_ready, to avoid triggering xcvrd)
 	- Request SAI-SDK to apply the SI settings via syncd
-		- If SAI-SDK returns success, OA will write `si_settings_sync_status = SI_SYNC_DONE:<N>` to PORT_TABLE|\<port\> (STATE_DB), where N matches the notification number received
+		- If SAI-SDK returns success, OA will write `si_settings_ack = SI_SYNC_DONE:<N>` to PORT_TABLE|\<port\> (STATE_DB), where N matches the notification number received
 		- In case of failure, OA will log an error message and proceed to handling the next port
-	- If `si_sync_status == SI_SETTINGS_DEFAULT:<N>` is received (transceiver removed), OA writes `si_settings_sync_status = SI_SETTINGS_DEFAULT:<N>` to STATE_DB (no serdes programming)
+	- If `si_settings_notification == SI_SETTINGS_DEFAULT:<N>` is received (transceiver removed), OA writes `si_settings_ack = SI_SETTINGS_DEFAULT:<N>` to STATE_DB (no serdes programming)
 
-4. CMIS_STATE_SI_SETTINGS_WAIT state will wait for `SI_SYNC_DONE:<N>` in STATE_DB `si_settings_sync_status`, where N must match the notification number sent. Upon match, CMIS SM transitions to CMIS_STATE_DP_INIT state.  
+4. CMIS_STATE_SI_SETTINGS_WAIT state will wait for `SI_SYNC_DONE:<N>` in STATE_DB `si_settings_ack`, where N must match the notification number sent. Upon match, CMIS SM transitions to CMIS_STATE_DP_INIT state.  
 There will be a timeout of 10s; upon timeout, CMIS SM proceeds to CMIS_STATE_DP_INIT with a warning (no reinit)
 
-5. The CmisManagerTask thread will set “CMIS_REINIT_REQUIRED" to false after CMIS SM reaches to a steady state (CMIS_STATE_UNKNOWN, CMIS_STATE_FAILED, CMIS_STATE_READY and CMIS_STATE_REMOVED) for the corresponding port
+5. The CmisManagerTask thread will set “CMIS_REINIT_REQUIRED” to false after CMIS SM reaches to a steady state (CMIS_STATE_UNKNOWN, CMIS_STATE_FAILED, CMIS_STATE_READY and CMIS_STATE_REMOVED) for the corresponding port
+
+5a. **`can_skip_cmis_init_after_restart`**: When xcvrd restarts (process restart or warm reboot), CmisManagerTask checks whether full CMIS re-initialization can be skipped for a port. Skipping avoids an unnecessary link flap on already-configured ports. All four conditions must hold:
+    1. The desired application code matches what is currently programmed on the module (per-lane check).
+    2. SI settings are already synced — `si_settings_notification` in APPL_DB is `SI_SETTINGS_NOTIFIED:<N>` and `si_settings_ack` in STATE_DB is `SI_SYNC_DONE:<N>` with matching `<N>`.
+    3. All active host lanes report `ConfigSuccess` status.
+    4. All active host lanes are in `DataPathActivated` state.
+
+    If all four pass, the CMIS SM skips directly to `CMIS_STATE_READY`. If any check fails, normal CMIS initialization proceeds from `CMIS_STATE_INSERTED`.
 
 6. XCVRD will subscribe to PORT_TABLE in STATE_DB and trigger self-restart if the PORT_TABLE|Ethernet* is deleted for the namespace.  
 All threads will be gracefully terminated and xcvrd deinit will be performed followed by issuing a SIGABRT to ensure XCVRD is restarted automatically by supervisord. After respawn, CMIS re-init and SI settings notification is triggered for the ports belonging to the affected namespace
 
-7. syncd/swss/orchagent restart (restart triggered due to docker container crash) clears the entire APPL-DB and PORT_TABLE|Ethernet* of STATE_DB (including “si_settings_sync_status”, “si_sync_status” and “CMIS_REINIT_REQUIRED” keys in PORT_TABLE)
+7. syncd/swss/orchagent restart (restart triggered due to docker container crash) clears the entire APPL_DB and PORT_TABLE|Ethernet* of STATE_DB (including “si_settings_ack”, “si_settings_notification” and “CMIS_REINIT_REQUIRED” keys in PORT_TABLE)
 
 8. In case of warm reboot, the PORT_TABLE in STATE_DB is not cleared. Hence, once xcvrd is spawned after the device reboot, the ports are not initialized again.
 
@@ -281,7 +290,7 @@ sequenceDiagram
             XCVRDMT ->> STATE_DB: PORT_TABLE|<lport>.CMIS_REINIT_REQUIRED = true
         end
     end
-    Note over STATE_DB: PORT_TABLE|<lport><br>CMIS_REINIT_REQUIRED : true/false<br>si_settings_sync_status : SI_SETTINGS_DEFAULT:<N>/SI_SYNC_DONE:<N><br>(si_settings_sync_status initialized to SI_SETTINGS_DEFAULT:0 by Orchagent during port init)
+    Note over STATE_DB: PORT_TABLE|<lport><br>CMIS_REINIT_REQUIRED : true/false<br>si_settings_ack : SI_SETTINGS_DEFAULT:<N>/SI_SYNC_DONE:<N><br>(si_settings_ack initialized to SI_SETTINGS_DEFAULT:0 by Orchagent during port init)
     XCVRDMT ->> CmisManagerTask: Spawns
     XCVRDMT ->> DomInfoUpdateTask: Spawns
     XCVRDMT ->> SfpStateUpdateTask: Spawns
@@ -318,10 +327,10 @@ sequenceDiagram
         alt post_port_sfp_info_to_db != SFP_EEPROM_NOT_READY
              Note over SfpStateUpdateTask: post_port_dom_threshold_info_to_db
             opt if not is_module_cmis_sm_driven and is_npu_si_settings_update_required
-                SfpStateUpdateTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_sync_status = SI_SETTINGS_NOTIFIED:<N>
+                SfpStateUpdateTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_settings_notification = SI_SETTINGS_NOTIFIED:<N>
                 APPL_DB -->> OA: Notify SI settings for ports (via ConsumerStateTable)
                 Note over OA: Disable admin status (update_host_tx_ready=false)<br>setPortSerdesAttribute
-                OA ->> STATE_DB: PORT_TABLE|<lport>.si_settings_sync_status = SI_SYNC_DONE:<N>
+                OA ->> STATE_DB: PORT_TABLE|<lport>.si_settings_ack = SI_SYNC_DONE:<N>
                 Note over OA: initHostTxReadyState
             end
         else
@@ -361,16 +370,16 @@ stateDiagram-v2
         Ensure ModuleReady and DataPathDeactivated
         Configure ZR laser frequency
         Apply SI settings from media_settings.json
-        Write si_sync_status = SI_SETTINGS_NOTIFIED[N] to APPL_DB PORT_TABLE
+        Write si_settings_notification = SI_SETTINGS_NOTIFIED[N] to APPL_DB PORT_TABLE
         Call set_application
     end note
     CMIS_STATE_AP_CONF --> if_state3
-    if_state3 --> CMIS_STATE_SI_SETTINGS_WAIT : si_sync_status == SI_SETTINGS_NOTIFIED[N]
-    if_state3 --> CMIS_STATE_DP_INIT : si_sync_status not set or == SI_SETTINGS_DEFAULT
-    CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_DP_INIT : STATE_DB si_settings_sync_status == SI_SYNC_DONE[N]
+    if_state3 --> CMIS_STATE_SI_SETTINGS_WAIT : si_settings_notification == SI_SETTINGS_NOTIFIED[N]
+    if_state3 --> CMIS_STATE_DP_INIT : si_settings_notification not set or == SI_SETTINGS_DEFAULT
+    CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_DP_INIT : STATE_DB si_settings_ack == SI_SYNC_DONE[N]
     CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_DP_INIT : 10s timeout - proceed to DP_INIT with warning
     note right of CMIS_STATE_SI_SETTINGS_WAIT
-        Polls STATE_DB si_settings_sync_status for SI_SYNC_DONE[N]
+        Polls STATE_DB si_settings_ack for SI_SYNC_DONE[N]
         N must match the notification number sent in APPL_DB
         On 10s timeout proceed to DP_INIT with warning
     end note
@@ -393,10 +402,10 @@ sequenceDiagram
     SfpStateUpdateTask -x STATE_DB : Delete TRANSCEIVER_INFO table for the port
     par         CmisManagerTask, SfpStateUpdateTask
         CmisManagerTask ->> CmisManagerTask : Transition CMIS SM to CMIS_STATE_REMOVED
-        SfpStateUpdateTask ->> APPL_DB : PORT_TABLE|<lport>.si_sync_status = <br> SI_SETTINGS_DEFAULT:<N+1>
+        SfpStateUpdateTask ->> APPL_DB : PORT_TABLE|<lport>.si_settings_notification = <br> SI_SETTINGS_DEFAULT:<N+1>
     end
-    APPL_DB -->> OA: si_sync_status = SI_SETTINGS_DEFAULT:<N+1> (via ConsumerStateTable)
-    OA ->> STATE_DB : PORT_TABLE|<lport>.si_settings_sync_status = <br> SI_SETTINGS_DEFAULT:<N+1>
+    APPL_DB -->> OA: si_settings_notification = SI_SETTINGS_DEFAULT:<N+1> (via ConsumerStateTable)
+    OA ->> STATE_DB : PORT_TABLE|<lport>.si_settings_ack = <br> SI_SETTINGS_DEFAULT:<N+1>
 
     SfpStateUpdateTask ->> SfpStateUpdateTask : event = SFP_STATUS_INSERTED
     SfpStateUpdateTask ->> STATE_DB : Create TRANSCEIVER_INFO table for the port
@@ -404,19 +413,19 @@ sequenceDiagram
         CmisManagerTask ->> CmisManagerTask : Transition CMIS SM to CMIS_STATE_INSERTED
         CmisManagerTask ->> CmisManagerTask : Eventually, CMIS SM transitions to CMIS_STATE_AP_CONF
         opt not is_module_cmis_sm_driven and is_npu_si_settings_update_required
-          SfpStateUpdateTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_sync_status = SI_SETTINGS_NOTIFIED:<M>
+          SfpStateUpdateTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_settings_notification = SI_SETTINGS_NOTIFIED:<M>
         end
         opt is_module_cmis_sm_driven and is_npu_si_settings_update_required
-          CmisManagerTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_sync_status = SI_SETTINGS_NOTIFIED:<M>
+          CmisManagerTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_settings_notification = SI_SETTINGS_NOTIFIED:<M>
           CmisManagerTask ->> CmisManagerTask : Transition CMIS SM to CMIS_STATE_SI_SETTINGS_WAIT
         end
         activate OA
-        APPL_DB -->> OA: si_sync_status = SI_SETTINGS_NOTIFIED:<M> (via ConsumerStateTable)
+        APPL_DB -->> OA: si_settings_notification = SI_SETTINGS_NOTIFIED:<M> (via ConsumerStateTable)
         Note over OA: Disable admin status (update_host_tx_ready=false)<br>setPortSerdesAttribute
-        OA ->> STATE_DB: PORT_TABLE|<lport>.si_settings_sync_status = SI_SYNC_DONE:<M>
+        OA ->> STATE_DB: PORT_TABLE|<lport>.si_settings_ack = SI_SYNC_DONE:<M>
         Note over OA: initHostTxReadyState
         deactivate OA
-        CmisManagerTask ->> CmisManagerTask : Poll STATE_DB si_settings_sync_status == SI_SYNC_DONE:<M><br>Transition CMIS SM to CMIS_STATE_DP_INIT
+        CmisManagerTask ->> CmisManagerTask : Poll STATE_DB si_settings_ack == SI_SYNC_DONE:<M><br>Transition CMIS SM to CMIS_STATE_DP_INIT
     end
 ```
 
@@ -469,7 +478,7 @@ sequenceDiagram
 ## Test plan and expectation
 
 **Process and device crash/restart and interface config command handling testplan**  
-| Event          | STATE_DB_<asic_n> cleared | Xcvrd restarted | SI settings renotify | si_settings_sync_status (STATE_DB) on xcvrd boot-up for initialized transceiver | CMIS re-init triggered | Link flap |
+| Event          | STATE_DB_<asic_n> cleared | Xcvrd restarted | SI settings renotify | si_settings_ack (STATE_DB) on xcvrd boot-up for initialized transceiver | CMIS re-init triggered | Link flap |
 | -------------- | ------------------------ | --------------- | -------------------- | -------------------------------------------------------------------------------- | ---------------------- | --------- |
 | Xcvrd restart | N | Y | N | SI_SYNC_DONE:<N> | N | N |
 | Pmon restart | N | Y | N | SI_SYNC_DONE:<N> | N | N |
@@ -483,7 +492,7 @@ sequenceDiagram
 | config interface startup | N | N | N | SI_SYNC_DONE:<N> | N | N/A |
 
 **Transceiver OIR testplan**  
-| Event | STATE_DB_<asic_n> cleared | Xcvrd restarted | SI settings notified | si_settings_sync_status (STATE_DB) upon event completion | CMIS init triggered |
+| Event | STATE_DB_<asic_n> cleared | Xcvrd restarted | SI settings notified | si_settings_ack (STATE_DB) upon event completion | CMIS init triggered |
 | -------------- | ------------------------ | --------------- | -------------------- | --------------------------------------------------------- | ---------------------- |
 | Transceiver Removal | N | N | N (resets to DEFAULT) | SI_SETTINGS_DEFAULT:<N+1> | N/A |
 | Transceiver Insertion | N | N | Y | SI_SYNC_DONE:<M> | Y |

--- a/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
+++ b/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
@@ -339,34 +339,40 @@ sequenceDiagram
 The below state machine is a high level flow and doesn't capture details for states other than CMIS_STATE_AP_CONF and CMIS_STATE_SI_SETTINGS_WAIT  
 
 ```mermaid
-stateDiagram
+stateDiagram-v2
     [*] --> CMIS_STATE_INSERTED
     state if_state <<choice>>
     state if_state2 <<choice>>
     state if_state3 <<choice>>
     state if_state4 <<choice>>
     CMIS_STATE_INSERTED --> if_state
-    if_state --> CMIS_STATE_READY : if host_tx_ready != True or<br>admin_status != up<br> Action - disable TX
-    if_state --> if_state2 : if host_tx_ready == True and<br>admin_status == up
+    if_state --> CMIS_STATE_READY : if host_tx_ready != True or admin_status != up - Action disable TX
+    if_state --> if_state2 : if host_tx_ready == True and admin_status == up
     if_state2 --> if_state4 : if appl >= 1 and host_lanes_mask > 0 and SI_lanes_mask > 0
-    if_state2 --> CMIS_STATE_FAILED : if appl < 1 or <br>host_lanes_mask <= 0 or <br>SI_lanes_mask <= 0
+    if_state2 --> CMIS_STATE_FAILED : if appl < 1 or host_lanes_mask <= 0 or SI_lanes_mask <= 0
     note left of CMIS_STATE_FAILED : PORT_TABLE.port.CMIS_REINIT_REQUIRED = false
-    if_state4 --> CMIS_STATE_READY : if can_skip_cmis_init_after_restart<br>(app matches, SI synced, ConfigSuccess, DataPathActivated)
+    if_state4 --> CMIS_STATE_READY : if can_skip_cmis_init_after_restart (app matches, SI synced, ConfigSuccess, DataPathActivated)
     note left of CMIS_STATE_READY : PORT_TABLE.port.CMIS_REINIT_REQUIRED = false
-    if_state4 --> CMIS_STATE_DP_DEINIT : if PORT_TABLE.port.CMIS_REINIT_REQUIRED == true or<br>is_cmis_application_update_required
+    if_state4 --> CMIS_STATE_DP_DEINIT : if PORT_TABLE.port.CMIS_REINIT_REQUIRED == true or is_cmis_application_update_required
 
     CMIS_STATE_DP_DEINIT --> CMIS_STATE_AP_CONF
 
-    note left of CMIS_STATE_AP_CONF : Ensure current states are ModuleReady and DataPathDeactivated<br>Configure laser frequency for ZR module<br>Apply module SI settings<br>Write si_sync_status = SI_SETTINGS_NOTIFIED:<N> to PORT_TABLE (APPL_DB)<br>set_application
+    note left of CMIS_STATE_AP_CONF
+        Ensure ModuleReady and DataPathDeactivated
+        Configure ZR laser frequency
+        Apply SI settings from media_settings.json
+        Write si_sync_status = SI_SETTINGS_NOTIFIED[N] to APPL_DB PORT_TABLE
+        Call set_application
+    end note
     CMIS_STATE_AP_CONF --> if_state3
-    if_state3 --> CMIS_STATE_SI_SETTINGS_WAIT : if SI_SETTINGS_NOTIFIED:<N> was written to APPL_DB
-    if_state3 --> CMIS_STATE_DP_INIT : if SI settings not notified (no si_sync_status or SI_SETTINGS_DEFAULT)
-    CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_DP_INIT : if STATE_DB PORT_TABLE&ltport&gt.si_settings_sync_status == SI_SYNC_DONE:<N>
-    CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_DP_INIT : Upon 10s timeout, proceed to DP_INIT with warning
+    if_state3 --> CMIS_STATE_SI_SETTINGS_WAIT : si_sync_status == SI_SETTINGS_NOTIFIED[N]
+    if_state3 --> CMIS_STATE_DP_INIT : si_sync_status not set or == SI_SETTINGS_DEFAULT
+    CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_DP_INIT : STATE_DB si_settings_sync_status == SI_SYNC_DONE[N]
+    CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_DP_INIT : 10s timeout - proceed to DP_INIT with warning
     note right of CMIS_STATE_SI_SETTINGS_WAIT
-        Polls STATE_DB PORT_TABLE&ltport&gt.si_settings_sync_status for SI_SYNC_DONE:<N>
-        where N must match the notification number sent in APPL_DB
-        After 10s timeout, proceeds to CMIS_STATE_DP_INIT with a warning (no reinit)
+        Polls STATE_DB si_settings_sync_status for SI_SYNC_DONE[N]
+        N must match the notification number sent in APPL_DB
+        On 10s timeout proceed to DP_INIT with warning
     end note
     CMIS_STATE_DP_INIT --> CMIS_STATE_DP_TXON
     CMIS_STATE_DP_TXON --> CMIS_STATE_DP_ACTIVATE

--- a/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
+++ b/doc/sfp-cmis/Interface-Link-bring-up-sequence.md
@@ -36,7 +36,7 @@ Deterministic Approach for Interface Link bring-up sequence
 | 0.8 | 02/16/2022  | Shyam Kumar                        | Updated feature-enablement workflow
 | 0.9 | 04/05/2022  | Shyam Kumar                        | Addressed review comments           |
 | 1.0 | 10/20/2023  | Mihir Patel                        | Added Port re-initialization during syncd/swss/orchagent crash section           |
-| 1.1 | 04/28/2026  | Arpit Kumar                        | Redesigned SI settings sync: two-field protocol (APPL_DB si_settings_notification + STATE_DB si_settings_ack), monotonic counter, CMIS_STATE_SI_SETTINGS_WAIT state; notification moved to CMIS_STATE_INSERTED and SffManagerTask gated by notify_si_settings flag; SI_SETTINGS_WAIT timeout triggers force_cmis_reinit |
+| 1.1 | 04/28/2026  | Arpit Kumar                        | Redesigned SI settings sync: two-field protocol (APPL_DB si_settings_notification + STATE_DB si_settings_ack), CMIS_STATE_SI_SETTINGS_WAIT state; notification moved to CMIS_STATE_INSERTED and SffManagerTask gated by notify_si_settings flag; SI_SETTINGS_WAIT timeout triggers force_cmis_reinit |
 
 
 # About this Manual
@@ -224,7 +224,7 @@ A transceiver is classified as CMIS SM driven transceiver if its module type is 
 
 | Value                        | Written by                                                                                                                                                                          | Purpose                                                                                   |
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `SI_SETTINGS_DEFAULT:<N>`    | 1\. SfpStateUpdateTask during transceiver removal (increments N)<br>2. xcvrd during boot-up initialization                                                                          | Signals to OA that transceiver was removed or SI settings are in default state             |
+| `SI_SETTINGS_DEFAULT:<N>`    | 1\. SfpStateUpdateTask during transceiver removal (increments N)                                                                          | Signals to OA that transceiver was removed or SI settings are in default state             |
 | `SI_SETTINGS_NOTIFIED:<N>`   | 1\. SffManagerTask for non-CMIS SM driven transceivers (on module insertion)<br>2. CmisManagerTask for CMIS SM driven transceivers (written in CMIS_STATE_INSERTED when `notify_si_settings=True`) | Signals to OA that SI settings have been written to PORT_TABLE (APPL_DB) for sequence N   |
 
 **STATE_DB PORT_TABLE `si_settings_ack`** — written by Orchagent, read by xcvrd  
@@ -233,7 +233,7 @@ A transceiver is classified as CMIS SM driven transceiver if its module type is 
 | ----------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `SI_SETTINGS_DEFAULT:0` | Orchagent during port initialization                                                 | Initial state; indicates SI settings have not been applied                                                    |
 | `SI_SETTINGS_DEFAULT:<N>` | Orchagent upon receiving `SI_SETTINGS_DEFAULT:<N>` from xcvrd via APPL_DB         | Acknowledges transceiver removal; used by xcvrd on restart to determine update is needed                      |
-| `SI_SYNC_DONE:<N>`      | Orchagent after successfully applying serdes settings for sequence N                | CmisManagerTask checks this in CMIS_STATE_SI_SETTINGS_WAIT to proceed to CMIS_STATE_DP_INIT; also used by `can_skip_cmis_init_after_restart` to verify SI settings are already applied |
+| `SI_SYNC_DONE:<N>`      | Orchagent after successfully applying serdes settings for sequence N                | CmisManagerTask checks this in CMIS_STATE_SI_SETTINGS_WAIT to proceed to CMIS_STATE_DP_INIT |
 
 
 2. Update and notify SI settings to OA  
@@ -250,9 +250,9 @@ A transceiver is classified as CMIS SM driven transceiver if its module type is 
 
 
 3. The OA upon receiving SI settings (via `si_settings_notification` update in APPL_DB) will  
-	- Disable port admin status (without updating host_tx_ready, to avoid triggering xcvrd)
+	- Disable host port if cached admin_state is up (without updating host_tx_ready, to avoid triggering xcvrd)
 	- Request SAI-SDK to apply the SI settings via syncd
-		- If SAI-SDK returns success, OA will write `si_settings_ack = SI_SYNC_DONE:<N>` to PORT_TABLE|\<port\> (STATE_DB), where N matches the notification number received
+		- If SAI-SDK returns success, OA will write `si_settings_ack = SI_SYNC_DONE:<N>` to PORT_TABLE|\<port\> (STATE_DB), where N matches the notification number received, then the OA will enable the host port (depends on the admin_state flag)
 		- In case of failure, OA will log an error message and proceed to handling the next port
 	- If `si_settings_notification == SI_SETTINGS_DEFAULT:<N>` is received (transceiver removed), OA writes `si_settings_ack = SI_SETTINGS_DEFAULT:<N>` to STATE_DB (no serdes programming)
 
@@ -359,10 +359,10 @@ sequenceDiagram
         opt xcvr_inserted (TRANSCEIVER_INFO SET) and not is_cmis_api
             SffManagerTask ->> SffManagerTask: sfp.get_transceiver_info()
             opt is_npu_si_settings_update_required
-                SffManagerTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_settings_notification = SI_SETTINGS_NOTIFIED:<N>
+                SffManagerTask ->> APPL_DB: Update SI params from media_settings.json to PORT_TABLE:<lport><br>si_settings_notification = SI_SETTINGS_NOTIFIED:<N+1>
                 APPL_DB -->> OA: Notify SI settings (via ConsumerStateTable)
                 Note over OA: Disable admin status (update_host_tx_ready=false)<br>setPortSerdesAttribute
-                OA ->> STATE_DB: PORT_TABLE|<lport>.si_settings_ack = SI_SYNC_DONE:<N>
+                OA ->> STATE_DB: PORT_TABLE|<lport>.si_settings_ack = SI_SYNC_DONE:<N+1>
                 Note over OA: initHostTxReadyState
             end
         end
@@ -384,19 +384,18 @@ stateDiagram-v2
     CMIS_STATE_INSERTED --> if_state
     note right of CMIS_STATE_INSERTED
         If notify_si_settings=True (module insertion or SI failure reinit):
-          Read transceiver info via api
           Write SI params + si_settings_notification = SI_SETTINGS_NOTIFIED[N] to APPL_DB
-          Reset notify_si_settings = False
     end note
     if_state --> CMIS_STATE_READY : if host_tx_ready != True or admin_status != up - Action disable TX
     if_state --> if_state2 : if host_tx_ready == True and admin_status == up
-    if_state2 --> if_state4 : if appl >= 1 and host_lanes_mask > 0 and SI_lanes_mask > 0
+    if_state2 --> CMIS_STATE_DP_PRE_INIT_CHECK : if appl >= 1 and host_lanes_mask > 0 and SI_lanes_mask > 0
     if_state2 --> CMIS_STATE_FAILED : if appl < 1 or host_lanes_mask <= 0 or SI_lanes_mask <= 0
     note left of CMIS_STATE_FAILED : PORT_TABLE.port.CMIS_REINIT_REQUIRED = false
+
+    CMIS_STATE_DP_PRE_INIT_CHECK --> if_state4
     if_state4 --> CMIS_STATE_READY : if can_skip_cmis_init_after_restart (app matches, SI synced, ConfigSuccess, DataPathActivated)
     note left of CMIS_STATE_READY : PORT_TABLE.port.CMIS_REINIT_REQUIRED = false
     if_state4 --> CMIS_STATE_DP_DEINIT : if PORT_TABLE.port.CMIS_REINIT_REQUIRED == true or is_cmis_application_update_required
-
     CMIS_STATE_DP_DEINIT --> CMIS_STATE_AP_CONF
 
     note left of CMIS_STATE_AP_CONF
@@ -409,7 +408,7 @@ stateDiagram-v2
     if_state3 --> CMIS_STATE_SI_SETTINGS_WAIT : si_settings_notification == SI_SETTINGS_NOTIFIED[N] in APPL_DB
     if_state3 --> CMIS_STATE_DP_INIT : si_settings_notification not set or == SI_SETTINGS_DEFAULT
     CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_DP_INIT : STATE_DB si_settings_ack == SI_SYNC_DONE[N]
-    CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_INSERTED : 10s timeout - reset si_settings_notification to DEFAULT,\nset notify_si_settings=True, force_cmis_reinit(retries+1)
+    CMIS_STATE_SI_SETTINGS_WAIT --> CMIS_STATE_INSERTED : Timeout - reset si_settings_notification to DEFAULT,set notify_si_settings=True, force_cmis_reinit(retries+1)
     note right of CMIS_STATE_SI_SETTINGS_WAIT
         Polls STATE_DB si_settings_ack for SI_SYNC_DONE[N]
         N must match the notification number sent in APPL_DB


### PR DESCRIPTION
Updated Interface link up sequence with SI settings sync between orchagent and xcvrd

| PR title | state | context |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| [[sonic-swss] [orchagent]: SI settings sync protocol between xcvrd and orchagent](https://github.com/sonic-net/sonic-swss/pull/4497) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-swss/4497) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-swss/4497) |
| [SI settings sync protocol between xcvrd and orchagent](https://github.com/sonic-net/sonic-platform-daemons/pull/799) | ![GitHub issue/pull request detail](https://img.shields.io/github/pulls/detail/state/Azure/sonic-platform-daemons/799) | ![GitHub pull request check contexts](https://img.shields.io/github/status/contexts/pulls/Azure/sonic-platform-daemons/799) |

