### PR TITLE
Add HLD for Console Mirror Feature

### DIFF
--- a/doc/console/Console-Mirror-High-Level-Design.md
+++ b/doc/console/Console-Mirror-High-Level-Design.md
@@ -111,38 +111,44 @@ The design extends the existing console monitor DCE architecture. The per-line p
 
 ```mermaid
 flowchart LR
-    userA["User A<br/>consutil connect 1"]
-    pts["PTS<br/>/dev/ttyUSB1-PTS"]
-    ptm["PTM<br/>/dev/ttyUSB1-PTM"]
-    proxy["Per-line proxy<br/>console-monitor-proxy@1"]
-    tty["Physical TTY<br/>/dev/ttyUSB1"]
     target["Managed device<br/>serial console"]
+    tty["Physical TTY<br/>/dev/ttyUSB1"]
 
-    userA <-- "interactive console" --> pts
-    pts <-- "PTY bridge" --> ptm
-    ptm <-- "normal TX/RX stream" --> proxy
-    proxy <-- "serial stream" --> tty
-    tty <-- "physical serial" --> target
-
-    subgraph MirrorPath["Mirror side path inside DCE"]
+    subgraph proxyBox["Per-line proxy process (console-monitor-proxy@1)"]
+        core["Existing proxy forwarding logic"]
         mirror["MirrorManager"]
         writer["RecordingWriter"]
-        log["Secure text logs<br/>/var/log/sonic/console-mirror/..."]
         state["STATE_DB<br/>CONSOLE_MIRROR|1"]
+        control["MirrorControlServer<br/>/run/console-monitor/mirror/line1.sock"]
+        display["DisplaySink"]
+        log["Text logs<br/>/var/log/sonic/console-mirror/..."]
     end
 
-    proxy -. "best-effort RX/TX copy" .-> mirror
+    ptm["PTM<br/>/dev/ttyUSB1-PTM"]
+    pts["PTS<br/>/dev/ttyUSB1-PTS"]
+    userA["User A<br/>consutil connect 1"]
+
+    
+
+    target <-- "physical serial" --> tty
+    tty <-- "serial stream" --> core
+
+    core <-- "normal TX/RX stream" --> ptm
+    ptm <-- "PTY bridge" --> pts
+    pts <-- "interactive console" --> userA
+
+    core -->|best-effort RX/TX copy| mirror
+
     mirror --> writer
     writer --> log
     mirror --> state
+    mirror --> display
 
-    userB["User B<br/>sudo consutil mirror start 1"]
-    uds["MirrorControlServer<br/>/run/console-monitor/mirror/line1.sock"]
+    control -->|start / stop / status / attach-display| mirror
 
-    userB <-- "start / stop / status" --> uds
-    uds --> mirror
-    mirror -. "optional escaped live display" .-> uds
-    uds -. "display stream" .-> userB
+    userB["User B<br/>sudo consutil mirror start 1 --display"]
+    userB -. "UDS control messages" .-> control
+    display -. "UDS display stream" .-> userB
 ```
 
 ### 2.2 Design Principles
@@ -222,7 +228,7 @@ For accepted records, `MirrorManager` creates a mirror record containing timesta
 * `RecordingWriter`, if recording is active.
 * `DisplaySink`, if live display is attached.
 
-Writer submission is best effort. If the writer queue is full, `MirrorManager` increments `pending_writer_drop_count`, writes a syslog warning, and does not block the forwarding loop. When the writer queue later accepts records again, `MirrorManager` emits one `EVENT` record with `reason=writer_queue_full` and the accumulated `dropped_records` value before recording subsequent data records.
+Writer submission is best effort. If the writer queue is full, `MirrorManager` increments `pending_writer_drop_count`, writes a syslog warning, and does not block the forwarding loop. When the writer queue later accepts records again, `MirrorManager` emits one `EVENT` record with `reason=writer_queue_full` and the accumulated `pending_writer_drop_count` value before recording subsequent data records.
 
 Display submission is also best effort. If the display queue is full, the display record is dropped and a syslog warning is written.
 
@@ -280,7 +286,7 @@ Only one `DisplaySink` is allowed per line. If a display sink is already attache
 
 | Resource | Description |
 |----------|-------------|
-| UDS connection | Connection back to the `consutil mirror start --display` process |
+| UDS connection | Accepted client connection from the `MirrorControlServer` back to the `consutil mirror start --display` process |
 | Display queue | Bounded queue receiving display records from `MirrorManager` |
 | Display task/thread | Background execution context that sends records to the CLI |
 

--- a/doc/console/Console-Mirror-High-Level-Design.md
+++ b/doc/console/Console-Mirror-High-Level-Design.md
@@ -26,7 +26,8 @@
     - [3.1 Proxy Changes](#31-proxy-changes)
       - [3.1.1 MirrorManager](#311-mirrormanager)
       - [3.1.2 RecordingWriter](#312-recordingwriter)
-      - [3.1.3 MirrorControlServer](#313-mirrorcontrolserver)
+      - [3.1.3 RecordingArchiver](#313-recordingarchiver)
+      - [3.1.4 MirrorControlServer](#314-mirrorcontrolserver)
     - [3.2 Mirror Control Message Protocol](#32-mirror-control-message-protocol)
     - [3.3 RX Mirroring](#33-rx-mirroring)
     - [3.4 TX Mirroring](#34-tx-mirroring)
@@ -37,7 +38,6 @@
       - [3.5.4 Data Record Lines](#354-data-record-lines)
       - [3.5.5 Event Lines](#355-event-lines)
       - [3.5.6 Payload Escaping Rules](#356-payload-escaping-rules)
-      - [3.5.7 Conversion Utility](#357-conversion-utility)
     - [3.6 Error Handling](#36-error-handling)
     - [3.7 Service Lifecycle](#37-service-lifecycle)
       - [Proxy Startup](#proxy-startup)
@@ -52,7 +52,6 @@
     - [5.1 Start Mirroring](#51-start-mirroring)
     - [5.2 Stop Mirroring](#52-stop-mirroring)
     - [5.3 Show Mirror Status](#53-show-mirror-status)
-    - [5.4 Export Recording](#54-export-recording)
   - [6. Example Workflow](#6-example-workflow)
     - [6.1 Manual Stop](#61-manual-stop)
     - [6.2 Automatic Stop](#62-automatic-stop)
@@ -98,6 +97,7 @@ The feature provides the following capabilities:
 * Support configurable timestamp resolution.
 * Allow only one mirror owner per line.
 * Automatically stop each mirror session after a finite timeout, defaulting to 24 hours.
+* Package all rotated log parts into one ZIP archive after recording stops.
 
 ---
 
@@ -116,9 +116,10 @@ flowchart LR
         core["Existing proxy forwarding logic"]
         mirror["MirrorManager"]
         writer["RecordingWriter"]
+        archiver["RecordingArchiver"]
         state["STATE_DB<br/>CONSOLE_MIRROR|1"]
         control["MirrorControlServer<br/>/run/console-monitor/mirror/line1.sock"]
-        log["Text logs<br/>/var/log/sonic/console-mirror/..."]
+        files["Recording files<br/>.log parts and final .zip"]
     end
 
     ptm["PTM<br/>/dev/ttyUSB1-PTM"]
@@ -135,10 +136,13 @@ flowchart LR
     core -->|best-effort RX/TX copy| mirror
 
     mirror --> writer
-    writer --> log
+    writer --> files
+    mirror -->|"closed recording prefix"| archiver
+    archiver -->|"package and delete source parts"| files
     mirror --> state
 
     control -->|start / stop / status| mirror
+    archiver -. "completion future" .-> control
 
     userB["User B<br/>start / stop / show"]
 
@@ -151,6 +155,7 @@ flowchart LR
 * **Single active mirror owner** - At most one mirror session can be active per line.
 * **Best-effort observability** - Recording should be reliable under normal operation, but slow disk I/O must not block the proxy data path.
 * **Bounded lifetime** - Every mirror session has a finite auto-stop timeout. The default timeout is 24 hours.
+* **Asynchronous finalization** - A stopped mirror becomes idle before archive creation completes. Archiving runs outside the serial forwarding path.
 * **Text-first storage** - The recording format is a line-oriented UTF-8 text log. Printable characters are written as text, while control bytes, ANSI escape bytes, and invalid UTF-8 bytes are represented using printable escape sequences.
 * **Minimal architecture change** - The existing PTY Bridge and `consutil connect` model are retained.
 * **Operational state only** - Mirror configuration is not persisted and is not restored after reboot.
@@ -183,9 +188,10 @@ The proxy adds the following internal components:
 |-----------|-------------|
 | `MirrorManager` | Maintains mirror session state |
 | `RecordingWriter` | Writes text records to the local file |
+| `RecordingArchiver` | Packages all recording parts for a stopped session into one ZIP archive and removes the source parts after success |
 | `MirrorControlServer` | Per-line UDS endpoint for start, stop, and status commands |
 
-The proxy main loop must keep serial forwarding as the highest priority. Mirroring work is offloaded to bounded queues and writer tasks.
+The proxy main loop must keep serial forwarding as the highest priority. Recording and archive work is offloaded to bounded queues and background tasks.
 
 #### 3.1.1 MirrorManager
 
@@ -204,25 +210,27 @@ The proxy main loop must keep serial forwarding as the highest priority. Mirrori
 | `timer` | Active auto-stop timer |
 | `file_path` | Current recording file path under the fixed secure directory |
 | `writer` | Active `RecordingWriter`, if a session is active |
-| `pending_writer_drop_count` | Number of writer records dropped since the last recorded drop event |
+| `writer_drop_count` | Number of writer records dropped since the last recorded drop event |
 
 `MirrorManager` exposes internal methods to the proxy and `MirrorControlServer`:
 
 | Method | Caller | Description |
 |--------|--------|-------------|
 | `start(options)` | `MirrorControlServer` | Validate options, create session metadata and `RecordingWriter`, set the auto-stop timer, update STATE_DB |
-| `stop(reason)` | `MirrorControlServer` or auto-stop timer | Write stop event, cancel the timer, stop writer, set STATE_DB state to `idle`, and retain the final file path |
+| `stop(reason)` | `MirrorControlServer` or auto-stop timer | Stop recording, set STATE_DB state to `idle`, submit an immutable archive job, and return its completion future |
 | `status()` | `MirrorControlServer` | Return current line mirror state |
 | `submit(direction, payload)` | Proxy forwarding loop | Best-effort submit of RX/TX data to the recording writer |
 
 The proxy forwarding loop calls `MirrorManager.submit()` after it observes console bytes on the RX or TX path. `submit()` must be non-blocking from the proxy's perspective. If mirroring is idle, the method returns immediately. If the active session does not include the submitted direction, the method returns immediately.
 
 
-Writer submission is best effort. If the writer queue is full, `MirrorManager` increments `pending_writer_drop_count`, writes a syslog warning, and does not block the forwarding loop. When the writer queue later accepts records again, `MirrorManager` emits one `EVENT` record with `reason=writer_queue_full` and the accumulated `pending_writer_drop_count` value before recording subsequent data records.
+Writer submission is best effort. If the writer queue is full, `MirrorManager` increments `writer_drop_count` and does not block the forwarding loop. When the writer queue later accepts records again, `MirrorManager` emits one `EVENT` record with `reason=writer_queue_full` and the accumulated `writer_drop_count` value before recording subsequent data records.
 
 When a session starts, `MirrorManager` calculates a monotonic deadline from the configured timeout and sets the `timer`. A monotonic clock prevents wall-clock adjustments from extending or shortening the recording unexpectedly. When the deadline expires, the timer invokes `stop(reason="timeout")`. Manual stop invokes the same shutdown path with `reason="manual"` and cancels the timer.
 
 The transition from `active` to `stopping` is atomic. If a manual stop races with timer expiration, only the caller that performs this transition executes the shutdown sequence; the other caller returns the resulting session state. This prevents duplicate stop events and double-closing the writer.
+
+After the writer is closed, `MirrorManager` creates an immutable archive job containing the line, direction, recording start timestamp, recording filename prefix, expected ZIP path, and stop reason. The manager submits this job to `RecordingArchiver` and immediately transitions the mirror state to `idle`. The archiver does not read mutable fields from the next mirror session.
 
 #### 3.1.2 RecordingWriter
 
@@ -268,7 +276,45 @@ Writer shutdown sequence:
 
 If the writer encounters a fatal file error, for example disk full or write failure, it reports the error to `MirrorManager`. `MirrorManager` stops the recording session, updates STATE_DB state, and leaves the console forwarding path running.
 
-#### 3.1.3 MirrorControlServer
+#### 3.1.3 RecordingArchiver
+
+`RecordingArchiver` runs archive jobs in a background execution context after recording has stopped. It does not run in the serial forwarding path and does not keep the mirror state active.
+
+All parts belonging to one recording share the same filename prefix:
+
+```text
+console-mirror-line<line>-<direction>-<UTC start timestamp>
+```
+
+For example, the archiver packages:
+
+```text
+console-mirror-line1-both-20260613T141200Z-part0001.log
+console-mirror-line1-both-20260613T141200Z-part0002.log
+console-mirror-line1-both-20260613T141200Z-part0003.log
+```
+
+into:
+
+```text
+console-mirror-line1-both-20260613T141200Z.zip
+```
+
+Archive sequence:
+
+1. Enumerate only regular `.log` files in the per-line directory that exactly match the immutable recording prefix and `-partNNNN.log` suffix.
+2. Sort source files by part number and verify that the expected parts are readable.
+3. Create the archive as `<archive_path>.tmp` using exclusive creation, with owner `root:root` and mode `0600`.
+4. Add each source part to the ZIP using its base filename.
+5. Close and validate the ZIP, then atomically rename the temporary archive to the expected `.zip` path.
+6. Only after the final ZIP exists successfully, delete the original `.log` parts.
+7. Complete the job future with the final archive path or an error.
+
+If archive creation fails, `RecordingArchiver` deletes the incomplete `.zip.tmp` file and preserves all source logs. Archive status and archive paths are not written to STATE_DB.
+
+Because the mirror state is already `idle`, a new mirror may start while a previous archive job is running. Recording start timestamps used in filenames must be unique for a line; the implementation uses sufficient fractional UTC precision and exclusive file creation to prevent a new session from reusing an archive job's prefix.
+
+#### 3.1.4 MirrorControlServer
 
 `MirrorControlServer` is the local IPC endpoint used by `consutil mirror` to control the in-process `MirrorManager`. It is created by each per-line proxy during startup.
 
@@ -290,13 +336,13 @@ The socket is created with restrictive permissions so only Admin/root users can 
 * No mirror session is already active when processing `start`.
 * A mirror session is active when processing `stop`.
 
-After validation, `MirrorControlServer` calls the corresponding `MirrorManager` method. It returns structured success or error responses to the CLI. For example, `start` returns the secure recording file path; `status` returns current STATE_DB-equivalent runtime metadata; `stop` returns the final file path.
+After validation, `MirrorControlServer` calls the corresponding `MirrorManager` method. For `start` and `status`, it returns one structured response. For manual `stop`, it sends an initial packaging response after recording has stopped, then keeps the UDS connection open until the archive future completes and sends a final response.
 
 `MirrorControlServer` must not perform disk I/O or serial I/O itself. It only validates control messages, enforces access policy, and invokes `MirrorManager`.
 
 ### 3.2 Mirror Control Message Protocol
 
-This section defines the message protocol used on the `MirrorControlServer` UDS described in [MirrorControlServer](#313-mirrorcontrolserver). Control messages are JSON objects framed with a 4-byte big-endian length prefix:
+This section defines the message protocol used on the `MirrorControlServer` UDS described in [MirrorControlServer](#314-mirrorcontrolserver). Control messages are JSON objects framed with a 4-byte big-endian length prefix:
 
 ```json
 {
@@ -323,7 +369,7 @@ Supported control operations:
 | `stop` | Stop the active mirror session |
 | `status` | Return current mirror state for the line |
 
-The response is also a length-prefixed JSON object. Successful responses include `status: "ok"` and operation-specific fields. Error responses include `status: "error"`, a machine-readable `code`, and a human-readable `message`.
+Each response is also a length-prefixed JSON object. Successful responses include a status and operation-specific fields. Error responses include `status: "error"`, a machine-readable `code`, and a human-readable `message`.
 
 Example success response for `start`:
 
@@ -345,6 +391,27 @@ Example error response when a mirror session is already active:
   "message": "Line 1 already has an active mirror session"
 }
 ```
+
+A manual `stop` produces two responses on the same UDS connection. The first response confirms that mirroring has ended and gives the expected archive location:
+
+```json
+{
+  "status": "packaging",
+  "message": "Mirror stopped; packaging recording",
+  "archive_path": "/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z.zip"
+}
+```
+
+The CLI prints this information and continues waiting on the socket. When packaging completes, the server sends:
+
+```json
+{
+  "status": "ok",
+  "archive_path": "/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z.zip"
+}
+```
+
+If the CLI disconnects while waiting, `MirrorControlServer` drops only the response subscription. The background archive job continues unchanged. If packaging fails, the final response uses `status: "error"` and reports that the original log parts were preserved.
 
 ### 3.3 RX Mirroring
 
@@ -396,6 +463,12 @@ Per-line recording path:
 /var/log/sonic/console-mirror/line<line>/console-mirror-line<line>-<direction>-<UTC timestamp>-part<part>.log
 ```
 
+Final archive path:
+
+```text
+/var/log/sonic/console-mirror/line<line>/console-mirror-line<line>-<direction>-<UTC timestamp>.zip
+```
+
 Example:
 
 ```text
@@ -411,8 +484,11 @@ The proxy is responsible for creating the base directory and per-line subdirecto
 | `/var/log/sonic/console-mirror/` | `root:root` | `0700` | Base directory for all mirror recordings |
 | `/var/log/sonic/console-mirror/line<line>/` | `root:root` | `0700` | Per-line recording directory |
 | `console-mirror-line<line>-<direction>-<timestamp>-part<part>.log` | `root:root` | `0600` | Recording file |
+| `console-mirror-line<line>-<direction>-<timestamp>.zip` | `root:root` | `0600` | Completed recording archive |
 
 The `<direction>` field is `rx`, `tx`, or `both`, matching the direction selected when the recording starts.
+
+The timestamp token identifies one recording and must be unique within a line directory. If another recording starts within the same second, the implementation includes fractional UTC digits in the token. Every part and the final ZIP for that recording use the same token.
 
 #### 3.5.2 File Rotation
 
@@ -544,17 +620,6 @@ The writer applies a deterministic printable escaping function to each payload:
 
 This keeps normal console text readable while preventing terminal control sequences from changing the viewer's terminal state. For example, the ANSI clear-screen sequence is written as `\x1b[2J` rather than being emitted as a literal ESC byte.
 
-#### 3.5.7 Conversion Utility
-
-A conversion utility may still be provided for structured processing:
-
-```bash
-sudo consutil mirror export console-mirror-line1-both-20260613T141200Z-part0001.log --format json
-sudo consutil mirror export console-mirror-line1-both-20260613T141200Z-part0001.log --format raw-text
-```
-
-JSON export parses the text log and preserves direction, timestamp, original byte length, and escaped payload. Raw-text export can drop metadata and print only the payload stream for quick inspection.
-
 ### 3.6 Error Handling
 
 The mirror implementation must not block or terminate the active console session because of recording errors.
@@ -566,6 +631,10 @@ The mirror implementation must not block or terminate the active console session
 | Auto-stop timer setup failure | Reject `start` and close any newly opened recording file |
 | Disk full | Stop recording, update STATE_DB, keep console forwarding |
 | Writer queue full | Drop mirror records, record a drop event when the writer queue recovers, keep forwarding |
+| ZIP creation failure | Preserve every source `.log` part, remove the incomplete `.zip.tmp`, and return an error to a waiting CLI |
+| Source log deletion failure | Keep the valid ZIP, report the undeleted source paths, and do not treat archive contents as lost |
+| Stop CLI disconnect | Continue the archive job; only the final completion notification is lost |
+| Proxy exits during packaging | Preserve source logs; an incomplete temporary ZIP is not considered a completed archive |
 | Proxy restart | Stop current mirror session and mark state `idle` after restart |
 
 The writer queue should be bounded. When the queue is full, new mirror records are dropped rather than blocking the proxy. A drop event is inserted when the queue becomes writable again.
@@ -595,18 +664,25 @@ The writer queue should be bounded. When the queue is full, new mirror records a
 2. Proxy cancels the auto-stop timer.
 3. Proxy writes a stop event with `reason=manual` to the recording file.
 4. Proxy drains the queue, flushes, and closes the writer.
-5. Proxy sets the mirror state to `idle` after the final recording bytes are durable and retains the final `file_path` in STATE_DB.
+5. Proxy creates an immutable archive job and expected ZIP path from the stopped recording prefix.
+6. Proxy sets the mirror state to `idle` and clears active recording fields, including `file_path`, from STATE_DB.
+7. `MirrorControlServer` sends the `packaging` response. The CLI prints that mirroring has stopped and displays the expected ZIP path, then waits for another framed response.
+8. `RecordingArchiver` packages all matching part files asynchronously.
+9. When the future completes, `MirrorControlServer` sends the final archive path or error to the waiting CLI.
+
+The mirror is already idle during steps 7 through 9, so another mirror can start without waiting for packaging. A CLI process terminated during this wait does not cancel the archive job.
 
 #### Automatic Mirror Stop
 
 1. The monotonic auto-stop deadline expires.
 2. `MirrorManager` invokes the same stop path used by the CLI with `reason=timeout`.
 3. Proxy writes the timeout stop event, drains the queue, flushes, and closes the writer.
-4. Proxy updates STATE_DB state to `idle` and retains the final recording metadata and file path.
+4. Proxy submits the archive job and updates STATE_DB state to `idle`, clearing active recording fields.
+5. `RecordingArchiver` packages the stopped recording in the background. There is no waiting CLI, so completion is recorded only in process logs.
 
 #### Proxy Shutdown
 
-On proxy shutdown, the auto-stop timer is cancelled and the mirror writer receives a stop event and flushes the recording file if possible. STATE_DB is updated to show the mirror session is no longer active. Because no mirror configuration is stored in CONFIG_DB, the session is not restored when the proxy or device starts again.
+On proxy shutdown, the auto-stop timer is cancelled and the mirror writer receives a stop event and flushes the recording file if possible. STATE_DB is updated to show the mirror session is no longer active. In-progress archive tasks are allowed a bounded shutdown interval; if they cannot finish, source logs are preserved. Because no mirror configuration is stored in CONFIG_DB, the session is not restored when the proxy or device starts again.
 
 ---
 
@@ -627,7 +703,7 @@ Runtime state is stored in STATE_DB.
 | `CONSOLE_MIRROR\|<line>` | `started_by` | username | User that started mirroring |
 | `CONSOLE_MIRROR\|<line>` | `start_time` | Unix timestamp | Mirror start time |
 | `CONSOLE_MIRROR\|<line>` | `timeout` | positive integer seconds | Configured auto-stop timeout |
-| `CONSOLE_MIRROR\|<line>` | `file_path` | path | Current recording file path |
+| `CONSOLE_MIRROR\|<line>` | `file_path` | path | Current active recording part; cleared when recording stops |
 | `CONSOLE_MIRROR\|<line>` | `direction` | `rx` / `tx` / `both` | Mirrored direction |
 | `CONSOLE_MIRROR\|<line>` | `resolution` | `us` / `ms` | Timestamp resolution |
 
@@ -657,7 +733,7 @@ admin@sonic:~$ sonic-db-cli STATE_DB HGETALL "CONSOLE_MIRROR|1"
 
 ## 5. CLI
 
-The CLI is added under `consutil` because it operates on console lines and manages recording lifecycle and export.
+The CLI is added under `consutil` because it operates on console lines and manages recording lifecycle.
 
 CLI permission requirements:
 
@@ -666,7 +742,6 @@ CLI permission requirements:
 | `consutil mirror start` | Admin/root | Starts a sensitive recording and creates a protected log file |
 | `consutil mirror stop` | Admin/root | Stops an active recording session |
 | `consutil mirror show` | Admin/root | Exposes active recording metadata, including recording file path |
-| `consutil mirror export` | Admin/root | Reads protected recording files |
 
 ### 5.1 Start Mirroring
 
@@ -721,9 +796,14 @@ sudo consutil mirror stop 1
 Expected output:
 
 ```text
-Stopped mirror on line [1]
-Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
+Stopped mirror on line [1]; packaging recording
+Expected archive: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z.zip
+Waiting for packaging to complete...
+
+Recording archive: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z.zip
 ```
+
+After printing the expected archive path, the CLI remains blocked waiting for the final server response. Interrupting or terminating the CLI does not cancel packaging.
 
 ### 5.3 Show Mirror Status
 
@@ -738,18 +818,6 @@ Line  State   Direction  Timeout  Stop Time             File
 ----  ------  ---------  -------  --------------------  ----
 1     active  both       24h      2026-06-14T14:12:00Z  /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
 2     idle    -          -        -                     -
-```
-
-### 5.4 Export Recording
-
-```bash
-sudo consutil mirror export <file> --format {json,raw-text}
-```
-
-Example:
-
-```bash
-sudo consutil mirror export /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log --format json
 ```
 
 ---
@@ -779,8 +847,11 @@ User B stops recording:
 
 ```bash
 admin@sonic:~$ sudo consutil mirror stop 1
-Stopped mirror on line [1]
-Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
+Stopped mirror on line [1]; packaging recording
+Expected archive: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z.zip
+Waiting for packaging to complete...
+
+Recording archive: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z.zip
 ```
 
 ### 6.2 Automatic Stop
@@ -801,6 +872,12 @@ If no manual stop is issued, the proxy stops the mirror automatically when the d
 2026-06-14T14:12:00.000000Z +086400000000us 00001000 EVENT 00000035 {"event":"stop","reason":"timeout"}
 ```
 
+The proxy then packages all parts into:
+
+```text
+/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z.zip
+```
+
 ---
 
 ## 7. Security Considerations
@@ -809,13 +886,14 @@ Console mirror recordings are highly sensitive. They may contain credentials, bo
 
 Security requirements:
 
-* Starting, stopping, showing, or exporting mirror sessions requires Admin/root privileges.
+* Starting, stopping, or showing mirror sessions requires Admin/root privileges.
 * Recording files are always written to `/var/log/sonic/console-mirror/`; users cannot specify a custom output directory.
-* Recording files are created with restrictive permissions (`0600`), owned by `root:root`.
+* Recording parts, temporary archives, and completed ZIP archives are created with restrictive permissions (`0600`), owned by `root:root`.
 * Recording directories are created with restrictive permissions (`0700`), owned by `root:root`, and are not world-readable.
 * The UDS control socket is created with restrictive permissions so only Admin/root users can issue mirror control commands.
 * CLI output should print the recording file path and active status for auditability.
-* STATE_DB records should include `started_by`, `owner_pid`, `start_time`, `timeout` and current `file_path`.
+* STATE_DB records should include `started_by`, `owner_pid`, `start_time`, `timeout` and the current active `file_path`.
+* Archive progress and archive paths are not stored in STATE_DB.
 * Mirroring should be visible through `consutil mirror show`.
 
 This revision does not encrypt recordings. Encryption can be added later as an optional writer mode without changing the proxy interception points.

--- a/doc/console/Console-Mirror-High-Level-Design.md
+++ b/doc/console/Console-Mirror-High-Level-Design.md
@@ -1,0 +1,839 @@
+# SONiC Console Mirror
+## High Level Design Document
+
+### Revision
+
+| Rev | Date | Author | Change Description |
+| :---: | :---------: | :--------: | ------------------ |
+| 0.1 | 06/13/2026 | William Zhang | Initial version |
+
+---
+
+## Table of Contents
+
+- [SONiC Console Mirror](#sonic-console-mirror)
+  - [High Level Design Document](#high-level-design-document)
+    - [Revision](#revision)
+  - [Table of Contents](#table-of-contents)
+  - [Terminology and Abbreviations](#terminology-and-abbreviations)
+  - [1. Feature Overview](#1-feature-overview)
+    - [1.1 Feature Requirements](#11-feature-requirements)
+  - [2. Design Overview](#2-design-overview)
+    - [2.1 Architecture](#21-architecture)
+    - [2.2 Design Principles](#22-design-principles)
+    - [2.3 User Model](#23-user-model)
+  - [3. Detailed Design](#3-detailed-design)
+    - [3.1 Proxy Changes](#31-proxy-changes)
+      - [3.1.1 MirrorManager](#311-mirrormanager)
+      - [3.1.2 RecordingWriter](#312-recordingwriter)
+      - [3.1.3 DisplaySink](#313-displaysink)
+      - [3.1.4 MirrorControlServer](#314-mirrorcontrolserver)
+    - [3.2 Mirror Control Message Protocol](#32-mirror-control-message-protocol)
+    - [3.3 RX Mirroring](#33-rx-mirroring)
+    - [3.4 TX Mirroring](#34-tx-mirroring)
+    - [3.5 Live Display Mode](#35-live-display-mode)
+    - [3.6 Recording File Format](#36-recording-file-format)
+      - [3.6.1 File Path](#361-file-path)
+      - [3.6.2 File Rotation](#362-file-rotation)
+      - [3.6.3 Header Lines](#363-header-lines)
+      - [3.6.4 Data Record Lines](#364-data-record-lines)
+      - [3.6.5 Event Lines](#365-event-lines)
+      - [3.6.6 Payload Escaping Rules](#366-payload-escaping-rules)
+      - [3.6.7 Conversion Utility](#367-conversion-utility)
+    - [3.7 Error Handling](#37-error-handling)
+    - [3.8 Service Lifecycle](#38-service-lifecycle)
+      - [Proxy Startup](#proxy-startup)
+      - [Mirror Start](#mirror-start)
+      - [Mirror Stop](#mirror-stop)
+      - [Proxy Shutdown](#proxy-shutdown)
+  - [4. Database Changes](#4-database-changes)
+    - [4.1 STATE\_DB](#41-state_db)
+      - [4.1.1 CONSOLE\_MIRROR Table](#411-console_mirror-table)
+  - [5. CLI](#5-cli)
+    - [5.1 Start Mirroring](#51-start-mirroring)
+    - [5.2 Stop Mirroring](#52-stop-mirroring)
+    - [5.3 Show Mirror Status](#53-show-mirror-status)
+    - [5.4 Export Recording](#54-export-recording)
+  - [6. Example Workflow](#6-example-workflow)
+    - [6.1 Record Without Live Display](#61-record-without-live-display)
+    - [6.2 Record With Live Display](#62-record-with-live-display)
+  - [7. Security Considerations](#7-security-considerations)
+  - [8. Future Work](#8-future-work)
+  - [9. References](#9-references)
+
+---
+
+## Terminology and Abbreviations
+
+| Term | Definition |
+|------|------------|
+| DCE | Data Communications Equipment - Console Server side |
+| DTE | Data Terminal Equipment - SONiC switch (managed device) side |
+| Mirror | A best-effort copy of serial console traffic for diagnostics |
+| PTM | Pseudo Terminal Master - master side of a PTY pair |
+| PTS | Pseudo Terminal Slave - slave side of a PTY pair |
+| PTY | Pseudo Terminal - virtual terminal interface |
+| PTY Bridge | Process that creates and bridges PTY pairs using socat |
+| Proxy | Per-line process that owns the physical serial device and bridges it to PTM |
+| RX | Data received by the console server from the managed device |
+| TX | Data sent from the console user toward the managed device |
+| UDS | Unix domain socket |
+
+---
+
+## 1. Feature Overview
+
+Diagnosing issues with the serial console can be challenging because the connection is exclusive, so only the user on that line knows what's happening. The Console Mirror feature allows an operator on the SONiC console server to start and stop recording traffic for a specific console line. The feature is intended for troubleshooting serial console issues without taking over the active console session.
+
+The existing console connection model is preserved. User A may already be connected to line 1 through the normal `consutil connect 1` path. User B can independently start mirroring for line 1 on the SONiC console server. User B may choose whether the mirrored traffic is only written to a local recording file or is also displayed in User B's terminal while recording is active.
+
+### 1.1 Feature Requirements
+
+The feature provides the following capabilities:
+
+* Start recording for a specific console line.
+* Stop recording for a specific console line.
+* Record RX data received from the managed device.
+* Record TX data sent by the active console user.
+* Store the byte stream in a file format that preserves direction and timestamp information.
+* Support configurable timestamp resolution.
+* Optionally display mirrored traffic in the mirror user's terminal.
+* Allow only one mirror owner per line.
+* Avoid impacting console availability when recording or display is slow.
+
+---
+
+## 2. Design Overview
+
+### 2.1 Architecture
+
+The design extends the existing console monitor DCE architecture. The per-line proxy remains the only process that owns the physical serial device. The PTY Bridge and the normal `consutil` connection flow remain unchanged.
+
+```mermaid
+flowchart LR
+    userA["User A<br/>consutil connect 1"]
+    pts["PTS<br/>/dev/ttyUSB1-PTS"]
+    ptm["PTM<br/>/dev/ttyUSB1-PTM"]
+    proxy["Per-line proxy<br/>console-monitor-proxy@1"]
+    tty["Physical TTY<br/>/dev/ttyUSB1"]
+    target["Managed device<br/>serial console"]
+
+    userA <-- "interactive console" --> pts
+    pts <-- "PTY bridge" --> ptm
+    ptm <-- "normal TX/RX stream" --> proxy
+    proxy <-- "serial stream" --> tty
+    tty <-- "physical serial" --> target
+
+    subgraph MirrorPath["Mirror side path inside DCE"]
+        mirror["MirrorManager"]
+        writer["RecordingWriter"]
+        log["Secure text logs<br/>/var/log/sonic/console-mirror/..."]
+        state["STATE_DB<br/>CONSOLE_MIRROR|1"]
+    end
+
+    proxy -. "best-effort RX/TX copy" .-> mirror
+    mirror --> writer
+    writer --> log
+    mirror --> state
+
+    userB["User B<br/>sudo consutil mirror start 1"]
+    uds["MirrorControlServer<br/>/run/console-monitor/mirror/line1.sock"]
+
+    userB <-- "start / stop / status" --> uds
+    uds --> mirror
+    mirror -. "optional escaped live display" .-> uds
+    uds -. "display stream" .-> userB
+```
+
+### 2.2 Design Principles
+
+* **Non-interference** - Mirroring must not change the console byte stream, line ownership, or active console session behavior.
+* **Single active mirror owner** - At most one mirror session can be active per line.
+* **Best-effort observability** - Recording should be reliable under normal operation, but a slow writer or display consumer must not block the proxy data path.
+* **Text-first storage** - The recording format is a line-oriented UTF-8 text log. Printable characters are written as text, while control bytes, ANSI escape bytes, and invalid UTF-8 bytes are represented using printable escape sequences.
+* **Minimal architecture change** - The existing PTY Bridge and `consutil connect` model are retained.
+
+### 2.3 User Model
+
+There are two independent users in the primary use case:
+
+* User A owns the active interactive console session on line 1.
+* User B starts mirroring line 1 from the SONiC console server.
+
+User B does not become a second interactive console user. User B cannot write data to the managed device through the mirror path. The mirror path is read-only with respect to serial traffic and records TX data only because the proxy already observes TX bytes on their way from PTM to the physical serial device.
+
+---
+
+## 3. Detailed Design
+
+### 3.1 Proxy Changes
+
+The proxy is extended with a `MirrorManager` object. The proxy already observes both byte-stream directions:
+
+* RX: physical serial device to PTM.
+* TX: PTM to physical serial device.
+
+The `MirrorManager` receives a copy of these bytes and records them with direction and timestamp metadata. It does not own the serial device and does not participate in forwarding decisions.
+
+The proxy adds the following internal components:
+
+| Component | Description |
+|-----------|-------------|
+| `MirrorManager` | Maintains mirror session state and queues records to sinks |
+| `RecordingWriter` | Writes text records to the local file |
+| `DisplaySink` | Optional single live display stream to the CLI process |
+| `MirrorControlServer` | Per-line UDS endpoint for start, stop, and status commands |
+
+The proxy main loop must keep serial forwarding as the highest priority. Mirroring work is offloaded to bounded queues and writer tasks.
+
+#### 3.1.1 MirrorManager
+
+`MirrorManager` is the per-line in-proxy coordinator for mirroring. It is created when the proxy starts and remains in memory for the lifetime of the proxy process.
+
+`MirrorManager` maintains the following runtime state:
+
+| State Item | Description |
+|------------|-------------|
+| `state` | `idle`, `active`, or `stopping` |
+| `session_id` | Random ID generated when a mirror session starts |
+| `line` | Console line owned by the proxy |
+| `direction` | `rx`, `tx`, or `both` |
+| `resolution` | Timestamp resolution for the recording |
+| `start_time` | Recording start timestamp |
+| `file_path` | Current recording file path under the fixed secure directory |
+| `writer` | Active `RecordingWriter`, if a session is active |
+| `display_sink` | Active `DisplaySink`, if live display is attached |
+| `pending_writer_drop_count` | Number of writer records dropped since the last recorded drop event |
+
+`MirrorManager` exposes internal methods to the proxy and `MirrorControlServer`:
+
+| Method | Caller | Description |
+|--------|--------|-------------|
+| `start(options)` | `MirrorControlServer` | Validate options, create session metadata, create `RecordingWriter`, update STATE_DB |
+| `stop()` | `MirrorControlServer` | Write stop event, stop writer, detach display, clear STATE_DB active state |
+| `status()` | `MirrorControlServer` | Return current line mirror state |
+| `attach_display(connection)` | `MirrorControlServer` | Attach the single display stream for the active session |
+| `submit(direction, payload)` | Proxy forwarding loop | Best-effort submit of RX/TX data to recording and display sinks |
+
+The proxy forwarding loop calls `MirrorManager.submit()` after it observes console bytes on the RX or TX path. `submit()` must be non-blocking from the proxy's perspective. If mirroring is idle, the method returns immediately. If the active session does not include the submitted direction, the method returns immediately.
+
+For accepted records, `MirrorManager` creates a mirror record containing timestamp, delta timestamp, sequence number, direction, original byte length, and raw payload bytes. It then submits the record to:
+
+* `RecordingWriter`, if recording is active.
+* `DisplaySink`, if live display is attached.
+
+Writer submission is best effort. If the writer queue is full, `MirrorManager` increments `pending_writer_drop_count`, writes a syslog warning, and does not block the forwarding loop. When the writer queue later accepts records again, `MirrorManager` emits one `EVENT` record with `reason=writer_queue_full` and the accumulated `dropped_records` value before recording subsequent data records.
+
+Display submission is also best effort. If the display queue is full, the display record is dropped and a syslog warning is written.
+
+#### 3.1.2 RecordingWriter
+
+`RecordingWriter` is responsible for durable on-disk recording. It is created for one mirror session and destroyed when that session stops.
+
+`RecordingWriter` owns:
+
+| Resource | Description |
+|----------|-------------|
+| Recording file descriptor | Opened under `/var/log/sonic/console-mirror/line<line>/` |
+| Writer queue | Bounded queue receiving data and event records from `MirrorManager` |
+| Writer task/thread | Background execution context that drains the queue and writes text lines |
+
+The writer opens the recording file with restrictive permissions:
+
+```text
+owner: root:root
+mode: 0600
+```
+
+The containing directories are created by the proxy with mode `0700` before the file is opened. The writer must not follow user-provided paths because custom output directories are not supported.
+
+Writer startup sequence:
+
+1. Create or validate `/var/log/sonic/console-mirror/`.
+2. Create or validate `/var/log/sonic/console-mirror/line<line>/`.
+3. Open the recording file with exclusive creation.
+4. Write SCM-Text header lines.
+5. Start draining the bounded writer queue.
+
+The writer converts records to SCM-Text lines. For data records, the payload is encoded using the printable escaping rules in [Payload Escaping Rules](#366-payload-escaping-rules). For event records, the payload is compact JSON.
+
+If `max_file_size` is configured, `RecordingWriter` monitors the current file size before writing each record. If the next record would exceed the configured limit, the writer rotates to a new file as described in [File Rotation](#362-file-rotation). Rotation is performed by the writer task and must not block the serial forwarding path.
+
+The writer must never run in the latency-sensitive serial forwarding path. If disk I/O is slow, only the bounded queue is affected. If the queue is full, records are dropped before reaching the writer, a syslog warning is written, and the proxy continues forwarding console bytes.
+
+Writer shutdown sequence:
+
+1. Accept a stop event from `MirrorManager`.
+2. Drain queued records up to a bounded shutdown timeout.
+3. Flush the file.
+4. Close the file descriptor.
+
+If the writer encounters a fatal file error, for example disk full or write failure, it reports the error to `MirrorManager`. `MirrorManager` stops the recording session, writes syslog, updates STATE_DB state, and leaves the console forwarding path running.
+
+#### 3.1.3 DisplaySink
+
+`DisplaySink` provides the optional live display for the mirror owner. It is created only when the CLI requests `--display` and attaches to an active mirror session.
+
+Only one `DisplaySink` is allowed per line. If a display sink is already attached, another attach request is rejected. This is separate from the single mirror owner rule: a line has at most one active mirror session, and that session has at most one live display sink.
+
+`DisplaySink` owns:
+
+| Resource | Description |
+|----------|-------------|
+| UDS connection | Connection back to the `consutil mirror start --display` process |
+| Display queue | Bounded queue receiving display records from `MirrorManager` |
+| Display task/thread | Background execution context that sends records to the CLI |
+
+The display path is read-only with respect to the console line. It never accepts user input for the managed device and cannot inject TX bytes.
+
+Display rendering uses the same printable escaping rules as the recording file. This prevents ANSI escape bytes and other control bytes from changing User B's terminal state. TX records may be prefixed with `[TX]` so that User B can distinguish user input from device output.
+
+If the display queue is full, `DisplaySink` drops display records and writes a syslog warning. It does not update STATE_DB and does not affect `RecordingWriter`. If the CLI disconnects, `DisplaySink` is detached, a syslog message is written, and the recording session remains active.
+
+#### 3.1.4 MirrorControlServer
+
+`MirrorControlServer` is the local IPC endpoint used by `consutil mirror` to control the in-process `MirrorManager`. It is created by each per-line proxy during startup.
+
+The control socket path is:
+
+```text
+/run/console-monitor/mirror/line<line>.sock
+```
+
+The socket is created with restrictive permissions so only Admin/root users can issue mirror control commands. This socket is a control channel only. It is not the normal interactive console data path and it is not a multi-user console fan-out channel.
+
+`MirrorControlServer` accepts JSON control messages with 4-byte big-endian length framing. It validates:
+
+* The requested line matches the proxy line.
+* The caller is authorized.
+* The requested operation is supported.
+* The requested direction and resolution are valid.
+* No mirror session is already active when processing `start`.
+* A mirror session is active when processing `stop` or `attach-display`.
+
+After validation, `MirrorControlServer` calls the corresponding `MirrorManager` method. It returns structured success or error responses to the CLI. For example, `start` returns the generated `session_id` and secure recording file path; `status` returns current STATE_DB-equivalent runtime metadata; `stop` returns the final file path.
+
+`MirrorControlServer` must not perform disk I/O or serial I/O itself. It only validates control messages, enforces access policy, and invokes `MirrorManager`.
+
+### 3.2 Mirror Control Message Protocol
+
+This section defines the message protocol used on the `MirrorControlServer` UDS described in [MirrorControlServer](#314-mirrorcontrolserver). Control messages are JSON objects framed with a 4-byte big-endian length prefix:
+
+```json
+{
+  "op": "start",
+  "line": "1",
+  "direction": "both",
+  "resolution": "us",
+  "display": false,
+  "max_file_size": "64MiB"
+}
+```
+
+`max_file_size` uses the same size syntax as the CLI `--max-file-size` option. Supported suffixes are `B`, `KiB`, `MiB`, and `GiB`; if no suffix is provided, the value is interpreted as bytes.
+
+Supported control operations:
+
+| Operation | Description |
+|-----------|-------------|
+| `start` | Start a mirror session if no mirror session is active |
+| `stop` | Stop the active mirror session |
+| `status` | Return current mirror state for the line |
+| `attach-display` | Attach the calling CLI process as the single display sink |
+
+The response is also a length-prefixed JSON object. Successful responses include `status: "ok"` and operation-specific fields. Error responses include `status: "error"`, a machine-readable `code`, and a human-readable `message`.
+
+Example success response for `start`:
+
+```json
+{
+  "status": "ok",
+  "session_id": "a1b2c3d4",
+  "file_path": "/var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log"
+}
+```
+
+Example error response when a mirror session is already active:
+
+```json
+{
+  "status": "error",
+  "code": "mirror_already_active",
+  "message": "Line 1 already has an active mirror session"
+}
+```
+
+### 3.3 RX Mirroring
+
+RX mirroring is performed from the same read buffer used for the normal RX forwarding path. After console-monitor heartbeat filtering, the proxy forwards the remaining user-visible bytes to PTM and submits a best-effort RX mirror record to `MirrorManager`. Mirror submission must not block or change the normal forwarding decision.
+
+```mermaid
+flowchart LR
+    tty["Physical serial"] --> read["Proxy RX read"]
+    read --> filter["Heartbeat filter"]
+    filter -- "heartbeat" --> state["Update oper state"]
+    filter -- "console bytes" --> ptm["Write PTM"]
+    filter -- "same console bytes" --> mirror["Best-effort mirror RX record"]
+```
+
+This default placement records the same RX data that User A would see in the interactive console. Internal heartbeat frames are not recorded by default because they are implementation details of console monitor rather than managed-device console traffic.
+
+### 3.4 TX Mirroring
+
+TX mirroring is performed from the same read buffer used for the normal TX forwarding path. After reading data from PTM, the proxy writes the bytes to the physical serial device and submits a best-effort TX mirror record to `MirrorManager`. Mirror submission must not block or change the normal forwarding decision.
+
+```mermaid
+flowchart LR
+    ptm["PTM"] --> read["Proxy TX read"]
+    read --> tty["Write physical serial"]
+    read --> mirror["Best-effort mirror TX record"]
+```
+
+This captures User A's console input without granting User B any ability to inject input.
+
+### 3.5 Live Display Mode
+
+When User B starts mirroring with live display enabled, the CLI sends `start` followed by `attach-display` on the same UDS connection. The proxy sends a copy of mirror records to this single display connection.
+
+The live display stream is an internal stream of mirror records. The CLI renders these records to User B's terminal using the same printable escaping rules as the on-disk text log. This stream does not change the on-disk text log format.
+
+Detailed display behavior:
+
+* RX bytes are written to stdout after printable escaping.
+* TX bytes may be shown with a configurable prefix, for example `[TX]`, to make user input distinguishable.
+* Non-printable bytes are escaped before being printed to User B's terminal.
+* ANSI escape bytes are printed as escaped text, for example `\x1b`, rather than being emitted as literal terminal control bytes.
+
+The display sink has its own bounded queue. If User B's terminal is slow, display records may be dropped and the proxy writes a warning to syslog. Display drop events are not recorded in STATE_DB. Dropping display records must not affect the recording writer or the console data path.
+
+If the display CLI exits, the proxy detaches only the display sink and writes a syslog message. The recording session remains active until `consutil mirror stop <line>` is executed or the proxy stops.
+
+### 3.6 Recording File Format
+
+The recording file is a UTF-8 text log. The format is named SCM-Text v1, short for Serial Console Mirror Text v1. It is line-oriented and append-only.
+
+The goal of the text format is to make common console output easy to inspect directly while still representing serial bytes that cannot be safely printed in a log file. Printable UTF-8 characters are written as-is. Unsafe bytes are escaped so that tools such as `cat`, `less`, `grep`, and log collectors do not interpret terminal control sequences or lose byte boundaries.
+
+#### 3.6.1 File Path
+
+Recording files are always written under a fixed, security-controlled directory. The CLI does not support overriding the output directory.
+
+Base directory:
+
+```text
+/var/log/sonic/console-mirror/
+```
+
+Per-line recording path:
+
+```text
+/var/log/sonic/console-mirror/line<line>/console-mirror-line<line>-<UTC timestamp>-<session id>-part<part>.log
+```
+
+Example:
+
+```text
+/var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log
+```
+
+The `.log` extension is used to make the text nature of the recording clear.
+
+The proxy is responsible for creating the base directory and per-line subdirectories with restrictive ownership and permissions:
+
+| Path | Owner | Permission | Description |
+|------|-------|------------|-------------|
+| `/var/log/sonic/console-mirror/` | `root:root` | `0700` | Base directory for all mirror recordings |
+| `/var/log/sonic/console-mirror/line<line>/` | `root:root` | `0700` | Per-line recording directory |
+| `console-mirror-line<line>-<timestamp>-<session_id>-part<part>.log` | `root:root` | `0600` | Recording file |
+
+The proxy generates `session_id` when a mirror session starts. The value should be a random hexadecimal string generated with a cryptographically strong random source, for example `secrets.token_hex(8)`.
+
+#### 3.6.2 File Rotation
+
+Rotation is controlled by `max_file_size`, which can be set through the CLI `--max-file-size` option or the control message `max_file_size` field.
+
+Rotation behavior:
+
+1. Each mirror session starts with `part0001`.
+2. Before writing a record, `RecordingWriter` checks whether appending that record would make the current file exceed `max_file_size`.
+3. If the limit would be exceeded, `RecordingWriter` writes a rotate event to the current file if space allows, flushes and closes the current file, increments the part number, opens the next file, writes header lines, and continues recording.
+4. The new file uses the same `session_id`, `line`, `start_time`, direction, and resolution, but a different part number.
+5. `STATE_DB` `file_path` is updated to the current active part file.
+6. Old part files are not deleted by this feature. Recording retention and deletion are handled by the platform log management policy.
+
+Example rotated files:
+
+```text
+/var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log
+/var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0002.log
+/var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0003.log
+```
+
+Rotate event example:
+
+```text
+2026-06-13T14:13:00.000000Z +000060000000us 00000125 EVENT 00000041 {"event":"rotate","next_part":"part0002"}
+```
+
+If opening the next part file fails, `RecordingWriter` reports a fatal writer error to `MirrorManager`. The mirror session is stopped, syslog is written, STATE_DB is updated, and the normal console forwarding path continues.
+
+#### 3.6.3 Header Lines
+
+The file starts with comment-style header lines. Header keys use `key=value` syntax.
+
+```text
+# SONIC_CONSOLE_MIRROR_TEXT version=1
+# line=1 direction=both resolution=us start_time=2026-06-13T14:12:00.123456Z session_id=a1b2c3d4 part=part0001 encoding=printable-escape
+# fields=timestamp delta seq direction length payload
+```
+
+Header lines start with `# ` so that simple text tools can distinguish metadata from data records.
+
+#### 3.6.4 Data Record Lines
+
+Each data record is written as one text line:
+
+```text
+<timestamp> <delta> <seq> <direction> <length> <payload>
+```
+
+The first five fields are space-delimited. The payload is the remainder of the line, so printable spaces from console output can be kept as spaces.
+
+Fields:
+
+| Field | Format | Example | Description |
+|-------|--------|---------|-------------|
+| `timestamp` | RFC 3339 UTC timestamp with configured fractional precision | `2026-06-13T14:12:01.000003Z` | Absolute time when the record is created |
+| `delta` | `+` followed by a zero-padded 12-digit decimal value and the resolution suffix | `+000000876547us` | Time elapsed since the recording start timestamp |
+| `seq` | Zero-padded 8-digit decimal number | `00000002` | Monotonic record sequence number, starting from `00000001` |
+| `direction` | Fixed token | `RX`, `TX`, or `EVENT` | Record direction or event marker |
+| `length` | Zero-padded 8-digit decimal number | `00000005` | Original payload length in bytes before escaping |
+| `payload` | Remainder of the line | `show\n` | Printable-escaped representation of the serial bytes |
+
+The `delta` field is a relative timestamp. It is calculated from the absolute record timestamp and the recording start timestamp:
+
+```text
+delta = record_timestamp - recording_start_timestamp
+```
+
+The unit suffix follows the selected timestamp resolution:
+
+| Resolution | Delta Suffix | Meaning |
+|------------|--------------|---------|
+| `ns` | `ns` | Delta value is in nanoseconds |
+| `us` | `us` | Delta value is in microseconds |
+| `ms` | `ms` | Delta value is in milliseconds |
+
+For example, if the recording starts at `2026-06-13T14:12:00.123456Z` and a record is created at `2026-06-13T14:12:01.000003Z`, the elapsed time is `876547` microseconds, so the `delta` field is written as `+000000876547us`. The delta field makes it easy to analyze timing gaps between RX and TX records without repeatedly subtracting absolute timestamps.
+
+Example records:
+
+```text
+2026-06-13T14:12:00.123456Z +000000000000us 00000001 RX 00000014 Booting SONiC\n
+2026-06-13T14:12:01.000003Z +000000876547us 00000002 TX 00000005 show\n
+2026-06-13T14:12:01.004200Z +000000880744us 00000003 RX 00000010 \x1b[2Jlogin:
+```
+
+#### 3.6.5 Event Lines
+
+Mirror lifecycle and error events are also written as text lines. Event lines use `EVENT` as the direction field and a JSON object as the payload.
+
+```text
+2026-06-13T14:12:05.000000Z +000004876544us 00000004 EVENT 00000028 {"event":"drop","count":128}
+```
+
+Events are used for start, stop, queue overflow, display detach, and writer error.
+
+#### 3.6.6 Payload Escaping Rules
+
+The writer applies a deterministic printable escaping function to each payload:
+
+| Input byte or character | Output |
+|-------------------------|--------|
+| Printable UTF-8 character | Written as-is |
+| Space | Written as-is |
+| `\n` | `\\n` |
+| `\r` | `\\r` |
+| `\t` | `\\t` |
+| Backslash | `\\\\` |
+| ESC byte `0x1b` | `\\x1b` |
+| Other C0/C1 control bytes | `\\xNN` |
+| Invalid UTF-8 byte | `\\xNN` |
+
+This keeps normal console text readable while preventing terminal control sequences from changing the viewer's terminal state. For example, the ANSI clear-screen sequence is written as `\x1b[2J` rather than being emitted as a literal ESC byte.
+
+#### 3.6.7 Conversion Utility
+
+A conversion utility may still be provided for structured processing:
+
+```bash
+sudo consutil mirror export console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log --format json
+sudo consutil mirror export console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log --format raw-text
+```
+
+JSON export parses the text log and preserves direction, timestamp, original byte length, and escaped payload. Raw-text export can drop metadata and print only the payload stream for quick inspection.
+
+### 3.7 Error Handling
+
+The mirror implementation must not block or terminate the active console session because of recording errors.
+
+| Error | Behavior |
+|-------|----------|
+| File open failure | Reject `start` and report error to CLI |
+| Disk full | Stop recording, update STATE_DB, keep console forwarding |
+| Writer queue full | Drop mirror records, write syslog warning, record a drop event when the writer queue recovers, keep forwarding |
+| Display queue full | Drop display records only, write syslog warning, keep recording |
+| Display client disconnect | Detach display, write syslog message, keep recording |
+| Proxy restart | Stop current mirror session and mark state inactive after restart |
+
+The writer queue should be bounded. When the queue is full, new mirror records are dropped rather than blocking the proxy, and a syslog warning is written. A drop event is inserted when the queue becomes writable again.
+
+### 3.8 Service Lifecycle
+
+#### Proxy Startup
+
+1. Initialize serial and PTM resources as in the existing console monitor design.
+2. Create the per-line mirror runtime directory.
+3. Start the `MirrorControlServer`.
+4. Initialize `MirrorManager` in idle state.
+5. Enter the normal proxy forwarding loop.
+
+#### Mirror Start
+
+1. CLI connects to the per-line mirror UDS.
+2. CLI sends a `start` request.
+3. Proxy validates line, permissions, and active mirror state.
+4. Proxy creates the recording file and starts `RecordingWriter`.
+5. Proxy updates STATE_DB with active mirror metadata.
+6. Proxy replies with session ID and file path.
+7. If display is requested, CLI attaches as the single display sink.
+
+#### Mirror Stop
+
+1. CLI sends a `stop` request.
+2. Proxy writes a stop event to the recording file.
+3. Proxy flushes and closes the writer.
+4. Proxy clears active mirror state and updates STATE_DB.
+
+#### Proxy Shutdown
+
+On proxy shutdown, the mirror writer receives a stop event and flushes the recording file if possible. STATE_DB is updated to show the mirror session is no longer active.
+
+---
+
+## 4. Database Changes
+
+No new persistent CONFIG_DB table is required for the initial implementation. Console mirroring is treated as an operational action rather than persistent configuration, so it should not automatically restart after device reboot.
+
+Runtime state is stored in STATE_DB.
+
+### 4.1 STATE_DB
+
+#### 4.1.1 CONSOLE_MIRROR Table
+
+| Key Format | Field | Value | Description |
+|------------|-------|-------|-------------|
+| `CONSOLE_MIRROR\|<line>` | `state` | `idle` / `active` / `error` | Mirror state |
+| `CONSOLE_MIRROR\|<line>` | `session_id` | string | Active session ID |
+| `CONSOLE_MIRROR\|<line>` | `owner_pid` | PID | CLI process that started the session |
+| `CONSOLE_MIRROR\|<line>` | `started_by` | username | User that started mirroring |
+| `CONSOLE_MIRROR\|<line>` | `start_time` | Unix timestamp | Mirror start time |
+| `CONSOLE_MIRROR\|<line>` | `file_path` | path | Current recording file path |
+| `CONSOLE_MIRROR\|<line>` | `direction` | `rx` / `tx` / `both` | Mirrored direction |
+| `CONSOLE_MIRROR\|<line>` | `resolution` | `ns` / `us` / `ms` | Timestamp resolution |
+| `CONSOLE_MIRROR\|<line>` | `display` | `yes` / `no` | Whether display sink is attached |
+
+Example:
+
+```bash
+admin@sonic:~$ sonic-db-cli STATE_DB HGETALL "CONSOLE_MIRROR|1"
+1) "state"
+2) "active"
+3) "session_id"
+4) "a1b2c3d4"
+5) "owner_pid"
+6) "12345"
+7) "started_by"
+8) "admin"
+9) "start_time"
+10) "1718287920"
+11) "file_path"
+12) "/var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log"
+13) "direction"
+14) "both"
+15) "resolution"
+16) "us"
+17) "display"
+18) "yes"
+```
+
+---
+
+## 5. CLI
+
+The CLI is added under `consutil` because it operates on console lines and can optionally attach to a live terminal display.
+
+CLI permission requirements:
+
+| Command | Required Privilege | Reason |
+|---------|--------------------|--------|
+| `consutil mirror start` | Admin/root | Starts a sensitive recording and creates a protected log file |
+| `consutil mirror stop` | Admin/root | Stops an active recording session |
+| `consutil mirror show` | Admin/root | Exposes active recording metadata, including recording file path |
+| `consutil mirror export` | Admin/root | Reads protected recording files |
+
+### 5.1 Start Mirroring
+
+```bash
+sudo consutil mirror start <target> [OPTIONS]
+```
+
+Options:
+
+| Option | Description |
+|--------|-------------|
+| `--devicename`, `-d` | Interpret target as remote device name instead of line number |
+| `--direction {rx,tx,both}` | Select mirrored direction, default `both` |
+| `--resolution {ns,us,ms}` | Timestamp resolution, default `us` |
+| `--display` | Also display mirrored traffic in the current terminal |
+| `--max-file-size <size>` | Maximum size of each recording part before rotation. Supported suffixes are `B`, `KiB`, `MiB`, and `GiB`; values without suffix are bytes |
+
+Example:
+
+```bash
+sudo consutil mirror start 1 --direction both --resolution us
+sudo consutil mirror start 1 --display
+```
+
+If a mirror session is already active for the target line, the command fails:
+
+```text
+Cannot start mirror: line [1] already has an active mirror session
+```
+
+### 5.2 Stop Mirroring
+
+```bash
+sudo consutil mirror stop <target> [--devicename]
+```
+
+Example:
+
+```bash
+sudo consutil mirror stop 1
+```
+
+Expected output:
+
+```text
+Stopped mirror on line [1]
+Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log
+```
+
+### 5.3 Show Mirror Status
+
+```bash
+sudo consutil mirror show [target] [--devicename]
+```
+
+Example output:
+
+```text
+Line  State   Direction  Display  File
+----  ------  ---------  -------  ----
+1     active  both       yes      /var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log
+2     idle    -          no       -
+```
+
+### 5.4 Export Recording
+
+```bash
+sudo consutil mirror export <file> --format {json,raw-text}
+```
+
+Example:
+
+```bash
+sudo consutil mirror export /var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log --format json
+```
+
+---
+
+## 6. Example Workflow
+
+### 6.1 Record Without Live Display
+
+User A is connected to line 1:
+
+```bash
+admin@sonic:~$ consutil connect 1
+Successful connection to line [1]
+```
+
+User B starts recording line 1:
+
+```bash
+admin@sonic:~$ sudo consutil mirror start 1
+Started mirror on line [1]
+Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log
+```
+
+User B stops recording:
+
+```bash
+admin@sonic:~$ sudo consutil mirror stop 1
+Stopped mirror on line [1]
+Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log
+```
+
+### 6.2 Record With Live Display
+
+User B starts recording and live display:
+
+```bash
+admin@sonic:~$ sudo consutil mirror start 1 --display
+Started mirror on line [1]
+Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log
+```
+
+Mirrored RX/TX traffic is then displayed in User B's terminal. If User B exits the display process, recording remains active until `consutil mirror stop 1` is executed.
+
+---
+
+## 7. Security Considerations
+
+Console mirror recordings are highly sensitive. They may contain credentials, bootloader commands, recovery tokens, private configuration, or device crash output.
+
+Security requirements:
+
+* Starting, stopping, showing, or exporting mirror sessions requires Admin/root privileges.
+* Recording files are always written to `/var/log/sonic/console-mirror/`; users cannot specify a custom output directory.
+* Recording files are created with restrictive permissions (`0600`), owned by `root:root`.
+* Recording directories are created with restrictive permissions (`0700`), owned by `root:root`, and are not world-readable.
+* The UDS control socket is created with restrictive permissions so only Admin/root users can issue mirror control commands.
+* CLI output should print the recording file path and active status for auditability.
+* STATE_DB records should include `started_by`, `owner_pid`, `start_time`, and current `file_path`.
+* Mirroring should be visible through `consutil mirror show`.
+
+This revision does not encrypt recordings. Encryption can be added later as an optional writer mode without changing the proxy interception points.
+
+---
+
+## 8. Future Work
+
+The following items can be added in later revisions:
+
+* CTS/RTS flow control signal mirroring.
+* Recording file encryption.
+* gNOI APIs for remote start and stop.
+* Optional inclusion of console-monitor internal heartbeat frames for debugging.
+* Optional redaction filters for known sensitive patterns.
+
+---
+
+## 9. References
+
+1. [SONiC Console Monitor High Level Design](https://github.com/sonic-net/SONiC/blob/master/doc/console/Console-Monitor-High-Level-Design.md)
+2. [SONiC Console Switch High Level Design](https://github.com/sonic-net/SONiC/blob/master/doc/console/SONiC-Console-Switch-High-Level-Design.md)
+3. [sonic-net/sonic-utilities](https://github.com/sonic-net/sonic-utilities/)
+4. [sonic-utilities consutil main.py](https://github.com/sonic-net/sonic-utilities/blob/master/consutil/main.py)

--- a/doc/console/Console-Mirror-High-Level-Design.md
+++ b/doc/console/Console-Mirror-High-Level-Design.md
@@ -26,25 +26,24 @@
     - [3.1 Proxy Changes](#31-proxy-changes)
       - [3.1.1 MirrorManager](#311-mirrormanager)
       - [3.1.2 RecordingWriter](#312-recordingwriter)
-      - [3.1.3 DisplaySink](#313-displaysink)
-      - [3.1.4 MirrorControlServer](#314-mirrorcontrolserver)
+      - [3.1.3 MirrorControlServer](#313-mirrorcontrolserver)
     - [3.2 Mirror Control Message Protocol](#32-mirror-control-message-protocol)
     - [3.3 RX Mirroring](#33-rx-mirroring)
     - [3.4 TX Mirroring](#34-tx-mirroring)
-    - [3.5 Live Display Mode](#35-live-display-mode)
-    - [3.6 Recording File Format](#36-recording-file-format)
-      - [3.6.1 File Path](#361-file-path)
-      - [3.6.2 File Rotation](#362-file-rotation)
-      - [3.6.3 Header Lines](#363-header-lines)
-      - [3.6.4 Data Record Lines](#364-data-record-lines)
-      - [3.6.5 Event Lines](#365-event-lines)
-      - [3.6.6 Payload Escaping Rules](#366-payload-escaping-rules)
-      - [3.6.7 Conversion Utility](#367-conversion-utility)
-    - [3.7 Error Handling](#37-error-handling)
-    - [3.8 Service Lifecycle](#38-service-lifecycle)
+    - [3.5 Recording File Format](#35-recording-file-format)
+      - [3.5.1 File Path](#351-file-path)
+      - [3.5.2 File Rotation](#352-file-rotation)
+      - [3.5.3 Header Lines](#353-header-lines)
+      - [3.5.4 Data Record Lines](#354-data-record-lines)
+      - [3.5.5 Event Lines](#355-event-lines)
+      - [3.5.6 Payload Escaping Rules](#356-payload-escaping-rules)
+      - [3.5.7 Conversion Utility](#357-conversion-utility)
+    - [3.6 Error Handling](#36-error-handling)
+    - [3.7 Service Lifecycle](#37-service-lifecycle)
       - [Proxy Startup](#proxy-startup)
       - [Mirror Start](#mirror-start)
       - [Mirror Stop](#mirror-stop)
+      - [Automatic Mirror Stop](#automatic-mirror-stop)
       - [Proxy Shutdown](#proxy-shutdown)
   - [4. Database Changes](#4-database-changes)
     - [4.1 STATE\_DB](#41-state_db)
@@ -55,8 +54,8 @@
     - [5.3 Show Mirror Status](#53-show-mirror-status)
     - [5.4 Export Recording](#54-export-recording)
   - [6. Example Workflow](#6-example-workflow)
-    - [6.1 Record Without Live Display](#61-record-without-live-display)
-    - [6.2 Record With Live Display](#62-record-with-live-display)
+    - [6.1 Manual Stop](#61-manual-stop)
+    - [6.2 Automatic Stop](#62-automatic-stop)
   - [7. Security Considerations](#7-security-considerations)
   - [8. Future Work](#8-future-work)
   - [9. References](#9-references)
@@ -85,7 +84,7 @@
 
 Diagnosing issues with the serial console can be challenging because the connection is exclusive, so only the user on that line knows what's happening. The Console Mirror feature allows an operator on the SONiC console server to start and stop recording traffic for a specific console line. The feature is intended for troubleshooting serial console issues without taking over the active console session.
 
-The existing console connection model is preserved. User A may already be connected to line 1 through the normal `consutil connect 1` path. User B can independently start mirroring for line 1 on the SONiC console server. User B may choose whether the mirrored traffic is only written to a local recording file or is also displayed in User B's terminal while recording is active.
+The existing console connection model is preserved. User A may already be connected to line 1 through the normal `consutil connect 1` path. User B can independently start mirroring for line 1 on the SONiC console server. Mirrored traffic is written to local recording files for later inspection.
 
 ### 1.1 Feature Requirements
 
@@ -97,9 +96,8 @@ The feature provides the following capabilities:
 * Record TX data sent by the active console user.
 * Store the byte stream in a file format that preserves direction and timestamp information.
 * Support configurable timestamp resolution.
-* Optionally display mirrored traffic in the mirror user's terminal.
 * Allow only one mirror owner per line.
-* Avoid impacting console availability when recording or display is slow.
+* Automatically stop each mirror session after a finite timeout, defaulting to 24 hours.
 
 ---
 
@@ -120,15 +118,12 @@ flowchart LR
         writer["RecordingWriter"]
         state["STATE_DB<br/>CONSOLE_MIRROR|1"]
         control["MirrorControlServer<br/>/run/console-monitor/mirror/line1.sock"]
-        display["DisplaySink"]
         log["Text logs<br/>/var/log/sonic/console-mirror/..."]
     end
 
     ptm["PTM<br/>/dev/ttyUSB1-PTM"]
     pts["PTS<br/>/dev/ttyUSB1-PTS"]
     userA["User A<br/>consutil connect 1"]
-
-    
 
     target <-- "physical serial" --> tty
     tty <-- "serial stream" --> core
@@ -142,22 +137,23 @@ flowchart LR
     mirror --> writer
     writer --> log
     mirror --> state
-    mirror --> display
 
-    control -->|start / stop / status / attach-display| mirror
+    control -->|start / stop / status| mirror
 
-    userB["User B<br/>sudo consutil mirror start 1 --display"]
+    userB["User B<br/>start / stop / show"]
+
     userB -. "UDS control messages" .-> control
-    display -. "UDS display stream" .-> userB
 ```
 
 ### 2.2 Design Principles
 
 * **Non-interference** - Mirroring must not change the console byte stream, line ownership, or active console session behavior.
 * **Single active mirror owner** - At most one mirror session can be active per line.
-* **Best-effort observability** - Recording should be reliable under normal operation, but a slow writer or display consumer must not block the proxy data path.
+* **Best-effort observability** - Recording should be reliable under normal operation, but slow disk I/O must not block the proxy data path.
+* **Bounded lifetime** - Every mirror session has a finite auto-stop timeout. The default timeout is 24 hours.
 * **Text-first storage** - The recording format is a line-oriented UTF-8 text log. Printable characters are written as text, while control bytes, ANSI escape bytes, and invalid UTF-8 bytes are represented using printable escape sequences.
 * **Minimal architecture change** - The existing PTY Bridge and `consutil connect` model are retained.
+* **Operational state only** - Mirror configuration is not persisted and is not restored after reboot.
 
 ### 2.3 User Model
 
@@ -185,9 +181,8 @@ The proxy adds the following internal components:
 
 | Component | Description |
 |-----------|-------------|
-| `MirrorManager` | Maintains mirror session state and queues records to sinks |
+| `MirrorManager` | Maintains mirror session state |
 | `RecordingWriter` | Writes text records to the local file |
-| `DisplaySink` | Optional single live display stream to the CLI process |
 | `MirrorControlServer` | Per-line UDS endpoint for start, stop, and status commands |
 
 The proxy main loop must keep serial forwarding as the highest priority. Mirroring work is offloaded to bounded queues and writer tasks.
@@ -201,36 +196,33 @@ The proxy main loop must keep serial forwarding as the highest priority. Mirrori
 | State Item | Description |
 |------------|-------------|
 | `state` | `idle`, `active`, or `stopping` |
-| `session_id` | Random ID generated when a mirror session starts |
 | `line` | Console line owned by the proxy |
 | `direction` | `rx`, `tx`, or `both` |
 | `resolution` | Timestamp resolution for the recording |
 | `start_time` | Recording start timestamp |
+| `timeout` | Configured finite session timeout |
+| `timer` | Active auto-stop timer |
 | `file_path` | Current recording file path under the fixed secure directory |
 | `writer` | Active `RecordingWriter`, if a session is active |
-| `display_sink` | Active `DisplaySink`, if live display is attached |
 | `pending_writer_drop_count` | Number of writer records dropped since the last recorded drop event |
 
 `MirrorManager` exposes internal methods to the proxy and `MirrorControlServer`:
 
 | Method | Caller | Description |
 |--------|--------|-------------|
-| `start(options)` | `MirrorControlServer` | Validate options, create session metadata, create `RecordingWriter`, update STATE_DB |
-| `stop()` | `MirrorControlServer` | Write stop event, stop writer, detach display, clear STATE_DB active state |
+| `start(options)` | `MirrorControlServer` | Validate options, create session metadata and `RecordingWriter`, set the auto-stop timer, update STATE_DB |
+| `stop(reason)` | `MirrorControlServer` or auto-stop timer | Write stop event, cancel the timer, stop writer, set STATE_DB state to `idle`, and retain the final file path |
 | `status()` | `MirrorControlServer` | Return current line mirror state |
-| `attach_display(connection)` | `MirrorControlServer` | Attach the single display stream for the active session |
-| `submit(direction, payload)` | Proxy forwarding loop | Best-effort submit of RX/TX data to recording and display sinks |
+| `submit(direction, payload)` | Proxy forwarding loop | Best-effort submit of RX/TX data to the recording writer |
 
 The proxy forwarding loop calls `MirrorManager.submit()` after it observes console bytes on the RX or TX path. `submit()` must be non-blocking from the proxy's perspective. If mirroring is idle, the method returns immediately. If the active session does not include the submitted direction, the method returns immediately.
 
-For accepted records, `MirrorManager` creates a mirror record containing timestamp, delta timestamp, sequence number, direction, original byte length, and raw payload bytes. It then submits the record to:
-
-* `RecordingWriter`, if recording is active.
-* `DisplaySink`, if live display is attached.
 
 Writer submission is best effort. If the writer queue is full, `MirrorManager` increments `pending_writer_drop_count`, writes a syslog warning, and does not block the forwarding loop. When the writer queue later accepts records again, `MirrorManager` emits one `EVENT` record with `reason=writer_queue_full` and the accumulated `pending_writer_drop_count` value before recording subsequent data records.
 
-Display submission is also best effort. If the display queue is full, the display record is dropped and a syslog warning is written.
+When a session starts, `MirrorManager` calculates a monotonic deadline from the configured timeout and sets the `timer`. A monotonic clock prevents wall-clock adjustments from extending or shortening the recording unexpectedly. When the deadline expires, the timer invokes `stop(reason="timeout")`. Manual stop invokes the same shutdown path with `reason="manual"` and cancels the timer.
+
+The transition from `active` to `stopping` is atomic. If a manual stop races with timer expiration, only the caller that performs this transition executes the shutdown sequence; the other caller returns the resulting session state. This prevents duplicate stop events and double-closing the writer.
 
 #### 3.1.2 RecordingWriter
 
@@ -261,11 +253,11 @@ Writer startup sequence:
 4. Write SCM-Text header lines.
 5. Start draining the bounded writer queue.
 
-The writer converts records to SCM-Text lines. For data records, the payload is encoded using the printable escaping rules in [Payload Escaping Rules](#366-payload-escaping-rules). For event records, the payload is compact JSON.
+The writer converts records to SCM-Text lines. For data records, the payload is encoded using the printable escaping rules in [Payload Escaping Rules](#356-payload-escaping-rules). For event records, the payload is compact JSON.
 
-If `max_file_size` is configured, `RecordingWriter` monitors the current file size before writing each record. If the next record would exceed the configured limit, the writer rotates to a new file as described in [File Rotation](#362-file-rotation). Rotation is performed by the writer task and must not block the serial forwarding path.
+If `max_file_size` is configured, `RecordingWriter` monitors the current file size before writing each record. If the next record would exceed the configured limit, the writer rotates to a new file as described in [File Rotation](#352-file-rotation). Rotation is performed by the writer task and must not block the serial forwarding path.
 
-The writer must never run in the latency-sensitive serial forwarding path. If disk I/O is slow, only the bounded queue is affected. If the queue is full, records are dropped before reaching the writer, a syslog warning is written, and the proxy continues forwarding console bytes.
+The writer must never run in the latency-sensitive serial forwarding path. If disk I/O is slow, only the bounded queue is affected. If the queue is full, records are dropped before reaching the writer, and the proxy continues forwarding console bytes.
 
 Writer shutdown sequence:
 
@@ -274,29 +266,9 @@ Writer shutdown sequence:
 3. Flush the file.
 4. Close the file descriptor.
 
-If the writer encounters a fatal file error, for example disk full or write failure, it reports the error to `MirrorManager`. `MirrorManager` stops the recording session, writes syslog, updates STATE_DB state, and leaves the console forwarding path running.
+If the writer encounters a fatal file error, for example disk full or write failure, it reports the error to `MirrorManager`. `MirrorManager` stops the recording session, updates STATE_DB state, and leaves the console forwarding path running.
 
-#### 3.1.3 DisplaySink
-
-`DisplaySink` provides the optional live display for the mirror owner. It is created only when the CLI requests `--display` and attaches to an active mirror session.
-
-Only one `DisplaySink` is allowed per line. If a display sink is already attached, another attach request is rejected. This is separate from the single mirror owner rule: a line has at most one active mirror session, and that session has at most one live display sink.
-
-`DisplaySink` owns:
-
-| Resource | Description |
-|----------|-------------|
-| UDS connection | Accepted client connection from the `MirrorControlServer` back to the `consutil mirror start --display` process |
-| Display queue | Bounded queue receiving display records from `MirrorManager` |
-| Display task/thread | Background execution context that sends records to the CLI |
-
-The display path is read-only with respect to the console line. It never accepts user input for the managed device and cannot inject TX bytes.
-
-Display rendering uses the same printable escaping rules as the recording file. This prevents ANSI escape bytes and other control bytes from changing User B's terminal state. TX records may be prefixed with `[TX]` so that User B can distinguish user input from device output.
-
-If the display queue is full, `DisplaySink` drops display records and writes a syslog warning. It does not update STATE_DB and does not affect `RecordingWriter`. If the CLI disconnects, `DisplaySink` is detached, a syslog message is written, and the recording session remains active.
-
-#### 3.1.4 MirrorControlServer
+#### 3.1.3 MirrorControlServer
 
 `MirrorControlServer` is the local IPC endpoint used by `consutil mirror` to control the in-process `MirrorManager`. It is created by each per-line proxy during startup.
 
@@ -314,16 +286,17 @@ The socket is created with restrictive permissions so only Admin/root users can 
 * The caller is authorized.
 * The requested operation is supported.
 * The requested direction and resolution are valid.
+* The requested timeout is a valid positive finite duration that fits within the selected resolution's 12-digit delta range.
 * No mirror session is already active when processing `start`.
-* A mirror session is active when processing `stop` or `attach-display`.
+* A mirror session is active when processing `stop`.
 
-After validation, `MirrorControlServer` calls the corresponding `MirrorManager` method. It returns structured success or error responses to the CLI. For example, `start` returns the generated `session_id` and secure recording file path; `status` returns current STATE_DB-equivalent runtime metadata; `stop` returns the final file path.
+After validation, `MirrorControlServer` calls the corresponding `MirrorManager` method. It returns structured success or error responses to the CLI. For example, `start` returns the secure recording file path; `status` returns current STATE_DB-equivalent runtime metadata; `stop` returns the final file path.
 
 `MirrorControlServer` must not perform disk I/O or serial I/O itself. It only validates control messages, enforces access policy, and invokes `MirrorManager`.
 
 ### 3.2 Mirror Control Message Protocol
 
-This section defines the message protocol used on the `MirrorControlServer` UDS described in [MirrorControlServer](#314-mirrorcontrolserver). Control messages are JSON objects framed with a 4-byte big-endian length prefix:
+This section defines the message protocol used on the `MirrorControlServer` UDS described in [MirrorControlServer](#313-mirrorcontrolserver). Control messages are JSON objects framed with a 4-byte big-endian length prefix:
 
 ```json
 {
@@ -331,12 +304,16 @@ This section defines the message protocol used on the `MirrorControlServer` UDS 
   "line": "1",
   "direction": "both",
   "resolution": "us",
-  "display": false,
+  "timeout": "24h",
   "max_file_size": "64MiB"
 }
 ```
 
 `max_file_size` uses the same size syntax as the CLI `--max-file-size` option. Supported suffixes are `B`, `KiB`, `MiB`, and `GiB`; if no suffix is provided, the value is interpreted as bytes.
+
+`timeout` uses the same duration syntax as the CLI `--timeout` option. Supported suffixes are `s`, `m`, `h`, and `d`. If omitted, the proxy uses the default value `24h`. Zero, negative, and infinite timeout values are rejected so every mirror session has a bounded lifetime.
+
+The timeout must also be no greater than the maximum recording duration supported by the selected timestamp resolution, as defined in [Data Record Lines](#354-data-record-lines).
 
 Supported control operations:
 
@@ -345,7 +322,6 @@ Supported control operations:
 | `start` | Start a mirror session if no mirror session is active |
 | `stop` | Stop the active mirror session |
 | `status` | Return current mirror state for the line |
-| `attach-display` | Attach the calling CLI process as the single display sink |
 
 The response is also a length-prefixed JSON object. Successful responses include `status: "ok"` and operation-specific fields. Error responses include `status: "error"`, a machine-readable `code`, and a human-readable `message`.
 
@@ -354,8 +330,9 @@ Example success response for `start`:
 ```json
 {
   "status": "ok",
-  "session_id": "a1b2c3d4",
-  "file_path": "/var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log"
+  "file_path": "/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log",
+  "timeout": "24h",
+  "stop_time": "2026-06-14T14:12:00Z"
 }
 ```
 
@@ -397,30 +374,13 @@ flowchart LR
 
 This captures User A's console input without granting User B any ability to inject input.
 
-### 3.5 Live Display Mode
-
-When User B starts mirroring with live display enabled, the CLI sends `start` followed by `attach-display` on the same UDS connection. The proxy sends a copy of mirror records to this single display connection.
-
-The live display stream is an internal stream of mirror records. The CLI renders these records to User B's terminal using the same printable escaping rules as the on-disk text log. This stream does not change the on-disk text log format.
-
-Detailed display behavior:
-
-* RX bytes are written to stdout after printable escaping.
-* TX bytes may be shown with a configurable prefix, for example `[TX]`, to make user input distinguishable.
-* Non-printable bytes are escaped before being printed to User B's terminal.
-* ANSI escape bytes are printed as escaped text, for example `\x1b`, rather than being emitted as literal terminal control bytes.
-
-The display sink has its own bounded queue. If User B's terminal is slow, display records may be dropped and the proxy writes a warning to syslog. Display drop events are not recorded in STATE_DB. Dropping display records must not affect the recording writer or the console data path.
-
-If the display CLI exits, the proxy detaches only the display sink and writes a syslog message. The recording session remains active until `consutil mirror stop <line>` is executed or the proxy stops.
-
-### 3.6 Recording File Format
+### 3.5 Recording File Format
 
 The recording file is a UTF-8 text log. The format is named SCM-Text v1, short for Serial Console Mirror Text v1. It is line-oriented and append-only.
 
 The goal of the text format is to make common console output easy to inspect directly while still representing serial bytes that cannot be safely printed in a log file. Printable UTF-8 characters are written as-is. Unsafe bytes are escaped so that tools such as `cat`, `less`, `grep`, and log collectors do not interpret terminal control sequences or lose byte boundaries.
 
-#### 3.6.1 File Path
+#### 3.5.1 File Path
 
 Recording files are always written under a fixed, security-controlled directory. The CLI does not support overriding the output directory.
 
@@ -433,13 +393,13 @@ Base directory:
 Per-line recording path:
 
 ```text
-/var/log/sonic/console-mirror/line<line>/console-mirror-line<line>-<UTC timestamp>-<session id>-part<part>.log
+/var/log/sonic/console-mirror/line<line>/console-mirror-line<line>-<direction>-<UTC timestamp>-part<part>.log
 ```
 
 Example:
 
 ```text
-/var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log
+/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
 ```
 
 The `.log` extension is used to make the text nature of the recording clear.
@@ -450,11 +410,11 @@ The proxy is responsible for creating the base directory and per-line subdirecto
 |------|-------|------------|-------------|
 | `/var/log/sonic/console-mirror/` | `root:root` | `0700` | Base directory for all mirror recordings |
 | `/var/log/sonic/console-mirror/line<line>/` | `root:root` | `0700` | Per-line recording directory |
-| `console-mirror-line<line>-<timestamp>-<session_id>-part<part>.log` | `root:root` | `0600` | Recording file |
+| `console-mirror-line<line>-<direction>-<timestamp>-part<part>.log` | `root:root` | `0600` | Recording file |
 
-The proxy generates `session_id` when a mirror session starts. The value should be a random hexadecimal string generated with a cryptographically strong random source, for example `secrets.token_hex(8)`.
+The `<direction>` field is `rx`, `tx`, or `both`, matching the direction selected when the recording starts.
 
-#### 3.6.2 File Rotation
+#### 3.5.2 File Rotation
 
 Rotation is controlled by `max_file_size`, which can be set through the CLI `--max-file-size` option or the control message `max_file_size` field.
 
@@ -462,17 +422,19 @@ Rotation behavior:
 
 1. Each mirror session starts with `part0001`.
 2. Before writing a record, `RecordingWriter` checks whether appending that record would make the current file exceed `max_file_size`.
-3. If the limit would be exceeded, `RecordingWriter` writes a rotate event to the current file if space allows, flushes and closes the current file, increments the part number, opens the next file, writes header lines, and continues recording.
-4. The new file uses the same `session_id`, `line`, `start_time`, direction, and resolution, but a different part number.
-5. `STATE_DB` `file_path` is updated to the current active part file.
-6. Old part files are not deleted by this feature. Recording retention and deletion are handled by the platform log management policy.
+3. If the limit would be exceeded, `RecordingWriter` writes a rotate event to the current file if space allows, then flushes and closes the current file.
+4. The writer increments the part number, creates the new file, writes its header lines, and updates STATE_DB `file_path`.
+5. The new file uses the same line, direction, start timestamp, resolution, and timeout, but a different part number.
+6. After updating STATE_DB, the writer continues writing data records to the new part.
+
+File rotation does not reset or extend the auto-stop deadline.
 
 Example rotated files:
 
 ```text
-/var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log
-/var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0002.log
-/var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0003.log
+/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
+/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0002.log
+/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0003.log
 ```
 
 Rotate event example:
@@ -481,21 +443,21 @@ Rotate event example:
 2026-06-13T14:13:00.000000Z +000060000000us 00000125 EVENT 00000041 {"event":"rotate","next_part":"part0002"}
 ```
 
-If opening the next part file fails, `RecordingWriter` reports a fatal writer error to `MirrorManager`. The mirror session is stopped, syslog is written, STATE_DB is updated, and the normal console forwarding path continues.
+If opening the next part file fails, `RecordingWriter` reports a fatal writer error to `MirrorManager`. The mirror session is stopped, STATE_DB is updated, and the normal console forwarding path continues.
 
-#### 3.6.3 Header Lines
+#### 3.5.3 Header Lines
 
 The file starts with comment-style header lines. Header keys use `key=value` syntax.
 
 ```text
 # SONIC_CONSOLE_MIRROR_TEXT version=1
-# line=1 direction=both resolution=us start_time=2026-06-13T14:12:00.123456Z session_id=a1b2c3d4 part=part0001 encoding=printable-escape
+# line=1 direction=both resolution=us start_time=2026-06-13T14:12:00.123456Z timeout=24h stop_time=2026-06-14T14:12:00.123456Z part=part0001 encoding=printable-escape
 # fields=timestamp delta seq direction length payload
 ```
 
 Header lines start with `# ` so that simple text tools can distinguish metadata from data records.
 
-#### 3.6.4 Data Record Lines
+#### 3.5.4 Data Record Lines
 
 Each data record is written as one text line:
 
@@ -526,9 +488,17 @@ The unit suffix follows the selected timestamp resolution:
 
 | Resolution | Delta Suffix | Meaning |
 |------------|--------------|---------|
-| `ns` | `ns` | Delta value is in nanoseconds |
 | `us` | `us` | Delta value is in microseconds |
 | `ms` | `ms` | Delta value is in milliseconds |
+
+Because the delta value is limited to 12 decimal digits, its maximum value is `999999999999`. This limits the maximum recording duration:
+
+| Resolution | Maximum Duration | Approximate Duration |
+|------------|------------------|----------------------|
+| `us` | `999999.999999` seconds | 11 days, 13 hours, 46 minutes, 39.999999 seconds |
+| `ms` | `999999999.999` seconds | 11,574 days, 1 hour, 46 minutes, 39.999 seconds, or approximately 31.69 years |
+
+The proxy rejects a `start` request when its timeout exceeds the maximum duration for the selected resolution. The default `24h` timeout is valid for both supported resolutions.
 
 For example, if the recording starts at `2026-06-13T14:12:00.123456Z` and a record is created at `2026-06-13T14:12:01.000003Z`, the elapsed time is `876547` microseconds, so the `delta` field is written as `+000000876547us`. The delta field makes it easy to analyze timing gaps between RX and TX records without repeatedly subtracting absolute timestamps.
 
@@ -540,7 +510,7 @@ Example records:
 2026-06-13T14:12:01.004200Z +000000880744us 00000003 RX 00000010 \x1b[2Jlogin:
 ```
 
-#### 3.6.5 Event Lines
+#### 3.5.5 Event Lines
 
 Mirror lifecycle and error events are also written as text lines. Event lines use `EVENT` as the direction field and a JSON object as the payload.
 
@@ -548,9 +518,15 @@ Mirror lifecycle and error events are also written as text lines. Event lines us
 2026-06-13T14:12:05.000000Z +000004876544us 00000004 EVENT 00000028 {"event":"drop","count":128}
 ```
 
-Events are used for start, stop, queue overflow, display detach, and writer error.
+Events are used for start, stop, queue overflow, file rotation, and writer error.
 
-#### 3.6.6 Payload Escaping Rules
+The stop event includes the reason so tooling can distinguish manual and automatic termination:
+
+```text
+2026-06-14T14:12:00.123456Z +086400000000us 00001000 EVENT 00000035 {"event":"stop","reason":"timeout"}
+```
+
+#### 3.5.6 Payload Escaping Rules
 
 The writer applies a deterministic printable escaping function to each payload:
 
@@ -568,62 +544,69 @@ The writer applies a deterministic printable escaping function to each payload:
 
 This keeps normal console text readable while preventing terminal control sequences from changing the viewer's terminal state. For example, the ANSI clear-screen sequence is written as `\x1b[2J` rather than being emitted as a literal ESC byte.
 
-#### 3.6.7 Conversion Utility
+#### 3.5.7 Conversion Utility
 
 A conversion utility may still be provided for structured processing:
 
 ```bash
-sudo consutil mirror export console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log --format json
-sudo consutil mirror export console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log --format raw-text
+sudo consutil mirror export console-mirror-line1-both-20260613T141200Z-part0001.log --format json
+sudo consutil mirror export console-mirror-line1-both-20260613T141200Z-part0001.log --format raw-text
 ```
 
 JSON export parses the text log and preserves direction, timestamp, original byte length, and escaped payload. Raw-text export can drop metadata and print only the payload stream for quick inspection.
 
-### 3.7 Error Handling
+### 3.6 Error Handling
 
 The mirror implementation must not block or terminate the active console session because of recording errors.
 
 | Error | Behavior |
 |-------|----------|
 | File open failure | Reject `start` and report error to CLI |
+| Invalid timeout | Reject `start`; zero, negative, infinite, and resolution-overflowing values are not accepted |
+| Auto-stop timer setup failure | Reject `start` and close any newly opened recording file |
 | Disk full | Stop recording, update STATE_DB, keep console forwarding |
-| Writer queue full | Drop mirror records, write syslog warning, record a drop event when the writer queue recovers, keep forwarding |
-| Display queue full | Drop display records only, write syslog warning, keep recording |
-| Display client disconnect | Detach display, write syslog message, keep recording |
-| Proxy restart | Stop current mirror session and mark state inactive after restart |
+| Writer queue full | Drop mirror records, record a drop event when the writer queue recovers, keep forwarding |
+| Proxy restart | Stop current mirror session and mark state `idle` after restart |
 
-The writer queue should be bounded. When the queue is full, new mirror records are dropped rather than blocking the proxy, and a syslog warning is written. A drop event is inserted when the queue becomes writable again.
+The writer queue should be bounded. When the queue is full, new mirror records are dropped rather than blocking the proxy. A drop event is inserted when the queue becomes writable again.
 
-### 3.8 Service Lifecycle
+### 3.7 Service Lifecycle
 
 #### Proxy Startup
 
 1. Initialize serial and PTM resources as in the existing console monitor design.
 2. Create the per-line mirror runtime directory.
 3. Start the `MirrorControlServer`.
-4. Initialize `MirrorManager` in idle state.
+4. Initialize `MirrorManager` in idle state and overwrite any stale STATE_DB active state from an unclean restart.
 5. Enter the normal proxy forwarding loop.
 
 #### Mirror Start
 
 1. CLI connects to the per-line mirror UDS.
 2. CLI sends a `start` request.
-3. Proxy validates line, permissions, and active mirror state.
+3. Proxy validates line, permissions, active mirror state, and timeout.
 4. Proxy creates the recording file and starts `RecordingWriter`.
-5. Proxy updates STATE_DB with active mirror metadata.
-6. Proxy replies with session ID and file path.
-7. If display is requested, CLI attaches as the single display sink.
+5. Proxy calculates `stop_time`, arms the monotonic auto-stop timer, and updates STATE_DB with active mirror metadata.
+6. Proxy replies with the recording file path, timeout, and expected stop time.
 
 #### Mirror Stop
 
 1. CLI sends a `stop` request.
-2. Proxy writes a stop event to the recording file.
-3. Proxy flushes and closes the writer.
-4. Proxy clears active mirror state and updates STATE_DB.
+2. Proxy cancels the auto-stop timer.
+3. Proxy writes a stop event with `reason=manual` to the recording file.
+4. Proxy drains the queue, flushes, and closes the writer.
+5. Proxy sets the mirror state to `idle` after the final recording bytes are durable and retains the final `file_path` in STATE_DB.
+
+#### Automatic Mirror Stop
+
+1. The monotonic auto-stop deadline expires.
+2. `MirrorManager` invokes the same stop path used by the CLI with `reason=timeout`.
+3. Proxy writes the timeout stop event, drains the queue, flushes, and closes the writer.
+4. Proxy updates STATE_DB state to `idle` and retains the final recording metadata and file path.
 
 #### Proxy Shutdown
 
-On proxy shutdown, the mirror writer receives a stop event and flushes the recording file if possible. STATE_DB is updated to show the mirror session is no longer active.
+On proxy shutdown, the auto-stop timer is cancelled and the mirror writer receives a stop event and flushes the recording file if possible. STATE_DB is updated to show the mirror session is no longer active. Because no mirror configuration is stored in CONFIG_DB, the session is not restored when the proxy or device starts again.
 
 ---
 
@@ -640,14 +623,13 @@ Runtime state is stored in STATE_DB.
 | Key Format | Field | Value | Description |
 |------------|-------|-------|-------------|
 | `CONSOLE_MIRROR\|<line>` | `state` | `idle` / `active` / `error` | Mirror state |
-| `CONSOLE_MIRROR\|<line>` | `session_id` | string | Active session ID |
 | `CONSOLE_MIRROR\|<line>` | `owner_pid` | PID | CLI process that started the session |
 | `CONSOLE_MIRROR\|<line>` | `started_by` | username | User that started mirroring |
 | `CONSOLE_MIRROR\|<line>` | `start_time` | Unix timestamp | Mirror start time |
+| `CONSOLE_MIRROR\|<line>` | `timeout` | positive integer seconds | Configured auto-stop timeout |
 | `CONSOLE_MIRROR\|<line>` | `file_path` | path | Current recording file path |
 | `CONSOLE_MIRROR\|<line>` | `direction` | `rx` / `tx` / `both` | Mirrored direction |
-| `CONSOLE_MIRROR\|<line>` | `resolution` | `ns` / `us` / `ms` | Timestamp resolution |
-| `CONSOLE_MIRROR\|<line>` | `display` | `yes` / `no` | Whether display sink is attached |
+| `CONSOLE_MIRROR\|<line>` | `resolution` | `us` / `ms` | Timestamp resolution |
 
 Example:
 
@@ -655,29 +637,27 @@ Example:
 admin@sonic:~$ sonic-db-cli STATE_DB HGETALL "CONSOLE_MIRROR|1"
 1) "state"
 2) "active"
-3) "session_id"
-4) "a1b2c3d4"
-5) "owner_pid"
-6) "12345"
-7) "started_by"
-8) "admin"
-9) "start_time"
-10) "1718287920"
+3) "owner_pid"
+4) "12345"
+5) "started_by"
+6) "admin"
+7) "start_time"
+8) "1718287920"
+9) "timeout"
+10) "86400"
 11) "file_path"
-12) "/var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log"
+12) "/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log"
 13) "direction"
 14) "both"
 15) "resolution"
 16) "us"
-17) "display"
-18) "yes"
 ```
 
 ---
 
 ## 5. CLI
 
-The CLI is added under `consutil` because it operates on console lines and can optionally attach to a live terminal display.
+The CLI is added under `consutil` because it operates on console lines and manages recording lifecycle and export.
 
 CLI permission requirements:
 
@@ -700,15 +680,24 @@ Options:
 |--------|-------------|
 | `--devicename`, `-d` | Interpret target as remote device name instead of line number |
 | `--direction {rx,tx,both}` | Select mirrored direction, default `both` |
-| `--resolution {ns,us,ms}` | Timestamp resolution, default `us` |
-| `--display` | Also display mirrored traffic in the current terminal |
+| `--resolution {us,ms}` | Timestamp resolution, default `us` |
+| `--timeout <duration>` | Auto-stop timeout, default `24h`. Supported suffixes are `s`, `m`, `h`, and `d`; the value must be positive, finite, and within the selected resolution's maximum duration |
 | `--max-file-size <size>` | Maximum size of each recording part before rotation. Supported suffixes are `B`, `KiB`, `MiB`, and `GiB`; values without suffix are bytes |
 
 Example:
 
 ```bash
 sudo consutil mirror start 1 --direction both --resolution us
-sudo consutil mirror start 1 --display
+sudo consutil mirror start 1 --timeout 2h
+```
+
+Expected output when the default timeout is used:
+
+```text
+Started mirror on line [1]
+Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
+Auto-stop timeout: 24h
+Expected stop time: 2026-06-14T14:12:00Z
 ```
 
 If a mirror session is already active for the target line, the command fails:
@@ -733,7 +722,7 @@ Expected output:
 
 ```text
 Stopped mirror on line [1]
-Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log
+Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
 ```
 
 ### 5.3 Show Mirror Status
@@ -745,10 +734,10 @@ sudo consutil mirror show [target] [--devicename]
 Example output:
 
 ```text
-Line  State   Direction  Display  File
-----  ------  ---------  -------  ----
-1     active  both       yes      /var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log
-2     idle    -          no       -
+Line  State   Direction  Timeout  Stop Time             File
+----  ------  ---------  -------  --------------------  ----
+1     active  both       24h      2026-06-14T14:12:00Z  /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
+2     idle    -          -        -                     -
 ```
 
 ### 5.4 Export Recording
@@ -760,14 +749,14 @@ sudo consutil mirror export <file> --format {json,raw-text}
 Example:
 
 ```bash
-sudo consutil mirror export /var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log --format json
+sudo consutil mirror export /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log --format json
 ```
 
 ---
 
 ## 6. Example Workflow
 
-### 6.1 Record Without Live Display
+### 6.1 Manual Stop
 
 User A is connected to line 1:
 
@@ -781,7 +770,9 @@ User B starts recording line 1:
 ```bash
 admin@sonic:~$ sudo consutil mirror start 1
 Started mirror on line [1]
-Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log
+Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
+Auto-stop timeout: 24h
+Expected stop time: 2026-06-14T14:12:00Z
 ```
 
 User B stops recording:
@@ -789,20 +780,26 @@ User B stops recording:
 ```bash
 admin@sonic:~$ sudo consutil mirror stop 1
 Stopped mirror on line [1]
-Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log
+Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
 ```
 
-### 6.2 Record With Live Display
+### 6.2 Automatic Stop
 
-User B starts recording and live display:
+User B starts recording with the default 24-hour timeout:
 
 ```bash
-admin@sonic:~$ sudo consutil mirror start 1 --display
+admin@sonic:~$ sudo consutil mirror start 1
 Started mirror on line [1]
-Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-20260613T141200Z-a1b2c3d4-part0001.log
+Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
+Auto-stop timeout: 24h
+Expected stop time: 2026-06-14T14:12:00Z
 ```
 
-Mirrored RX/TX traffic is then displayed in User B's terminal. If User B exits the display process, recording remains active until `consutil mirror stop 1` is executed.
+If no manual stop is issued, the proxy stops the mirror automatically when the deadline expires. The recording ends with a timeout stop event:
+
+```text
+2026-06-14T14:12:00.000000Z +086400000000us 00001000 EVENT 00000035 {"event":"stop","reason":"timeout"}
+```
 
 ---
 
@@ -818,7 +815,7 @@ Security requirements:
 * Recording directories are created with restrictive permissions (`0700`), owned by `root:root`, and are not world-readable.
 * The UDS control socket is created with restrictive permissions so only Admin/root users can issue mirror control commands.
 * CLI output should print the recording file path and active status for auditability.
-* STATE_DB records should include `started_by`, `owner_pid`, `start_time`, and current `file_path`.
+* STATE_DB records should include `started_by`, `owner_pid`, `start_time`, `timeout` and current `file_path`.
 * Mirroring should be visible through `consutil mirror show`.
 
 This revision does not encrypt recordings. Encryption can be added later as an optional writer mode without changing the proxy interception points.

--- a/doc/console/Console-Mirror-High-Level-Design.md
+++ b/doc/console/Console-Mirror-High-Level-Design.md
@@ -43,6 +43,7 @@
       - [Proxy Startup](#proxy-startup)
       - [Mirror Start](#mirror-start)
       - [Mirror Stop](#mirror-stop)
+      - [Mirror Timeout Update](#mirror-timeout-update)
       - [Automatic Mirror Stop](#automatic-mirror-stop)
       - [Proxy Shutdown](#proxy-shutdown)
   - [4. Database Changes](#4-database-changes)
@@ -51,7 +52,8 @@
   - [5. CLI](#5-cli)
     - [5.1 Start Mirroring](#51-start-mirroring)
     - [5.2 Stop Mirroring](#52-stop-mirroring)
-    - [5.3 Show Mirror Status](#53-show-mirror-status)
+    - [5.3 Update Mirror Timeout](#53-update-mirror-timeout)
+    - [5.4 Show Mirror Status](#54-show-mirror-status)
   - [6. Example Workflow](#6-example-workflow)
     - [6.1 Manual Stop](#61-manual-stop)
     - [6.2 Automatic Stop](#62-automatic-stop)
@@ -94,10 +96,8 @@ The feature provides the following capabilities:
 * Record RX data received from the managed device.
 * Record TX data sent by the active console user.
 * Store the byte stream in a file format that preserves direction and timestamp information.
-* Support configurable timestamp resolution.
 * Allow only one mirror owner per line.
 * Automatically stop each mirror session after a finite timeout, defaulting to 24 hours.
-* Package all rotated log parts into one ZIP archive after recording stops.
 
 ---
 
@@ -141,10 +141,10 @@ flowchart LR
     archiver -->|"package and delete source parts"| files
     mirror --> state
 
-    control -->|start / stop / status| mirror
+    control -->|start / stop / timeout / status| mirror
     archiver -. "completion future" .-> control
 
-    userB["User B<br/>start / stop / show"]
+    userB["User B<br/>start / stop / timeout / show"]
 
     userB -. "UDS control messages" .-> control
 ```
@@ -204,7 +204,6 @@ The proxy main loop must keep serial forwarding as the highest priority. Recordi
 | `state` | `idle`, `active`, or `stopping` |
 | `line` | Console line owned by the proxy |
 | `direction` | `rx`, `tx`, or `both` |
-| `resolution` | Timestamp resolution for the recording |
 | `start_time` | Recording start timestamp |
 | `timeout` | Configured finite session timeout |
 | `timer` | Active auto-stop timer |
@@ -217,7 +216,8 @@ The proxy main loop must keep serial forwarding as the highest priority. Recordi
 | Method | Caller | Description |
 |--------|--------|-------------|
 | `start(options)` | `MirrorControlServer` | Validate options, create session metadata and `RecordingWriter`, set the auto-stop timer, update STATE_DB |
-| `stop(reason)` | `MirrorControlServer` or auto-stop timer | Stop recording, set STATE_DB state to `idle`, submit an immutable archive job, and return its completion future |
+| `stop(reason, archive)` | `MirrorControlServer` or auto-stop timer | Stop recording and either retain source logs or submit an immutable archive job |
+| `update_timeout(timeout)` | `MirrorControlServer` | Replace the configured timeout and reset the remaining time from the update moment |
 | `status()` | `MirrorControlServer` | Return current line mirror state |
 | `submit(direction, payload)` | Proxy forwarding loop | Best-effort submit of RX/TX data to the recording writer |
 
@@ -226,11 +226,13 @@ The proxy forwarding loop calls `MirrorManager.submit()` after it observes conso
 
 Writer submission is best effort. If the writer queue is full, `MirrorManager` increments `writer_drop_count` and does not block the forwarding loop. When the writer queue later accepts records again, `MirrorManager` emits one `EVENT` record with `reason=writer_queue_full` and the accumulated `writer_drop_count` value before recording subsequent data records.
 
-When a session starts, `MirrorManager` calculates a monotonic deadline from the configured timeout and sets the `timer`. A monotonic clock prevents wall-clock adjustments from extending or shortening the recording unexpectedly. When the deadline expires, the timer invokes `stop(reason="timeout")`. Manual stop invokes the same shutdown path with `reason="manual"` and cancels the timer.
+When a session starts, `MirrorManager` calculates a monotonic deadline from the configured timeout and sets the `timer`. A monotonic clock prevents wall-clock adjustments from extending or shortening the recording unexpectedly. When the deadline expires, the timer invokes `stop(reason="timeout", archive=true)`.
 
-The transition from `active` to `stopping` is atomic. If a manual stop races with timer expiration, only the caller that performs this transition executes the shutdown sequence; the other caller returns the resulting session state. This prevents duplicate stop events and double-closing the writer.
+`update_timeout(timeout)` validates the new duration and prepares a replacement timer with a deadline of `now + timeout`. Under the manager lock, it atomically installs the replacement and cancels the previous timer. If replacement timer setup fails, the previous timeout and timer remain active. Thus, if 5 minutes remain and the timeout is changed to `2h`, the new remaining time is 2 hours. The recording `start_time` does not change. After replacement succeeds, the update writes a timeout-change event.
 
-After the writer is closed, `MirrorManager` creates an immutable archive job containing the line, direction, recording start timestamp, recording filename prefix, expected ZIP path, and stop reason. The manager submits this job to `RecordingArchiver` and immediately transitions the mirror state to `idle`. The archiver does not read mutable fields from the next mirror session.
+The transition from `active` to `stopping` is atomic. If a manual stop, timeout update, and timer expiration race, state and timer changes are serialized. Once stopping begins, a timeout update is rejected. Only the caller that performs the transition to `stopping` executes the shutdown sequence, preventing duplicate stop events and double-closing the writer.
+
+After the writer is closed, `MirrorManager` immediately transitions the mirror state to `idle`. If archiving is requested, it creates an immutable archive job containing the line, direction, recording start timestamp, recording filename prefix, expected ZIP path, and stop reason. The archiver does not read mutable fields from the next mirror session. If archiving is not requested, all `.log` parts remain in their original directory.
 
 #### 3.1.2 RecordingWriter
 
@@ -278,7 +280,7 @@ If the writer encounters a fatal file error, for example disk full or write fail
 
 #### 3.1.3 RecordingArchiver
 
-`RecordingArchiver` runs archive jobs in a background execution context after recording has stopped. It does not run in the serial forwarding path and does not keep the mirror state active.
+`RecordingArchiver` runs requested archive jobs in a background execution context after recording has stopped. It is used when a manual stop includes `-a` / `--archive` and for every automatic timeout stop. It does not run in the serial forwarding path and does not keep the mirror state active.
 
 All parts belonging to one recording share the same filename prefix:
 
@@ -314,6 +316,8 @@ If archive creation fails, `RecordingArchiver` deletes the incomplete `.zip.tmp`
 
 Because the mirror state is already `idle`, a new mirror may start while a previous archive job is running. Recording start timestamps used in filenames must be unique for a line; the implementation uses sufficient fractional UTC precision and exclusive file creation to prevent a new session from reusing an archive job's prefix.
 
+When archiving is not requested, `RecordingArchiver` is not invoked and the original `.log` parts remain unchanged.
+
 #### 3.1.4 MirrorControlServer
 
 `MirrorControlServer` is the local IPC endpoint used by `consutil mirror` to control the in-process `MirrorManager`. It is created by each per-line proxy during startup.
@@ -331,12 +335,12 @@ The socket is created with restrictive permissions so only Admin/root users can 
 * The requested line matches the proxy line.
 * The caller is authorized.
 * The requested operation is supported.
-* The requested direction and resolution are valid.
-* The requested timeout is a valid positive finite duration that fits within the selected resolution's 12-digit delta range.
+* The requested direction is valid.
+* The requested timeout is a valid positive finite duration that fits within the fixed millisecond 12-digit delta range.
 * No mirror session is already active when processing `start`.
 * A mirror session is active when processing `stop`.
 
-After validation, `MirrorControlServer` calls the corresponding `MirrorManager` method. For `start` and `status`, it returns one structured response. For manual `stop`, it sends an initial packaging response after recording has stopped, then keeps the UDS connection open until the archive future completes and sends a final response.
+After validation, `MirrorControlServer` calls the corresponding `MirrorManager` method. For `start`, `status`, `timeout`, and a manual stop without archiving, it returns one structured response. For `stop --archive`, it sends an initial packaging response after recording has stopped, then keeps the UDS connection open until the archive future completes and sends a final response.
 
 `MirrorControlServer` must not perform disk I/O or serial I/O itself. It only validates control messages, enforces access policy, and invokes `MirrorManager`.
 
@@ -349,24 +353,24 @@ This section defines the message protocol used on the `MirrorControlServer` UDS 
   "op": "start",
   "line": "1",
   "direction": "both",
-  "resolution": "us",
   "timeout": "24h",
-  "max_file_size": "64MiB"
+  "max_file_size": 64
 }
 ```
 
-`max_file_size` uses the same size syntax as the CLI `--max-file-size` option. Supported suffixes are `B`, `KiB`, `MiB`, and `GiB`; if no suffix is provided, the value is interpreted as bytes.
+`max_file_size` uses the same value semantics as the CLI `--max-file-size` option. It is a positive integer expressed in MB. Unit suffixes are not accepted; for example, `64` means 64 MB.
 
 `timeout` uses the same duration syntax as the CLI `--timeout` option. Supported suffixes are `s`, `m`, `h`, and `d`. If omitted, the proxy uses the default value `24h`. Zero, negative, and infinite timeout values are rejected so every mirror session has a bounded lifetime.
 
-The timeout must also be no greater than the maximum recording duration supported by the selected timestamp resolution, as defined in [Data Record Lines](#354-data-record-lines).
+For `start`, the timeout must be no greater than the maximum duration supported by the fixed millisecond delta field. For `timeout`, the sum of elapsed recording time and the new timeout must not exceed that maximum, as defined in [Data Record Lines](#354-data-record-lines).
 
 Supported control operations:
 
 | Operation | Description |
 |-----------|-------------|
 | `start` | Start a mirror session if no mirror session is active |
-| `stop` | Stop the active mirror session |
+| `stop` | Stop the active mirror session and optionally archive its log parts |
+| `timeout` | Reset the timeout and remaining time of an active mirror session |
 | `status` | Return current mirror state for the line |
 
 Each response is also a length-prefixed JSON object. Successful responses include a status and operation-specific fields. Error responses include `status: "error"`, a machine-readable `code`, and a human-readable `message`.
@@ -378,7 +382,7 @@ Example success response for `start`:
   "status": "ok",
   "file_path": "/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log",
   "timeout": "24h",
-  "stop_time": "2026-06-14T14:12:00Z"
+  "remaining": "24h"
 }
 ```
 
@@ -392,7 +396,27 @@ Example error response when a mirror session is already active:
 }
 ```
 
-A manual `stop` produces two responses on the same UDS connection. The first response confirms that mirroring has ended and gives the expected archive location:
+A manual stop request contains an explicit archive flag:
+
+```json
+{
+  "op": "stop",
+  "line": "1",
+  "archive": true
+}
+```
+
+If `archive` is omitted or false, the server returns one response and leaves all log parts on disk:
+
+```json
+{
+  "status": "ok",
+  "message": "Mirror stopped; recording files retained",
+  "recording_prefix": "/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z"
+}
+```
+
+If `archive` is true, the stop produces two responses on the same UDS connection. The first response confirms that mirroring has ended and gives the expected archive location:
 
 ```json
 {
@@ -412,6 +436,41 @@ The CLI prints this information and continues waiting on the socket. When packag
 ```
 
 If the CLI disconnects while waiting, `MirrorControlServer` drops only the response subscription. The background archive job continues unchanged. If packaging fails, the final response uses `status: "error"` and reports that the original log parts were preserved.
+
+Example timeout update request:
+
+```json
+{
+  "op": "timeout",
+  "line": "1",
+  "timeout": "2h"
+}
+```
+
+Successful response:
+
+```json
+{
+  "status": "ok",
+  "timeout": "2h",
+  "remaining": "2h"
+}
+```
+
+Example status response:
+
+```json
+{
+  "status": "ok",
+  "state": "active",
+  "line": "1",
+  "start_time": "2026-06-13T14:12:00Z",
+  "direction": "both",
+  "timeout": "24h",
+  "remaining": "12h15m",
+  "file_path": "/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log"
+}
+```
 
 ### 3.3 RX Mirroring
 
@@ -492,7 +551,7 @@ The timestamp token identifies one recording and must be unique within a line di
 
 #### 3.5.2 File Rotation
 
-Rotation is controlled by `max_file_size`, which can be set through the CLI `--max-file-size` option or the control message `max_file_size` field.
+Rotation is controlled by `max_file_size`.
 
 Rotation behavior:
 
@@ -500,7 +559,7 @@ Rotation behavior:
 2. Before writing a record, `RecordingWriter` checks whether appending that record would make the current file exceed `max_file_size`.
 3. If the limit would be exceeded, `RecordingWriter` writes a rotate event to the current file if space allows, then flushes and closes the current file.
 4. The writer increments the part number, creates the new file, writes its header lines, and updates STATE_DB `file_path`.
-5. The new file uses the same line, direction, start timestamp, resolution, and timeout, but a different part number.
+5. The new file uses the same line, direction, and start timestamp, but a different part number. Its header contains the timeout effective at rotation time.
 6. After updating STATE_DB, the writer continues writing data records to the new part.
 
 File rotation does not reset or extend the auto-stop deadline.
@@ -516,7 +575,7 @@ Example rotated files:
 Rotate event example:
 
 ```text
-2026-06-13T14:13:00.000000Z +000060000000us 00000125 EVENT 00000041 {"event":"rotate","next_part":"part0002"}
+2026-06-13T14:13:00.000Z +000000060000ms 00000125 EVENT 00000041 {"event":"rotate","next_part":"part0002"}
 ```
 
 If opening the next part file fails, `RecordingWriter` reports a fatal writer error to `MirrorManager`. The mirror session is stopped, STATE_DB is updated, and the normal console forwarding path continues.
@@ -527,11 +586,13 @@ The file starts with comment-style header lines. Header keys use `key=value` syn
 
 ```text
 # SONIC_CONSOLE_MIRROR_TEXT version=1
-# line=1 direction=both resolution=us start_time=2026-06-13T14:12:00.123456Z timeout=24h stop_time=2026-06-14T14:12:00.123456Z part=part0001 encoding=printable-escape
+# line=1 direction=both start_time=2026-06-13T14:12:00.123Z timeout=24h part=part0001 encoding=printable-escape
 # fields=timestamp delta seq direction length payload
 ```
 
 Header lines start with `# ` so that simple text tools can distinguish metadata from data records.
+
+The `timeout` header value is the effective timeout when that part is created. Later timeout changes are represented by `timeout_update` event records.
 
 #### 3.5.4 Data Record Lines
 
@@ -547,8 +608,8 @@ Fields:
 
 | Field | Format | Example | Description |
 |-------|--------|---------|-------------|
-| `timestamp` | RFC 3339 UTC timestamp with configured fractional precision | `2026-06-13T14:12:01.000003Z` | Absolute time when the record is created |
-| `delta` | `+` followed by a zero-padded 12-digit decimal value and the resolution suffix | `+000000876547us` | Time elapsed since the recording start timestamp |
+| `timestamp` | RFC 3339 UTC timestamp with millisecond precision | `2026-06-13T14:12:01.000Z` | Absolute time when the record is created |
+| `delta` | `+` followed by a zero-padded 12-digit millisecond value and the `ms` suffix | `+000000000877ms` | Time elapsed since the recording start timestamp |
 | `seq` | Zero-padded 8-digit decimal number | `00000002` | Monotonic record sequence number, starting from `00000001` |
 | `direction` | Fixed token | `RX`, `TX`, or `EVENT` | Record direction or event marker |
 | `length` | Zero-padded 8-digit decimal number | `00000005` | Original payload length in bytes before escaping |
@@ -560,30 +621,16 @@ The `delta` field is a relative timestamp. It is calculated from the absolute re
 delta = record_timestamp - recording_start_timestamp
 ```
 
-The unit suffix follows the selected timestamp resolution:
+The fixed delta unit is milliseconds. Because the delta value is limited to 12 decimal digits, its maximum value is `999999999999ms`, which is approximately 11,574 days or 31.69 years. The proxy rejects a start or timeout-update request that exceeds this maximum.
 
-| Resolution | Delta Suffix | Meaning |
-|------------|--------------|---------|
-| `us` | `us` | Delta value is in microseconds |
-| `ms` | `ms` | Delta value is in milliseconds |
-
-Because the delta value is limited to 12 decimal digits, its maximum value is `999999999999`. This limits the maximum recording duration:
-
-| Resolution | Maximum Duration | Approximate Duration |
-|------------|------------------|----------------------|
-| `us` | `999999.999999` seconds | 11 days, 13 hours, 46 minutes, 39.999999 seconds |
-| `ms` | `999999999.999` seconds | 11,574 days, 1 hour, 46 minutes, 39.999 seconds, or approximately 31.69 years |
-
-The proxy rejects a `start` request when its timeout exceeds the maximum duration for the selected resolution. The default `24h` timeout is valid for both supported resolutions.
-
-For example, if the recording starts at `2026-06-13T14:12:00.123456Z` and a record is created at `2026-06-13T14:12:01.000003Z`, the elapsed time is `876547` microseconds, so the `delta` field is written as `+000000876547us`. The delta field makes it easy to analyze timing gaps between RX and TX records without repeatedly subtracting absolute timestamps.
+For example, if the recording starts at `2026-06-13T14:12:00.123Z` and a record is created at `2026-06-13T14:12:01.000Z`, the elapsed time is `877` milliseconds, so the `delta` field is written as `+000000000877ms`. The delta field makes it easy to analyze timing gaps between RX and TX records without repeatedly subtracting absolute timestamps.
 
 Example records:
 
 ```text
-2026-06-13T14:12:00.123456Z +000000000000us 00000001 RX 00000014 Booting SONiC\n
-2026-06-13T14:12:01.000003Z +000000876547us 00000002 TX 00000005 show\n
-2026-06-13T14:12:01.004200Z +000000880744us 00000003 RX 00000010 \x1b[2Jlogin:
+2026-06-13T14:12:00.123Z +000000000000ms 00000001 RX 00000014 Booting SONiC\n
+2026-06-13T14:12:01.000Z +000000000877ms 00000002 TX 00000005 show\n
+2026-06-13T14:12:01.004Z +000000000881ms 00000003 RX 00000010 \x1b[2Jlogin:
 ```
 
 #### 3.5.5 Event Lines
@@ -591,7 +638,7 @@ Example records:
 Mirror lifecycle and error events are also written as text lines. Event lines use `EVENT` as the direction field and a JSON object as the payload.
 
 ```text
-2026-06-13T14:12:05.000000Z +000004876544us 00000004 EVENT 00000028 {"event":"drop","count":128}
+2026-06-13T14:12:05.000Z +000000004877ms 00000004 EVENT 00000028 {"event":"drop","count":128}
 ```
 
 Events are used for start, stop, queue overflow, file rotation, and writer error.
@@ -599,7 +646,13 @@ Events are used for start, stop, queue overflow, file rotation, and writer error
 The stop event includes the reason so tooling can distinguish manual and automatic termination:
 
 ```text
-2026-06-14T14:12:00.123456Z +086400000000us 00001000 EVENT 00000035 {"event":"stop","reason":"timeout"}
+2026-06-14T14:12:00.123Z +000086400000ms 00001000 EVENT 00000035 {"event":"stop","reason":"timeout"}
+```
+
+A timeout update is also recorded:
+
+```text
+2026-06-13T14:55:00.123Z +000002580000ms 00000500 EVENT 00000041 {"event":"timeout_update","timeout":"2h"}
 ```
 
 #### 3.5.6 Payload Escaping Rules
@@ -627,7 +680,9 @@ The mirror implementation must not block or terminate the active console session
 | Error | Behavior |
 |-------|----------|
 | File open failure | Reject `start` and report error to CLI |
-| Invalid timeout | Reject `start`; zero, negative, infinite, and resolution-overflowing values are not accepted |
+| Invalid timeout | Reject `start` or `timeout`; zero, negative and overflowing values are not accepted |
+| Timeout update during stop | Reject the update because the session is no longer active |
+| Timeout timer reset failure | Keep the previous timeout and timer active, and return an error |
 | Auto-stop timer setup failure | Reject `start` and close any newly opened recording file |
 | Disk full | Stop recording, update STATE_DB, keep console forwarding |
 | Writer queue full | Drop mirror records, record a drop event when the writer queue recovers, keep forwarding |
@@ -655,27 +710,35 @@ The writer queue should be bounded. When the queue is full, new mirror records a
 2. CLI sends a `start` request.
 3. Proxy validates line, permissions, active mirror state, and timeout.
 4. Proxy creates the recording file and starts `RecordingWriter`.
-5. Proxy calculates `stop_time`, arms the monotonic auto-stop timer, and updates STATE_DB with active mirror metadata.
-6. Proxy replies with the recording file path, timeout, and expected stop time.
+5. Proxy calculates the deadline, arms the auto-stop timer, and updates STATE_DB with active mirror metadata.
+6. Proxy replies with the recording file path, timeout and remaining time.
 
 #### Mirror Stop
 
-1. CLI sends a `stop` request.
+1. CLI sends a `stop` request with `archive=false` by default or `archive=true` when `-a` / `--archive` is specified.
 2. Proxy cancels the auto-stop timer.
 3. Proxy writes a stop event with `reason=manual` to the recording file.
 4. Proxy drains the queue, flushes, and closes the writer.
-5. Proxy creates an immutable archive job and expected ZIP path from the stopped recording prefix.
-6. Proxy sets the mirror state to `idle` and clears active recording fields, including `file_path`, from STATE_DB.
-7. `MirrorControlServer` sends the `packaging` response. The CLI prints that mirroring has stopped and displays the expected ZIP path, then waits for another framed response.
-8. `RecordingArchiver` packages all matching part files asynchronously.
-9. When the future completes, `MirrorControlServer` sends the final archive path or error to the waiting CLI.
+5. Proxy sets the mirror state to `idle` and clears active recording fields, including `file_path`, from STATE_DB.
+6. If `archive=false`, the proxy leaves all recording parts in place and returns the recording prefix immediately.
+7. If `archive=true`, the proxy creates an immutable archive job and expected ZIP path, sends the `packaging` response, and submits the job to `RecordingArchiver`.
+8. When the archive future completes, `MirrorControlServer` sends the final archive path or error to the waiting CLI.
 
-The mirror is already idle during steps 7 through 9, so another mirror can start without waiting for packaging. A CLI process terminated during this wait does not cancel the archive job.
+The mirror is already idle during archive creation, so another mirror can start without waiting for packaging. A CLI process terminated during this wait does not cancel the archive job.
+
+#### Mirror Timeout Update
+
+1. CLI sends a `timeout` request for an active line.
+2. Proxy validates the new duration against the delta limit.
+3. Proxy prepares a replacement timer with a monotonic deadline equal to the current monotonic time plus the requested duration.
+4. Under the manager lock, the proxy installs the replacement timer, sets `timeout` to the requested duration, and cancels the previous timer. If replacement setup fails, the old timeout and timer remain active.
+5. Proxy updates STATE_DB `timeout` and writes a timeout-change event to the recording.
+6. Proxy returns the new timeout and remaining duration, which are equal immediately after the reset.
 
 #### Automatic Mirror Stop
 
 1. The monotonic auto-stop deadline expires.
-2. `MirrorManager` invokes the same stop path used by the CLI with `reason=timeout`.
+2. `MirrorManager` invokes `stop(reason="timeout", archive=true)`.
 3. Proxy writes the timeout stop event, drains the queue, flushes, and closes the writer.
 4. Proxy submits the archive job and updates STATE_DB state to `idle`, clearing active recording fields.
 5. `RecordingArchiver` packages the stopped recording in the background. There is no waiting CLI, so completion is recorded only in process logs.
@@ -705,7 +768,6 @@ Runtime state is stored in STATE_DB.
 | `CONSOLE_MIRROR\|<line>` | `timeout` | positive integer seconds | Configured auto-stop timeout |
 | `CONSOLE_MIRROR\|<line>` | `file_path` | path | Current active recording part; cleared when recording stops |
 | `CONSOLE_MIRROR\|<line>` | `direction` | `rx` / `tx` / `both` | Mirrored direction |
-| `CONSOLE_MIRROR\|<line>` | `resolution` | `us` / `ms` | Timestamp resolution |
 
 Example:
 
@@ -725,8 +787,6 @@ admin@sonic:~$ sonic-db-cli STATE_DB HGETALL "CONSOLE_MIRROR|1"
 12) "/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log"
 13) "direction"
 14) "both"
-15) "resolution"
-16) "us"
 ```
 
 ---
@@ -741,6 +801,7 @@ CLI permission requirements:
 |---------|--------------------|--------|
 | `consutil mirror start` | Admin/root | Starts a sensitive recording and creates a protected log file |
 | `consutil mirror stop` | Admin/root | Stops an active recording session |
+| `consutil mirror timeout` | Admin/root | Resets the timeout of an active recording session |
 | `consutil mirror show` | Admin/root | Exposes active recording metadata, including recording file path |
 
 ### 5.1 Start Mirroring
@@ -753,17 +814,17 @@ Options:
 
 | Option | Description |
 |--------|-------------|
-| `--devicename`, `-d` | Interpret target as remote device name instead of line number |
+| `--devicename` | Interpret target as remote device name instead of line number |
 | `--direction {rx,tx,both}` | Select mirrored direction, default `both` |
-| `--resolution {us,ms}` | Timestamp resolution, default `us` |
-| `--timeout <duration>` | Auto-stop timeout, default `24h`. Supported suffixes are `s`, `m`, `h`, and `d`; the value must be positive, finite, and within the selected resolution's maximum duration |
-| `--max-file-size <size>` | Maximum size of each recording part before rotation. Supported suffixes are `B`, `KiB`, `MiB`, and `GiB`; values without suffix are bytes |
+| `--timeout <duration>` | Auto-stop timeout, default `24h`. Supported suffixes are `s`, `m`, `h`, and `d`; the value must be positive and within the delta maximum |
+| `--max-file-size <MB>` | Maximum size of each recording part before rotation, expressed as a positive integer in MB. For example, `64` means 64 MB |
 
 Example:
 
 ```bash
-sudo consutil mirror start 1 --direction both --resolution us
+sudo consutil mirror start 1 --direction both
 sudo consutil mirror start 1 --timeout 2h
+sudo consutil mirror start 1 --max-file-size 64
 ```
 
 Expected output when the default timeout is used:
@@ -772,7 +833,7 @@ Expected output when the default timeout is used:
 Started mirror on line [1]
 Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
 Auto-stop timeout: 24h
-Expected stop time: 2026-06-14T14:12:00Z
+Remaining: 24h
 ```
 
 If a mirror session is already active for the target line, the command fails:
@@ -784,13 +845,34 @@ Cannot start mirror: line [1] already has an active mirror session
 ### 5.2 Stop Mirroring
 
 ```bash
-sudo consutil mirror stop <target> [--devicename]
+sudo consutil mirror stop <target> [OPTIONS]
 ```
+
+Options:
+
+| Option | Description |
+|--------|-------------|
+| `--devicename` | Interpret target as remote device name instead of line number |
+| `-a`, `--archive` | Package all parts into a ZIP and remove source logs after successful packaging |
 
 Example:
 
 ```bash
 sudo consutil mirror stop 1
+```
+
+By default, manual stop keeps all `.log` parts in their original directory:
+
+```text
+Stopped mirror on line [1]
+Recording files retained with prefix:
+/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z
+```
+
+Use `-a` or `--archive` to create a ZIP and remove the source logs after successful packaging:
+
+```bash
+sudo consutil mirror stop 1 -a
 ```
 
 Expected output:
@@ -805,7 +887,29 @@ Recording archive: /var/log/sonic/console-mirror/line1/console-mirror-line1-both
 
 After printing the expected archive path, the CLI remains blocked waiting for the final server response. Interrupting or terminating the CLI does not cancel packaging.
 
-### 5.3 Show Mirror Status
+### 5.3 Update Mirror Timeout
+
+```bash
+sudo consutil mirror timeout <target> <duration> [--devicename]
+```
+
+The command resets both the configured timeout and remaining session time from the moment the command is processed.
+
+Example:
+
+```bash
+sudo consutil mirror timeout 1 2h
+```
+
+Expected output:
+
+```text
+Updated mirror timeout on line [1]
+Timeout: 2h
+Remaining: 2h
+```
+
+### 5.4 Show Mirror Status
 
 ```bash
 sudo consutil mirror show [target] [--devicename]
@@ -814,11 +918,13 @@ sudo consutil mirror show [target] [--devicename]
 Example output:
 
 ```text
-Line  State   Direction  Timeout  Stop Time             File
-----  ------  ---------  -------  --------------------  ----
-1     active  both       24h      2026-06-14T14:12:00Z  /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
-2     idle    -          -        -                     -
+Line  State   Start Time            Direction  Timeout  Remaining  File
+----  ------  --------------------  ---------  -------  ---------  ----
+1     active  2026-06-13T14:12:00Z  both       24h      12h15m     /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
+2     idle    -                     -          -        -          -
 ```
+
+`Start Time` is derived from STATE_DB `start_time`. `Remaining` is calculated at request time from the in-memory deadline and is not persisted in STATE_DB.
 
 ---
 
@@ -840,13 +946,22 @@ admin@sonic:~$ sudo consutil mirror start 1
 Started mirror on line [1]
 Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
 Auto-stop timeout: 24h
-Expected stop time: 2026-06-14T14:12:00Z
+Remaining: 24h
 ```
 
-User B stops recording:
+User B stops recording without archiving:
 
 ```bash
 admin@sonic:~$ sudo consutil mirror stop 1
+Stopped mirror on line [1]
+Recording files retained with prefix:
+/var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z
+```
+
+Alternatively, User B requests an archive:
+
+```bash
+admin@sonic:~$ sudo consutil mirror stop 1 -a
 Stopped mirror on line [1]; packaging recording
 Expected archive: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z.zip
 Waiting for packaging to complete...
@@ -863,13 +978,13 @@ admin@sonic:~$ sudo consutil mirror start 1
 Started mirror on line [1]
 Recording file: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z-part0001.log
 Auto-stop timeout: 24h
-Expected stop time: 2026-06-14T14:12:00Z
+Remaining: 24h
 ```
 
 If no manual stop is issued, the proxy stops the mirror automatically when the deadline expires. The recording ends with a timeout stop event:
 
 ```text
-2026-06-14T14:12:00.000000Z +086400000000us 00001000 EVENT 00000035 {"event":"stop","reason":"timeout"}
+2026-06-14T14:12:00.000Z +000086400000ms 00001000 EVENT 00000035 {"event":"stop","reason":"timeout"}
 ```
 
 The proxy then packages all parts into:
@@ -886,7 +1001,7 @@ Console mirror recordings are highly sensitive. They may contain credentials, bo
 
 Security requirements:
 
-* Starting, stopping, or showing mirror sessions requires Admin/root privileges.
+* Starting, stopping, updating timeout, or showing mirror sessions requires Admin/root privileges.
 * Recording files are always written to `/var/log/sonic/console-mirror/`; users cannot specify a custom output directory.
 * Recording parts, temporary archives, and completed ZIP archives are created with restrictive permissions (`0600`), owned by `root:root`.
 * Recording directories are created with restrictive permissions (`0700`), owned by `root:root`, and are not world-readable.

--- a/doc/console/Console-Mirror-High-Level-Design.md
+++ b/doc/console/Console-Mirror-High-Level-Design.md
@@ -193,6 +193,8 @@ The proxy adds the following internal components:
 
 The proxy main loop must keep serial forwarding as the highest priority. Recording and archive work is offloaded to bounded queues and background tasks.
 
+The `stop --archive` archive-completion wait is bounded. After the initial packaging response, the CLI waits up to 10 minutes for the final archive response. The server also waits up to 10 minutes for archive completion.
+
 #### 3.1.1 MirrorManager
 
 `MirrorManager` is the per-line in-proxy coordinator for mirroring. It is created when the proxy starts and remains in memory for the lifetime of the proxy process.
@@ -210,6 +212,8 @@ The proxy main loop must keep serial forwarding as the highest priority. Recordi
 | `file_path` | Current recording file path under the fixed secure directory |
 | `writer` | Active `RecordingWriter`, if a session is active |
 | `writer_drop_count` | Number of writer records dropped since the last recorded drop event |
+
+Valid runtime transitions are `idle -> active` when a session starts, `active -> stopping` when a manual stop, timeout, fatal writer error, or proxy shutdown begins, and `stopping -> idle` after the writer is closed. There is no persistent `error` mirror state; errors are reported through CLI responses, process logs, and recording `EVENT` records when a recording file is still writable.
 
 `MirrorManager` exposes internal methods to the proxy and `MirrorControlServer`:
 
@@ -276,7 +280,7 @@ Writer shutdown sequence:
 3. Flush the file.
 4. Close the file descriptor.
 
-If the writer encounters a fatal file error, for example disk full or write failure, it reports the error to `MirrorManager`. `MirrorManager` stops the recording session, updates STATE_DB state, and leaves the console forwarding path running.
+If the writer encounters a fatal file error, for example disk full or write failure, it reports the error to `MirrorManager`. `MirrorManager` transitions the recording session through `stopping` to `idle`, updates STATE_DB state, and leaves the console forwarding path running.
 
 #### 3.1.3 RecordingArchiver
 
@@ -340,7 +344,9 @@ The socket is created with restrictive permissions so only Admin/root users can 
 * No mirror session is already active when processing `start`.
 * A mirror session is active when processing `stop`.
 
-After validation, `MirrorControlServer` calls the corresponding `MirrorManager` method. For `start`, `status`, `timeout`, and a manual stop without archiving, it returns one structured response. For `stop --archive`, it sends an initial packaging response after recording has stopped, then keeps the UDS connection open until the archive future completes and sends a final response.
+After validation, `MirrorControlServer` calls the corresponding `MirrorManager` method. For `start`, `status`, `timeout`, and a manual stop without archiving, it returns one structured response. For `stop --archive`, it sends an initial packaging response after recording has stopped, then keeps the UDS connection open until the archive future completes, the server-side archive wait budget expires, or the client disconnects.
+
+`MirrorControlServer` enforces a bounded archive-completion wait for `stop --archive`. It applies a 10-minute server-side wait budget for the final archive completion response. If the server-side wait budget expires before the archive future completes, the server closes the response stream without sending another response and requests cancellation of the archive job. If cancellation succeeds, the archiver removes any incomplete `.zip.tmp` file and preserves all source `.log` parts.
 
 `MirrorControlServer` must not perform disk I/O or serial I/O itself. It only validates control messages, enforces access policy, and invokes `MirrorManager`.
 
@@ -358,7 +364,7 @@ This section defines the message protocol used on the `MirrorControlServer` UDS 
 }
 ```
 
-`max_file_size` uses the same value semantics as the CLI `--max-file-size` option. It is a positive integer expressed in MB. Unit suffixes are not accepted; for example, `64` means 64 MB.
+`max_file_size` uses the same value semantics as the CLI `--max-file-size` option. It is a positive integer expressed in MB and defaults to 64 MB. Unit suffixes are not accepted; for example, `64` means 64 MB.
 
 `timeout` uses the same duration syntax as the CLI `--timeout` option. Supported suffixes are `s`, `m`, `h`, and `d`. If omitted, the proxy uses the default value `24h`. Zero, negative, and infinite timeout values are rejected so every mirror session has a bounded lifetime.
 
@@ -435,7 +441,9 @@ The CLI prints this information and continues waiting on the socket. When packag
 }
 ```
 
-If the CLI disconnects while waiting, `MirrorControlServer` drops only the response subscription. The background archive job continues unchanged. If packaging fails, the final response uses `status: "error"` and reports that the original log parts were preserved.
+If the CLI does not receive the final response within 10 minutes, it exits. If the server-side 10-minute archive wait budget expires first, the server closes the response stream without sending another response and cancels the archive job. If packaging fails before the wait budget expires, the final response uses `status: "error"` and reports that the original log parts were preserved.
+
+If the CLI disconnects while waiting, `MirrorControlServer` drops only the response subscription. The background archive job continues unchanged.
 
 Example timeout update request:
 
@@ -623,6 +631,8 @@ delta = record_timestamp - recording_start_timestamp
 
 The fixed delta unit is milliseconds. Because the delta value is limited to 12 decimal digits, its maximum value is `999999999999ms`, which is approximately 11,574 days or 31.69 years. The proxy rejects a start or timeout-update request that exceeds this maximum.
 
+Because `timestamp` and `delta` are derived from UTC wall-clock time, they are time references and are not guaranteed to be monotonic if the system clock is adjusted; `seq` is the strict monotonic ordering field.
+
 For example, if the recording starts at `2026-06-13T14:12:00.123Z` and a record is created at `2026-06-13T14:12:01.000Z`, the elapsed time is `877` milliseconds, so the `delta` field is written as `+000000000877ms`. The delta field makes it easy to analyze timing gaps between RX and TX records without repeatedly subtracting absolute timestamps.
 
 Example records:
@@ -684,13 +694,14 @@ The mirror implementation must not block or terminate the active console session
 | Timeout update during stop | Reject the update because the session is no longer active |
 | Timeout timer reset failure | Keep the previous timeout and timer active, and return an error |
 | Auto-stop timer setup failure | Reject `start` and close any newly opened recording file |
-| Disk full | Stop recording, update STATE_DB, keep console forwarding |
+| Disk full | Transition the mirror through `stopping` to `idle`, update STATE_DB, keep console forwarding |
 | Writer queue full | Drop mirror records, record a drop event when the writer queue recovers, keep forwarding |
 | ZIP creation failure | Preserve every source `.log` part, remove the incomplete `.zip.tmp`, and return an error to a waiting CLI |
 | Source log deletion failure | Keep the valid ZIP, report the undeleted source paths, and do not treat archive contents as lost |
+| Archive wait timeout | CLI exits on its own wait timeout; server-side timeout closes the response stream, cancels the archive job if possible, removes incomplete temporary archive files, and preserves source logs |
 | Stop CLI disconnect | Continue the archive job; only the final completion notification is lost |
 | Proxy exits during packaging | Preserve source logs; an incomplete temporary ZIP is not considered a completed archive |
-| Proxy restart | Stop current mirror session and mark state `idle` after restart |
+| Proxy restart | Stop any current mirror session and mark state `idle` after restart |
 
 The writer queue should be bounded. When the queue is full, new mirror records are dropped rather than blocking the proxy. A drop event is inserted when the queue becomes writable again.
 
@@ -701,7 +712,7 @@ The writer queue should be bounded. When the queue is full, new mirror records a
 1. Initialize serial and PTM resources as in the existing console monitor design.
 2. Create the per-line mirror runtime directory.
 3. Start the `MirrorControlServer`.
-4. Initialize `MirrorManager` in idle state and overwrite any stale STATE_DB active state from an unclean restart.
+4. Initialize `MirrorManager` in `idle` state and overwrite any stale STATE_DB `active` or `stopping` state from an unclean restart.
 5. Enter the normal proxy forwarding loop.
 
 #### Mirror Start
@@ -718,11 +729,13 @@ The writer queue should be bounded. When the queue is full, new mirror records a
 1. CLI sends a `stop` request with `archive=false` by default or `archive=true` when `-a` / `--archive` is specified.
 2. Proxy cancels the auto-stop timer.
 3. Proxy writes a stop event with `reason=manual` to the recording file.
-4. Proxy drains the queue, flushes, and closes the writer.
-5. Proxy sets the mirror state to `idle` and clears active recording fields, including `file_path`, from STATE_DB.
-6. If `archive=false`, the proxy leaves all recording parts in place and returns the recording prefix immediately.
-7. If `archive=true`, the proxy creates an immutable archive job and expected ZIP path, sends the `packaging` response, and submits the job to `RecordingArchiver`.
-8. When the archive future completes, `MirrorControlServer` sends the final archive path or error to the waiting CLI.
+4. Proxy atomically transitions the mirror state from `active` to `stopping` and updates STATE_DB.
+5. Proxy drains the queue, flushes, and closes the writer.
+6. Proxy sets the mirror state to `idle` and clears active recording fields, including `file_path`, from STATE_DB.
+7. If `archive=false`, the proxy leaves all recording parts in place and returns the recording prefix immediately.
+8. If `archive=true`, the proxy creates an immutable archive job and expected ZIP path, sends the `packaging` response, and submits the job to `RecordingArchiver`.
+9. When the archive future completes before the 10-minute server-side archive wait budget expires, `MirrorControlServer` sends the final archive path or error to the waiting CLI.
+10. If the 10-minute server-side wait budget expires first, `MirrorControlServer` closes the response stream and requests archive job cancellation.
 
 The mirror is already idle during archive creation, so another mirror can start without waiting for packaging. A CLI process terminated during this wait does not cancel the archive job.
 
@@ -739,13 +752,14 @@ The mirror is already idle during archive creation, so another mirror can start 
 
 1. The monotonic auto-stop deadline expires.
 2. `MirrorManager` invokes `stop(reason="timeout", archive=true)`.
-3. Proxy writes the timeout stop event, drains the queue, flushes, and closes the writer.
-4. Proxy submits the archive job and updates STATE_DB state to `idle`, clearing active recording fields.
-5. `RecordingArchiver` packages the stopped recording in the background. There is no waiting CLI, so completion is recorded only in process logs.
+3. Proxy atomically transitions the mirror state from `active` to `stopping` and updates STATE_DB.
+4. Proxy writes the timeout stop event, drains the queue, flushes, and closes the writer.
+5. Proxy submits the archive job and updates STATE_DB state to `idle`, clearing active recording fields.
+6. `RecordingArchiver` packages the stopped recording in the background. There is no waiting CLI, so completion is recorded only in process logs.
 
 #### Proxy Shutdown
 
-On proxy shutdown, the auto-stop timer is cancelled and the mirror writer receives a stop event and flushes the recording file if possible. STATE_DB is updated to show the mirror session is no longer active. In-progress archive tasks are allowed a bounded shutdown interval; if they cannot finish, source logs are preserved. Because no mirror configuration is stored in CONFIG_DB, the session is not restored when the proxy or device starts again.
+On proxy shutdown, the auto-stop timer is cancelled and the mirror writer receives a stop event and flushes the recording file if possible. If a session was `active`, it transitions through `stopping`; STATE_DB is updated to `idle` once the mirror session is no longer active. In-progress archive tasks are allowed a bounded shutdown interval; if they cannot finish, source logs are preserved.
 
 ---
 
@@ -761,7 +775,7 @@ Runtime state is stored in STATE_DB.
 
 | Key Format | Field | Value | Description |
 |------------|-------|-------|-------------|
-| `CONSOLE_MIRROR\|<line>` | `state` | `idle` / `active` / `error` | Mirror state |
+| `CONSOLE_MIRROR\|<line>` | `state` | `idle` / `active` / `stopping` | Mirror state |
 | `CONSOLE_MIRROR\|<line>` | `owner_pid` | PID | CLI process that started the session |
 | `CONSOLE_MIRROR\|<line>` | `started_by` | username | User that started mirroring |
 | `CONSOLE_MIRROR\|<line>` | `start_time` | Unix timestamp | Mirror start time |
@@ -817,7 +831,7 @@ Options:
 | `--devicename` | Interpret target as remote device name instead of line number |
 | `--direction {rx,tx,both}` | Select mirrored direction, default `both` |
 | `--timeout <duration>` | Auto-stop timeout, default `24h`. Supported suffixes are `s`, `m`, `h`, and `d`; the value must be positive and within the delta maximum |
-| `--max-file-size <MB>` | Maximum size of each recording part before rotation, expressed as a positive integer in MB. For example, `64` means 64 MB |
+| `--max-file-size <MB>` | Maximum size of each recording part before rotation, expressed as a positive integer in MB, default `64`. For example, `64` means 64 MB |
 
 Example:
 
@@ -885,7 +899,7 @@ Waiting for packaging to complete...
 Recording archive: /var/log/sonic/console-mirror/line1/console-mirror-line1-both-20260613T141200Z.zip
 ```
 
-After printing the expected archive path, the CLI remains blocked waiting for the final server response. Interrupting or terminating the CLI does not cancel packaging.
+After printing the expected archive path, the CLI waits up to 10 minutes for the final server response. If the server-side wait expires first, the server closes the response stream and cancels packaging if possible. Interrupting or terminating the CLI closes only the response subscription.
 
 ### 5.3 Update Mirror Timeout
 
@@ -1033,3 +1047,4 @@ The following items can be added in later revisions:
 2. [SONiC Console Switch High Level Design](https://github.com/sonic-net/SONiC/blob/master/doc/console/SONiC-Console-Switch-High-Level-Design.md)
 3. [sonic-net/sonic-utilities](https://github.com/sonic-net/sonic-utilities/)
 4. [sonic-utilities consutil main.py](https://github.com/sonic-net/sonic-utilities/blob/master/consutil/main.py)
+5. [sonic-net/sonic-host-services](https://github.com/sonic-net/sonic-host-services)

--- a/doc/console/Console-Mirror-High-Level-Design.md
+++ b/doc/console/Console-Mirror-High-Level-Design.md
@@ -6,6 +6,7 @@
 | Rev | Date | Author | Change Description |
 | :---: | :---------: | :--------: | ------------------ |
 | 0.1 | 06/13/2026 | William Zhang | Initial version |
+| 0.2 | 07/16/2026 | William Zhang | Define CLI audit metadata and align CLI error output |
 
 ---
 
@@ -358,11 +359,15 @@ This section defines the message protocol used on the `MirrorControlServer` UDS 
 {
   "op": "start",
   "line": "1",
+  "owner_pid": 12345,
+  "started_by": "admin",
   "direction": "both",
   "timeout": "24h",
   "max_file_size": 64
 }
 ```
+
+`owner_pid` is the PID of the `consutil` process that starts the mirror session. `started_by` is the original invoking username.
 
 `max_file_size` uses the same value semantics as the CLI `--max-file-size` option. It is a positive integer expressed in MB and defaults to 64 MB. Unit suffixes are not accepted; for example, `64` means 64 MB.
 
@@ -853,7 +858,7 @@ Remaining: 24h
 If a mirror session is already active for the target line, the command fails:
 
 ```text
-Cannot start mirror: line [1] already has an active mirror session
+Mirror request failed on line [1]: Line 1 already has an active mirror session
 ```
 
 ### 5.2 Stop Mirroring

--- a/doc/console/Console-Mirror-High-Level-Design.md
+++ b/doc/console/Console-Mirror-High-Level-Design.md
@@ -712,6 +712,8 @@ The writer queue should be bounded. When the queue is full, new mirror records a
 
 ### 3.7 Service Lifecycle
 
+![State Machine Diagram](./Console-Mirror-State-Machine.svg)
+
 #### Proxy Startup
 
 1. Initialize serial and PTM resources as in the existing console monitor design.

--- a/doc/console/Console-Mirror-High-Level-Design.md
+++ b/doc/console/Console-Mirror-High-Level-Design.md
@@ -1044,7 +1044,7 @@ The following items can be added in later revisions:
 * Recording file encryption.
 * gNOI APIs for remote start and stop.
 * Optional inclusion of console-monitor internal heartbeat frames for debugging.
-* Optional redaction filters for known sensitive patterns.
+* Optional redaction filters for known sensitive patterns (including usernames, passwords, etc.).
 
 ---
 

--- a/doc/console/Console-Mirror-State-Machine.svg
+++ b/doc/console/Console-Mirror-State-Machine.svg
@@ -1,0 +1,133 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="1100" height="420"
+     viewBox="0 0 1100 420"
+     role="img"
+     aria-labelledby="title desc">
+
+  <title id="title">Console mirror state machine</title>
+  <desc id="desc">
+    Initial state transitions to idle. Idle transitions to active on Start.
+    Active has a self-loop for Update Timeout. Active transitions to stopping
+    on Manual or Auto stop, or Fatal error. Stopping transitions back to idle
+    after the writer is closed and an archive job is submitted.
+  </desc>
+
+  <defs>
+    <marker id="arrow"
+            markerWidth="10" markerHeight="10"
+            refX="9" refY="5"
+            orient="auto"
+            markerUnits="strokeWidth">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#334155"/>
+    </marker>
+
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="3" stdDeviation="4"
+                    flood-color="#0f172a" flood-opacity="0.14"/>
+    </filter>
+
+    <style>
+      .state {
+        fill: #ffffff;
+        stroke: #334155;
+        stroke-width: 2.5;
+        filter: url(#shadow);
+      }
+
+      .state-text {
+        fill: #0f172a;
+        font-family: Inter, "Segoe UI", Arial, sans-serif;
+        font-size: 24px;
+        font-weight: 600;
+        text-anchor: middle;
+        dominant-baseline: middle;
+      }
+
+      .transition {
+        fill: none;
+        stroke: #334155;
+        stroke-width: 2.5;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        marker-end: url(#arrow);
+      }
+
+      .label-bg {
+        fill: #ffffff;
+        opacity: 0.96;
+      }
+
+      .label {
+        fill: #334155;
+        font-family: Inter, "Segoe UI", Arial, sans-serif;
+        font-size: 17px;
+        font-weight: 500;
+        text-anchor: middle;
+      }
+
+      .note {
+        fill: #475569;
+        font-family: Inter, "Segoe UI", Arial, sans-serif;
+        font-size: 16px;
+        font-weight: 500;
+        text-anchor: middle;
+      }
+
+      .initial {
+        fill: #0f172a;
+      }
+    </style>
+  </defs>
+
+  <!-- Initial node -->
+  <circle class="initial" cx="70" cy="210" r="10"/>
+  <path class="transition" d="M 82 210 H 200"/>
+
+  <!-- States -->
+  <rect class="state" x="210" y="165" width="180" height="90" rx="22"/>
+  <text class="state-text" x="300" y="210">idle</text>
+
+  <rect class="state" x="470" y="165" width="180" height="90" rx="22"/>
+  <text class="state-text" x="560" y="210">active</text>
+
+  <rect class="state" x="790" y="165" width="210" height="90" rx="22"/>
+  <text class="state-text" x="895" y="210">stopping</text>
+
+  <!-- idle -> active -->
+  <path class="transition" d="M 390 210 H 458"/>
+  <rect class="label-bg" x="405" y="177" width="38" height="24" rx="6"/>
+  <text class="label" x="424" y="195">Start</text>
+
+  <!-- active self-loop -->
+  <path class="transition"
+        d="M 520 165
+           C 505 95, 615 95, 600 165"/>
+  <rect class="label-bg" x="492" y="72" width="136" height="27" rx="7"/>
+  <text class="label" x="560" y="92">Update Timeout</text>
+
+  <!-- active -> stopping: Manual/Auto stop -->
+  <path class="transition"
+        d="M 650 190
+           C 700 155, 735 155, 790 190"/>
+  <rect class="label-bg" x="660" y="127" width="132" height="26" rx="7"/>
+  <text class="label" x="726" y="146">Manual/Auto stop</text>
+
+  <!-- active -> stopping: Fatal error -->
+  <path class="transition"
+        d="M 650 230
+           C 700 265, 735 265, 790 230"/>
+  <rect class="label-bg" x="680" y="267" width="92" height="26" rx="7"/>
+  <text class="label" x="726" y="286">Fatal error</text>
+
+  <!-- stopping -> idle -->
+  <path class="transition"
+        d="M 895 255
+           V 350
+           H 300
+           V 267"/>
+  <rect class="label-bg" x="474" y="313" width="247" height="48" rx="9"/>
+  <text class="note" x="597" y="333">
+    <tspan x="597" dy="0">Writer closed,</tspan>
+    <tspan x="597" dy="20">[archive job submitted]</tspan>
+  </text>
+</svg>


### PR DESCRIPTION
The console mirror feature enables on-demand recording of serial console traffic for a specific console line. It mirrors RX and TX data streams observed by the per-line console proxy to secure local recording files and can optionally display the mirrored stream live to the mirror user. This helps diagnose serial console issues without taking over or interrupting the active console session.

 | Description | Repo | PR title | State |
|-------------|------|----------|-------|
| Implement design in sonic-host-services | sonic-host-services | [Add console mirror recording and control support](https://github.com/sonic-net/sonic-host-services/pull/414) | Merged |
| Support CLI commands in sonic-utilities | sonic-utilities | [Add console mirror CLI commands](https://github.com/sonic-net/sonic-utilities/pull/4697) | Merged |
| Publish test plan in sonic-mgmt | sonic-mgmt | [Add Console Mirror test plan](https://github.com/sonic-net/sonic-mgmt/pull/26629) | Merged |
| Implement test in sonic-mgmt | sonic-mgmt | [Add Console Mirror test cases](https://github.com/sonic-net/sonic-mgmt/pull/27003) | Merged |
