### PR TITLE
Hardware accelerated sFlow HLD

### DIFF
--- a/doc/sflow/hw_sflow_hld.md
+++ b/doc/sflow/hw_sflow_hld.md
@@ -1,0 +1,1020 @@
+# Hardware Accelerated sFlow High Level Design
+
+## Table of Content
+
+- [1. Revision](#1-revision)
+- [2. Scope](#2-scope)
+- [3. Definitions/Abbreviations](#3-definitionsabbreviations)
+- [4. Overview](#4-overview)
+- [5. Requirements](#5-requirements)
+- [6. Architecture Design](#6-architecture-design)
+- [7. High-Level Design](#7-high-level-design)
+  - [7.1 Built-in vs Application Extension](#71-built-in-vs-application-extension)
+  - [7.2 Modified modules / repositories](#72-modified-modules--repositories)
+  - [7.3 Module interfaces and dependencies](#73-module-interfaces-and-dependencies)
+  - [7.4 SWSS changes](#74-swss-changes)
+  - [7.5 SWSS and Syncd changes in detail](#75-swss-and-syncd-changes-in-detail)
+  - [7.6 DB and Schema changes](#76-db-and-schema-changes)
+  - [7.7 Sequence diagrams](#77-sequence-diagrams)
+  - [7.8 Linux dependencies and interface](#78-linux-dependencies-and-interface)
+  - [7.9 Scalability and performance](#79-scalability-and-performance)
+  - [7.10 Management interfaces](#710-management-interfaces)
+  - [7.11 Serviceability and Debug](#711-serviceability-and-debug)
+  - [7.12 Platform-specific considerations](#712-platform-specific-considerations)
+- [8. SAI API](#8-sai-api)
+- [9. Configuration and management](#9-configuration-and-management)
+  - [9.1 Manifest (if the feature is an Application Extension)](#91-manifest-if-the-feature-is-an-application-extension)
+  - [9.2 CLI / YANG model Enhancements](#92-cli--yang-model-enhancements)
+  - [9.3 Config DB Enhancements](#93-config-db-enhancements)
+  - [9.4 End-to-end CONFIG_DB walkthrough](#94-end-to-end-config_db-walkthrough)
+- [10. Warmboot and Fastboot Design Impact](#10-warmboot-and-fastboot-design-impact)
+- [11. Memory Consumption](#11-memory-consumption)
+- [12. Restrictions / Limitations](#12-restrictions--limitations)
+- [13. Testing Requirements / Design](#13-testing-requirements--design)
+  - [13.1 Unit test cases](#131-unit-test-cases)
+  - [13.2 System test cases](#132-system-test-cases)
+- [14. Open / Action items](#14-open--action-items)
+
+### 1\. Revision
+
+| Revision | Date | Author | Change Description |
+| ----- | ----- | ----- | ----- |
+| 0.1 | 2026-06-01 | Darius Grassi | Initial Proposal |
+
+### 2\. Scope
+
+This document describes the addition of an optional sFlow feature in
+SONiC, hardware accelerated sFlow. The design proposes new paths through
+existing orchagents to wire the relevant SAI attribute with their
+underlying hardware-capable platforms, while reusing logic from existing
+implementations. The goals are to:
+- Add a new path through SONiC for sFlow telemetry to configure an
+increasingly-supported silicon feature
+- Limit drastic changes to the fundamental SONiC behavior while doing so
+
+### 3\. Definitions/Abbreviations
+
+| Term | Definition |
+| :---- | :---- |
+| sFlow | Sampled flow, RFC 3176 / sflow.org v5 |
+| HW sFlow | Hardware accelerated sFlow |
+| CPU sFlow | The existing sample-and-punt sFlow path documented in SONiC’s [`sflow_hld.md`](https://github.com/sonic-net/SONiC/blob/master/doc/sflow/sflow_hld.md) |
+| SAI | Switch Abstraction Interface |
+| MOD | Mirror-on-Drop |
+| COPP | Control Plane Policing (host-interface trap rate limiter) |
+| `MIRROR_SESSION_TYPE_SFLOW` | SAI mirror session type that builds sFlow v5 datagrams in silicon ([`saimirror.h:51`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h)). Today's SAI surface; subject to change. |
+| `INGRESS_SAMPLE_MIRROR_SESSION` | SAI port attribute binding a list of sampled mirror sessions for ingress sampling ([`saiport.h:1399-1423`](https://github.com/opencomputeproject/SAI/blob/master/inc/saiport.h)) |
+| TAM | Telemetry and Monitoring |
+| TamOrch | Orchagent in `sonic-swss` that owns SAI TAM objects. Proposed in unmerged [sonic-swss#4370](https://github.com/sonic-net/sonic-swss/pull/4370); not present on `master`. |
+| hsflowd | InMon's host-sflow agent (`https://github.com/sflow/host-sflow`) |
+
+### 4\. Overview
+
+In the existing SONiC sFlow architecture, all sampled packets are punted
+to the CPU over a generic-netlink channel and `hsflowd` performs sFlow
+datagram construction in userspace. This works well at moderate sampling
+rates and link speeds, but is sharply rate-limited on multi-Tbps
+platforms: every sample must cross the COPP policer, the kernel
+genetlink path, the userspace agent, and the kernel UDP send path.
+
+Concretely: the SONiC default COPP configuration installs the
+`sample_packet` trap at 1000 packets per second (see
+[`copp_cfg.j2:76-88,
+135-138`](https://github.com/sonic-net/sonic-buildimage/blob/master/files/image_config/copp/copp_cfg.j2)).
+For comparison, a single 800G port at line rate with 64-byte frames
+produces ~1.19 Gpps; sampling at 1-in-2048 yields ~580K samples per
+second, well over the COPP cap on one port alone. Operators who raise
+the cap trade CPU saturation for sample completeness; neither outcome
+is desirable.
+
+Multi-Tbps platforms increasingly support an alternative model in which
+a hardware block:
+
+1. Performs the 1-in-N sampling decision in the ingress (and/or egress)
+   pipeline.
+2. Truncates the sampled packet to the configured header size.
+3. Prepends sFlow flow-record fields (using preserved system metadata to
+   recover ingress / egress port info).
+4. Prepends the sFlow datagram header, with an HW-maintained sequence
+   number.
+5. Prepends an Ethernet/IP/UDP encapsulation toward the configured
+   collector, stamping the UDP checksum.
+6. Emits the resulting sFlow v5 UDP datagram out a normal egress port.
+
+In this model, the host CPU is involved only at session-create time (to
+load the sample rate, the encap template, and the datagram-header layout
+into silicon) and at re-program time (to refresh the encap when the
+next-hop or source IP changes). Steady-state sample throughput is
+decoupled from CPU and COPP capacity.
+
+This document describes the high-level design for hardware accelerated
+sFlow in SONiC: an alternative datapath in which sampled packets are
+encapsulated and emitted as wire-format sFlow v5 UDP datagrams by the
+forwarding silicon itself.
+
+This HLD proposes to wire this path by extending the existing
+`SflowOrch` with a new sibling class, `HwSflow`, that owns the HW sFlow
+lifecycle. The CPU-based path documented in
+[`doc/sflow/sflow_hld.md`](https://github.com/sonic-net/SONiC/blob/master/doc/sflow/sflow_hld.md)
+remains the default path on platforms that lack the necessary silicon
+support.
+
+### 5\. Requirements
+
+#### Phase I
+
+1. Detect platform capability for HW sFlow via SAI capability query, and
+   reflect it in `STATE_DB:SWITCH_CAPABILITY`.
+2. Support configuring HW sFlow on physical interfaces in both ingress
+   and egress directions, reusing the existing per-port
+`sample_direction: rx | tx | both` setting on `SFLOW_SESSION` rows.
+3. Support up to 4 concurrent sFlow collectors, subject to the
+   hardware-advertised session maximum.
+4. Support IPv4 and IPv6 collectors.
+5. Select the sFlow datapath automatically from platform capability:
+   HW sFlow on platforms that advertise it, CPU sFlow otherwise,
+uniformly across all sFlow-enabled ports and collectors. The operator
+does not configure the datapath in the normal workflow. A system-wide
+`mode` override knob (`auto` / `hw-accelerated` / `cpu-path`, default
+`auto`) exists for debug and forced-path scenarios only.
+6. Resolve the destination MAC, source MAC, source IP, and other
+   encapsulation parameters automatically from kernel routing/neighbor
+state.
+7. Automatically refresh the silicon encap when the resolved next-hop
+   MAC, source IP, or routing changes.
+8. Counter samples and MOD notifications (when MOD is performed via
+   sFlow) continue to be produced by the existing CPU path even when HW
+sFlow is active.
+9. Portchannel (LAG) interface support, including LAG-egress sampling.
+
+#### Phase II
+
+10. Operator configuration of resolved encap fields (manual TOS/TTL).
+
+#### Not planned to be supported
+
+1. HW-accelerated counter samples (out of scope).
+2. ACL-driven HW sFlow sessions (support is be port-level only).
+
+### 6\. Architecture Design
+
+This change extends `SflowOrch` in `sonic-swss` with a new `HwSflow`
+sibling class and adds CLI / YANG / CONFIG_DB fields. SAI TAM APIs are
+called directly from `SflowOrch::HwSflow`. The sibling-class shape is
+identical to `SflowDropMonitor` in the unmerged
+[`sonic-net/sonic-swss#3970`](https://github.com/sonic-net/sonic-swss/pull/3970).
+
+HW sFlow is the same operator-facing feature as CPU sFlow with a
+different datapath, so it stays under the `sflow` CLI/CONFIG_DB namespace
+and `SflowOrch` owns both paths. The operator never configures or sees
+TAM rows; platform capability selects the datapath (with `mode` as a
+debug override, §7.5). The cost is that
+`SflowOrch::HwSflow` carries its own `NeighOrch` / `RouteOrch` resolver,
+duplicating logic also present in `MirrorOrch` (resolver consolidation is
+tracked in §14 item 1).
+
+### 7\. High-Level Design
+
+The design extends `SflowOrch` in `sonic-swss` with a new `HwSflow`
+sibling class that owns the HW sFlow lifecycle: collector/encap
+resolution against `NeighOrch` / `RouteOrch`, SAI TAM object create /
+update / delete, the sFlow session SAI object, and per-port binding via
+`INGRESS_SAMPLE_MIRROR_SESSION` / `EGRESS_SAMPLE_MIRROR_SESSION`.
+
+The current design gates on silicon SAI support
+(`SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` and the egress
+equivalent, plus `SAI_MIRROR_SESSION_TYPE_SFLOW` or its TAM-namespace
+successor - see §7.12).
+
+### 7.1 Built-in vs Application Extension
+
+Built-in feature modification.
+
+### 7.2 Modified modules / repositories
+
+| Repository | Component | Change |
+| :---- | :---- | :---- |
+| `sonic-swss` | `SflowOrch` | New `HwSflow` sibling class that consumes `SFLOW_COLLECTOR`, attaches `Observer`s to `NeighOrch` and `RouteOrch`, resolves `(dst_mac, src_mac, egress_port)` against kernel routing/neighbor state and pins encap `src_ip` to `SFLOW|global:agent_id`'s IP (see §7.5) on session create and on observer-callback refresh, calls SAI TAM APIs directly to create `TAM_TRANSPORT` / `TAM_COLLECTOR` / sFlow session, and binds the result via `INGRESS_SAMPLE_MIRROR_SESSION` / `EGRESS_SAMPLE_MIRROR_SESSION`. |
+| `sonic-swss` | `SflowOrch::HwSflow` resolver | New. |
+| `sonic-swss` | `SwitchOrch` | Expose `INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE` (and the egress equivalent) from `sai_query_attribute_capability()` in `STATE_DB:SWITCH_CAPABILITY`. |
+| `sonic-utilities` | `config sflow` / `show sflow` | New `mode` override knob (debug; default `auto`) and diagnostic output. HW sFlow is fully driven through `config sflow` (single operator CLI surface); the normal workflow needs no datapath config. |
+| `sonic-yang-models` | `sonic-sflow.yang` | Add `mode` field. |
+| `sonic-buildimage` | sflow container | hsflowd config template: optional `sub_agent_id` field (open issue, see §14). |
+| `sonic-buildimage` | `db_migrator.py` | Migrate existing config to new schema (additive, absent `mode` = `auto`). |
+| `sonic-mgmt` | tests | New PTF tests for HW path (see §13). |
+
+### 7.3 Module interfaces and dependencies
+
+* `SflowOrch::HwSflow` consumes
+`STATE_DB:SWITCH_CAPABILITY:INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE` (and
+the egress equivalent) to gate the HW path globally. The selected path
+applies to the entire system.
+* `SflowOrch::HwSflow` consumes `APP_DB:SFLOW_SESSION_TABLE` and
+`CONFIG_DB:SFLOW_COLLECTOR`. It performs collector resolution using a
+new resolver attached to `NeighOrch` and `RouteOrch`, modeled on
+resolvers from `MirrorOrch` and `TamOrch` (unmerged).
+It then calls SAI TAM APIs directly to create one
+`SAI_OBJECT_TYPE_TAM_TRANSPORT` (refcounted across collectors) and one
+`SAI_OBJECT_TYPE_TAM_COLLECTOR` per collector, plus the sFlow session
+SAI object.
+* `SflowOrch::HwSflow` binds the resulting session OID via
+`SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` (or its TAM-namespace
+successor; see §7.12) on each enabled port, honoring `sample_direction`
+to also bind `EGRESS_SAMPLE_MIRROR_SESSION` when configured.
+
+### 7.4 SWSS changes
+
+A new sibling class `HwSflow` is added inside `SflowOrch` (same shape as
+`SflowDropMonitor` in
+[sonic-swss#3970](https://github.com/sonic-net/sonic-swss/pull/3970)),
+plus a `mode` knob in `SFLOW|global`. The `HwSflow` class consumes
+`SFLOW_COLLECTOR`, attaches a new resolver to `NeighOrch` / `RouteOrch`,
+calls SAI TAM APIs directly, and binds the resulting session via port
+attributes.
+
+### 7.5 SWSS and Syncd changes in detail
+
+#### Object graph diagram
+
+The diagram below shows the SAI object graph that `SflowOrch::HwSflow`
+creates per configured collector.
+
+```mermaid
+flowchart TB
+    subgraph SFO["SflowOrch (sonic-swss)"]
+        HwSflow["HwSflow sibling class<br/>(includes NeighOrch/RouteOrch resolver)"]
+        SP["SAI_OBJECT_TYPE_SAMPLEPACKET<br/>(CPU path only — idle when HW active)"]
+    end
+
+    HwSflow -->|creates| TT["SAI_OBJECT_TYPE_TAM_TRANSPORT<br/>SRC/DST_MAC, SRC/DST_PORT<br/>refcounted across collectors"]
+    HwSflow -->|creates| TC["SAI_OBJECT_TYPE_TAM_COLLECTOR<br/>SRC/DST_IP, DSCP"]
+    TC -.->|references| TT
+    HwSflow -->|creates| SES["sFlow session SAI object<br/>today: SAI_OBJECT_TYPE_MIRROR_SESSION<br/>TYPE=SFLOW<br/>future: TAM-namespaced object"]
+    SES -.->|carries SAMPLE_RATE,<br/>TRUNCATE_SIZE, UDP_*,<br/>encap fields| TC
+
+    HwSflow -->|binds OID| PORT["Port:<br/>SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION<br/>and/or _EGRESS_SAMPLE_MIRROR_SESSION"]
+    SES -.->|bound to| PORT
+```
+
+#### Producer / consumer split
+
+`SflowOrch::HwSflow` is both the producer (consuming `SFLOW` /
+`SFLOW_COLLECTOR`, resolving encap) and the consumer (calling SAI TAM
+APIs, binding port attributes). The operator never sees `TAM_SESSION`
+rows because HW sFlow is fully encapsulated under the `sflow` CLI
+namespace.
+
+`HwSflow` handles address resolution as well. On session create, it
+walks `NeighOrch` / `RouteOrch` to populate `(dst_mac, src_mac,
+egress_port)` and pins `src_ip` to `agent_id`'s IP (see §7.5 "Agent
+address coupling"), and registers as a neighbor / next-hop observer to
+refresh on kernel state changes. A future refactor extracting this
+resolver into a shared helper is tracked in §14; it is out of scope for
+this work.
+
+`SflowOrch` resolves the system-wide effective path from platform
+capability and `SFLOW|global:mode` (default `auto`; explicit values are
+a debug/override facility, not the normal workflow):
+
+  | `mode` | Capable | Effective path |
+  | :---- | :---- | :---- |
+  | `auto` (default) | yes | HW |
+  | `auto` (default) | no | CPU (`STATE_DB:SFLOW_STATE.path_reason` records why, e.g. `platform_not_capable`) |
+  | `cpu-path` | (any) | CPU (forced) |
+  | `hw-accelerated` | yes | HW (forced) |
+  | `hw-accelerated` | no | **failed** (sFlow admin-down, WARN syslog, `STATE_DB:SFLOW_STATE.path_reason=platform_not_capable`) |
+
+"Capable" means the platform advertises the capability bits required by
+the *current config*: ingress support always, plus egress support when
+any port is configured `sample_direction=tx`/`both`. Under `auto` a
+config that demands egress sampling on an ingress-only platform
+therefore resolves to CPU (uniform system-wide path, reason
+`egress_sample_not_capable`), never to `failed`. Capability selection
+happens at path-selection time only — `auto` is not an error-driven
+runtime fallback. If the HW path is selected and later hits a
+structural failure, the system reports `active_path=failed` (see
+below) rather than silently reverting to CPU.
+
+On entering HW path, `SflowOrch` creates one `TAM_TRANSPORT` + one
+`TAM_COLLECTOR` per configured collector, plus the sFlow session SAI
+object, then binds the session OID via the appropriate port attribute(s)
+honoring `sample_direction`. On entering CPU path it uses the existing
+`SAI_OBJECT_TYPE_SAMPLEPACKET` flow unchanged. Mode transitions tear
+down the old path's SAI state before standing up the new path's; a brief
+sampling outage is expected.
+
+**Collector over-subscription.** When the configured collector count
+exceeds the supported maximum (the lesser of the 4-collector scaling
+target, §5 requirement 3, and the platform's advertised limit),
+`SflowOrch::HwSflow` programs
+the first N collectors (sorted by name, so the set is stable across
+restarts and reconciles) and leaves the rest unprogrammed —
+`SFLOW_COLLECTOR_STATE.PROGRAMMED=false,
+LAST_ERROR=hw_session_limit_exceeded`, plus a WARN syslog naming them. The
+system stays `active_path=hw` rather than failing wholesale for one excess
+row.
+
+#### Lifecycle implications
+
+`HwSflow` must handle next-hop / encap changes and operator-driven
+sample-rate changes. The current plan is **tear-down + recreate**: delete
+the `TAM_COLLECTOR`, decrement the `TAM_TRANSPORT` refcount, recreate — so
+the vendor driver sees a delete-then-create on every attribute change,
+costing a sampling gap and a sequence-number reset. An in-place
+`set_*_attribute()` fast path is not uniformly available (not all
+attributes support it on every platform — see §7.12) and is tracked as a
+§14 enhancement.
+
+#### Partial-create failure handling
+
+Programming a collector is a sequence: `TAM_TRANSPORT` (or a refcount bump
+on an existing one) → `TAM_COLLECTOR` → sFlow session object → port
+binding. If any step fails, `HwSflow` unwinds in reverse, deleting only
+what this collector created and decrementing the shared `TAM_TRANSPORT`
+refcount (objects shared with other collectors stay intact) — so no
+partial graph is ever left bound to a port. The failed collector is
+flagged `SFLOW_COLLECTOR_STATE.PROGRAMMED=false` with the SAI error in
+`LAST_ERROR`; others are unaffected. A structural failure (e.g. capability
+lost) escalates to the system-wide `SFLOW_STATE.active_path=failed` path
+instead.
+
+Lifecycle gaps in the resolver, not specific to HW sFlow:
+
+* **Egress port programming.** The resolver resolves the egress port but
+does not pass it into a SAI attribute today; silicon IP route lookup
+determines egress at emit time. Whether HW sFlow needs explicit
+egress-port pinning is a vendor-contract question (§7.12, §14).
+* **ECMP and LAG distribution.** The resolver picks the first nexthop and
+the first LAG member. Must be resolved in Phase I alongside LAG support
+(§5 requirement 9, §14 open item).
+* **L4 source port stability.** The resolver uses a random ephemeral port
+per session. Phase I HW sFlow accepts random-per-session; stable-port is
+tracked in §14.
+
+#### Agent address coupling
+
+Every sFlow v5 datagram carries an *Agent Address*: the IP the collector
+uses as primary key to group a switch's samples (distinct from the
+arbitrary-integer `sub_agent_id` — §14 item 2). In the CPU path, `hsflowd`
+sets it from `SFLOW|global:agent_id`, decoupled from transport. On the HW
+path the silicon reuses the encap source IP and exposes no separate Agent
+Address field, so identity and transport source are *coupled by
+construction* (per the §7.12 item 1 contract, the Agent Address is the
+session source-IP attribute `SAI_MIRROR_SESSION_ATTR_SRC_IP_ADDRESS`).
+
+`SflowOrch::HwSflow` resolves this in the operator's favor: the encap
+source IP is **pinned to `agent_id`'s resolved IP for every collector**
+(only `dst_mac`, `src_mac`, `egress_port` come from the route lookup).
+With the §7.12 item 1 vendor contract that the v5 Agent Address *is* the
+session source IP, the Agent Address equals `agent_id`'s IP by
+construction — nothing to detect or fail on, and a loopback source still
+routes to any collector normally. The cost is a documented limitation
+(§12 item 4): unlike the CPU path, HW cannot decouple advertised identity
+from transport source; such a config still works, it just emits with both
+equal to `agent_id`'s IP.
+
+#### Syncd
+
+No SAI API additions are needed today. The relevant enums and attributes
+(`SAI_MIRROR_SESSION_TYPE_SFLOW`,
+`SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION`,
+`SAI_MIRROR_SESSION_ATTR_SAMPLE_RATE`), and the TAM transport/collector
+attributes are all existing standard enums. If the SAI surface for
+sampling migrates to the TAM namespace, `HwSflow` picks up the new APIs
+through the standard sairedis surface; no syncd changes are anticipated.
+
+### 7.6 DB and Schema changes
+
+**Existing tables (unchanged in Phase I):**
+
+* `CONFIG_DB:SFLOW_COLLECTOR`: unchanged in Phase I. (Phase II MAY add
+optional manual-override fields for encap.)
+* `APP_DB:SFLOW_SESSION_TABLE`: unchanged. The per-port
+`sample_direction: rx | tx | both` field is honored on the HW path in
+both directions.
+* `APP_DB`: no new tables.
+
+**New / extended tables:**
+
+* `STATE_DB:SWITCH_CAPABILITY`: NEW
+`INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE` (and the egress equivalent).
+Attribute names preserved across the SAI-namespace question; if the
+capability query migrates, the bits are renamed in lockstep.
+* `CONFIG_DB:SFLOW`: add optional `mode` field (`auto` |
+`hw-accelerated` | `cpu-path`; default `auto`). Absent in the normal
+workflow — explicit values are a debug/override facility.
+* `STATE_DB:SFLOW_STATE`: NEW single `|global` row exposing configured
+`mode`, resolved system-wide `active_path` (`hw` / `cpu` / `failed`),
+`path_reason`, and last update timestamp. Populated by `SflowOrch`.
+* `STATE_DB:SFLOW_COLLECTOR_STATE`: NEW per-collector view: resolved
+encap fields, SAI session OID, last error, last update timestamp.
+Populated by `SflowOrch::HwSflow` only when the system is in HW mode.
+
+`SflowOrch::HwSflow` calls SAI TAM APIs directly; no `CFG_TAM_*` rows
+are introduced. The HW sFlow session is implicit in the `SFLOW` /
+`SFLOW_COLLECTOR` configuration plus the `mode` knob.
+
+### 7.7 Sequence diagrams
+
+#### Initial enablement, HW path
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Op as Operator (CLI)
+    participant Redis as CONFIG_DB / STATE_DB
+    participant SO as SflowOrch::HwSflow
+    participant NO as NeighOrch + RouteOrch
+    participant SAI as SAI / vendor driver
+    participant HW as Silicon
+    participant Col as Collector
+
+    Op->>Redis: config sflow enable<br/>config sflow collector add ts1 198.51.100.5
+    Note right of Redis: SFLOW|global (mode absent = auto)<br/>SFLOW_COLLECTOR|ts1
+
+    Redis-->>SO: SFLOW + SFLOW_COLLECTOR updates
+    SO->>Redis: read STATE_DB:SWITCH_CAPABILITY<br/>INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE = true
+    SO->>SO: mode=auto + platform capable → HW path selected
+
+    SO->>NO: resolve(198.51.100.5)
+    NO-->>SO: dst_mac, src_mac, egress_port<br/>(src_ip pinned to agent_id IP)
+
+    SO->>SAI: create_tam_transport(SRC/DST_MAC, SRC/DST_PORT)
+    SO->>SAI: create_tam_collector(SRC/DST_IP, TRANSPORT, DSCP)
+    SO->>SAI: create sFlow session<br/>(TYPE=SFLOW, SAMPLE_RATE, TRUNCATE_SIZE,<br/>SRC/DST_IP, SRC/DST_MAC, UDP_SRC/DST_PORT)
+    Note right of SAI: Today: SAI_OBJECT_TYPE_MIRROR_SESSION<br/>Future: TAM-namespaced object<br/>(see §7.12)
+    SAI->>HW: program sampler + encap
+    SAI-->>SO: session_oid
+
+    loop for each enabled port
+        SO->>SAI: set_port_attribute(port,<br/>INGRESS_SAMPLE_MIRROR_SESSION and/or<br/>EGRESS_SAMPLE_MIRROR_SESSION, [oid])
+        SAI->>HW: enable 1-in-N sampler on port
+    end
+
+    SO->>Redis: STATE_DB:SFLOW_STATE|global<br/>mode=auto, active_path=hw
+    SO->>Redis: STATE_DB:SFLOW_COLLECTOR_STATE|ts1<br/>session_oid, resolved_*
+
+    Note over HW: ASIC samples 1-in-N, builds<br/>sFlow v5 datagram in silicon
+    HW->>Col: sFlow v5 UDP datagrams (front-panel egress)
+```
+
+#### Next-hop change
+
+The HW-side outcome is a sampling gap with a sequence-number reset. The
+diagram below traces the tear-down + recreate path.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant K as Kernel (rtnetlink)
+    participant NO as NeighOrch
+    participant Owner as SflowOrch::HwSflow
+    participant SAI as SAI / vendor driver
+    participant HW as Silicon
+    participant Col as Collector
+
+    Note over HW,Col: Steady state — silicon emits sFlow v5<br/>with current DST_MAC
+
+    K->>NO: NEIGH update (ARP refresh / route change)
+    NO->>NO: update APP_NEIGH_TABLE
+    NO-->>Owner: NeighborUpdate / NextHopUpdate
+
+    Owner->>Owner: re-resolve → new dst_mac
+
+    rect rgb(245,245,235)
+        Note over Owner,HW: Tear-down + recreate path<br/>(set_*_attribute fast path is a future enhancement —<br/>see §7.9 and §12 item 6)
+        Owner->>SAI: delete sFlow session OID
+        Owner->>SAI: delete_tam_collector(old_oid)
+        Owner->>SAI: tam_transport refcount--<br/>(delete if last user)
+        Owner->>SAI: create_tam_transport(new SRC/DST_MAC)
+        Owner->>SAI: create_tam_collector(new SRC/DST_IP, TRANSPORT)
+        Owner->>SAI: create sFlow session<br/>(SAMPLE_RATE, TRUNCATE_SIZE, UDP_*, ...)
+        SAI->>HW: tear down old HW sFlow session + encap<br/>(sampling stops — destination gone)
+        SAI->>HW: program new session with new DST_MAC<br/>(sequence number resets to base)
+        SAI->>HW: sampling resumes on the recreated session
+    end
+
+    SAI-->>Owner: new session_oid
+
+    Note over HW,Col: Sampling gap during tear-down + recreate<br/>(vendor-specific, see §7.9). Sequence number<br/>restarts from 0.
+    HW->>Col: sFlow v5 datagrams resume
+```
+
+### 7.8 Linux dependencies and interface
+
+* Collector resolution consumes the same kernel interfaces SONiC already
+uses for routing/neighbor state (rtnetlink via `NeighOrch` /
+`RouteOrch`). No new kernel modules and no new subscriptions specific
+to sFlow.
+* `psample` and `NET_DM` genetlink remain in use for counter samples and
+MOD respectively.
+* Outbound sFlow datagrams on the HW path do not pass through any Linux
+netdev. Standard packet-capture tools on the management / front-panel
+netdevs WILL NOT see HW sFlow traffic; vendor-specific debug tools are
+required. (Egress-port TX counters do count HW-emitted datagrams.)
+
+### 7.9 Scalability and performance
+
+* HW path supports flow-sample rates limited by silicon (typically full
+line-rate at the configured 1-in-N divisor).
+* Sample-rate or encap changes on the HW path trigger a tear-down +
+recreate of the SAI session (lifecycle detail in §7.5), costing a
+sampling gap and sequence-number reset per change.
+
+Because each change costs a gap, `HwSflow` owns a short coalescing window
+(debounce) over config-driven changes: rapid successive writes to
+`sample_rate` or encap-affecting fields for a given collector collapse
+into a single tear-down + recreate once the window settles, rather than
+one recreate per write. The default window is a small fixed interval
+(~100 ms, tunable), well under operator-perceptible latency while
+absorbing bursts of CLI or route churn. A `set_*_attribute()` fast path,
+where the silicon supports it, would shrink the per-change cost further
+(tracked in §14).
+
+### 7.10 Management interfaces
+
+* CLI: see [Section 9.2](#92-cli--yang-model-enhancements) (`config
+sflow` / `show sflow`).
+* gNMI / REST: derived from the YANG model, additive.
+
+### 7.11 Serviceability and Debug
+
+* `STATE_DB:SFLOW_STATE|global` exposes the configured `mode`, the
+resolved system-wide active path, and the `path_reason` on forced-mode
+failure or when `auto` resolves to CPU.
+* Per-collector resolution (encap fields, SAI session OID, last error)
+is exposed via `STATE_DB:SFLOW_COLLECTOR_STATE`.
+* `show sflow` CLI reports the system active path, the configured
+`mode`, and per-collector resolved encap. See §9.2.
+* `SflowOrch` emits syslog at INFO on mode transitions and at
+WARN/ERROR on capability mismatches and resolution failures.
+* **Egress port TX counters MAY include HW-emitted sFlow datagrams**
+(vendor-specific, not HLD-mandated). Operators
+troubleshooting "collector sees nothing" should not expect a missing-TX
+symptom on the egress port (§7.8).
+* **Per-session HW emit counter**: neither SAI's `MIRROR_SESSION`
+surface nor the `TAM_COLLECTOR` / `TAM_TRANSPORT` surface standardizes a
+`samples_generated` counter. Vendor-specific counters MAY be exposed via
+debug CLI. Capture as §14 open item for the SAI community.
+
+### 7.12 Platform-specific considerations
+
+This feature is **only effective on platforms whose SAI advertises**
+`SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` capability (and the egress
+equivalent for §5 requirement 2) AND maps
+`SAI_MIRROR_SESSION_TYPE_SFLOW` (or its forthcoming TAM-namespace
+successor — see SAI surface caveat below) to in-silicon sFlow datagram
+construction. Under the default `mode=auto`, platforms without this
+capability resolve to the existing CPU path unchanged — no breakage, no
+behavioral change, and nothing for the operator to configure
+(`STATE_DB:SFLOW_STATE.path_reason` records why HW was not selected).
+Capability drives selection at path-selection time only; there is no
+error-driven runtime fall-through after a path is selected (§7.5). If
+an operator forces `mode=hw-accelerated` on a platform that does not
+advertise the capability, sFlow fails closed
+(`STATE_DB:SFLOW_STATE.active_path=failed,
+path_reason=platform_not_capable`, WARN syslog) rather than silently
+reverting to CPU — the forced value is an explicit debug/override
+choice. To recover, the operator returns `mode` to `auto` (or
+`cpu-path`).
+
+**SAI surface caveat.** Today's SAI hosts the in-silicon sFlow primitive
+under `SAI_OBJECT_TYPE_MIRROR_SESSION`. The 2025-03 SAI TAM enhancements
+([PR #2141](https://github.com/opencomputeproject/SAI/pull/2141)) added
+sampling primitives in the TAM namespace but did **not** migrate
+`MIRROR_SESSION_TYPE_SFLOW`, so its long-term namespace is unsettled. This
+HLD is forward-compatible with either landing; the vendor-contract items
+below apply to whichever SAI object type currently hosts the sFlow
+primitive on a given platform/version.
+
+The community SHOULD be informed in advance of merge. Silicon vendors
+who want their platforms to use the HW path MUST:
+
+1. Implement the sFlow-builder SAI primitive (today:
+   `SAI_MIRROR_SESSION_TYPE_SFLOW`; future: the TAM-namespace successor)
+such that the silicon emits wire-format sFlow v5 UDP datagrams. The Agent
+Address field **MUST** equal the session source-IP attribute (today:
+`SAI_MIRROR_SESSION_ATTR_SRC_IP_ADDRESS`); SONiC pins that IP to
+`SFLOW|global:agent_id`, so any other derivation silently breaks operator
+identity (§7.5 "Agent address coupling").
+2. Advertise capability via `sai_query_attribute_capability()` on
+   `SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` and the egress
+equivalent (or their successor port-binding attributes).
+3. Ideally, apply attribute changes via `set_*_attribute()` on the
+   relevant session SAI object without requiring the application to tear
+down and recreate it. **This is a desired vendor behavior, not a SAI spec
+guarantee, and is not uniformly available across attributes or
+platforms.** `HwSflow` plans a tear-down + recreate lifecycle that
+sidesteps this gap; a per-field fast path is tracked in §14.
+4. **Sequence-number behavior on attribute updates**: vendors MAY reset
+   the sFlow datagram sequence number on attribute updates. SONiC's HLD
+does not require preservation. Collectors are expected to
+tolerate sequence-number resets, which most modern sFlow collectors do.
+With tear-down + recreate, sequence-number resets are the norm (a
+recreated session always starts at 0); collectors that depend on
+continuous sequencing across topology change will need to tolerate this.
+5. **Egress port programming.** `HwSflow` does not currently pass the
+   resolved egress port into a SAI attribute, relying on silicon IP route
+lookup at emit time. Vendors whose HW sFlow path requires explicit
+egress-port pinning MUST advertise that requirement (tracked in §14).
+
+## 8\. SAI API
+
+No new SAI APIs are introduced. All referenced enums and attributes
+exist in standard SAI today (verified against
+[`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h),
+[`saiport.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saiport.h),
+[`saitam.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saitam.h),
+and a shipping vendor SAI implementation).
+
+**SAI surface note.** The table reflects today's surface, where the
+in-silicon sFlow datagram-builder lives under
+`SAI_OBJECT_TYPE_MIRROR_SESSION`; its long-term namespace is unsettled
+(see §7.12 "SAI surface caveat"). Where the table cites
+`SAI_MIRROR_SESSION_ATTR_*`, the equivalent TAM-namespaced attribute (if
+it lands) is the substitute; the *semantics* in the "Use" column don't
+change. The `SAI_TAM_*` rows reflect the objects `SflowOrch::HwSflow`
+creates per configured collector.
+
+| API / Object / Attribute | Use | Reference |
+| :---- | :---- | :---- |
+| `SAI_OBJECT_TYPE_TAM_TRANSPORT` | Per-collector L2 encap container (SRC/DST_MAC, SRC/DST_PORT). Refcounted across collectors. | [`saitam.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saitam.h) |
+| `SAI_OBJECT_TYPE_TAM_COLLECTOR` | Per-collector L3 encap container (SRC/DST_IP, TRANSPORT ref, DSCP). | [`saitam.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saitam.h) |
+| `SAI_OBJECT_TYPE_MIRROR_SESSION` | Per-collector sFlow session container (today's SAI surface; may migrate to TAM namespace) | standard |
+| `SAI_MIRROR_SESSION_ATTR_TYPE = SAI_MIRROR_SESSION_TYPE_SFLOW` | Selects the HW sFlow datagram-builder path | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
+| `SAI_MIRROR_SESSION_ATTR_MONITOR_PORT` | Vendor-specified internal/monitor port | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
+| `SAI_MIRROR_SESSION_ATTR_TRUNCATE_SIZE` | Sample truncation size (default 128) | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
+| `SAI_MIRROR_SESSION_ATTR_SAMPLE_RATE` | 1-in-N divisor on the mirror session | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
+| `SAI_MIRROR_SESSION_ATTR_SRC_MAC_ADDRESS` | Encap source MAC (resolved by the orchagent's collector resolver) | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
+| `SAI_MIRROR_SESSION_ATTR_DST_MAC_ADDRESS` | Encap destination MAC (resolved next-hop) | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
+| `SAI_MIRROR_SESSION_ATTR_SRC_IP_ADDRESS` | Encap source IP — **also embedded as v5 Agent Address** (see §7.5) | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
+| `SAI_MIRROR_SESSION_ATTR_DST_IP_ADDRESS` | Encap destination IP (collector) | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
+| `SAI_MIRROR_SESSION_ATTR_IPHDR_VERSION` | IPv4 / IPv6 | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
+| `SAI_MIRROR_SESSION_ATTR_TOS`, `_TTL` | IP header fields | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
+| `SAI_MIRROR_SESSION_ATTR_UDP_SRC_PORT`, `_UDP_DST_PORT` | UDP header fields | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
+| `SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` | Bind session(s) to ingress port | [`saiport.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saiport.h) |
+| `SAI_PORT_ATTR_EGRESS_SAMPLE_MIRROR_SESSION` | Bind session(s) to egress port (Phase I, §5 requirement 2) | [`saiport.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saiport.h) |
+
+Capability discovery uses the standard
+`sai_query_attribute_capability()` against `SAI_OBJECT_TYPE_PORT` for
+`SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` (and the egress
+equivalent). If the SAI port-binding attribute migrates to the TAM
+namespace, the capability query target migrates with it; SwitchOrch's
+exposed `STATE_DB:SWITCH_CAPABILITY` bit name is preserved for backward
+compatibility.
+
+The existing `SAI_OBJECT_TYPE_SAMPLEPACKET` API continues to be used
+unchanged whenever the system resolves to the CPU path (`auto` on a
+platform without HW sFlow capability, or forced `cpu-path`), and for
+counter-sample / MOD paths.
+
+## 9\. Configuration and management
+
+### 9.1 Manifest (if the feature is an Application Extension)
+
+Not applicable — this is a built-in feature modification to swss and
+configuration tooling (see §7.1).
+
+### 9.2 CLI / YANG model Enhancements
+
+The CPU-path CLI (`config sflow enable/disable`, `config sflow
+collector ...`, `config sflow agent-id ...`, per-port `config sflow
+interface sample-rate/sample-direction`) is unchanged.
+
+#### CLI additions
+
+1. `config sflow mode <auto|hw-accelerated|cpu-path>`
+   - Debug/override knob only; the normal workflow never sets it.
+   - Default `auto`: the datapath is selected from platform capability
+   (§7.5) — HW where advertised, CPU otherwise. Zero configuration.
+   - `cpu-path`: force the CPU path (e.g. to isolate a suspected HW
+   sampling problem, or to preserve exact pre-existing behavior).
+   - `hw-accelerated`: force the HW path. If unavailable on the
+   platform, sFlow is administratively failed with a syslog error and
+   `STATE_DB` reflects the failure (fail-closed, not silent CPU
+   fallback).
+
+2. `show sflow` is extended to display:
+   - Platform capability (`hw_sflow_capable: true|false`)
+   - Configured mode (`mode: auto|hw-accelerated|cpu-path`)
+   - System active path (`active_path: hw|cpu|failed`) and `path_reason`
+   on failure
+   - When `active_path=hw`, per-collector resolved encap summary
+   (`resolved_dst_mac`, `resolved_src_ip`, `egress_port`) and SAI
+   session OID
+   - Last resolution timestamp and last error
+
+No existing CLI is removed or changed in incompatible ways.
+
+#### YANG model
+
+`sonic-sflow.yang` gains:
+
+```
+leaf mode {
+    type enumeration {
+        enum auto;
+        enum hw-accelerated;
+        enum cpu-path;
+    }
+
+    default "auto";
+    description "sFlow datapath override. Default 'auto' selects
+                 hardware-accelerated sFlow when the platform is capable,
+                 CPU-based sFlow otherwise. Explicit values force a path
+                 for debug.";
+}
+```
+
+The enum literals (`auto`, `hw-accelerated`, `cpu-path`) are identical across
+the CLI token, the YANG enum, and the value stored in
+`CONFIG_DB:SFLOW|global:mode` — there is no underscore variant and no
+CLI-to-DB translation. `show sflow` and `STATE_DB` echo the same
+spelling. (YANG validation rejects config whose stored value does not
+match an enum literal, so the three must agree exactly.)
+
+### 9.3 Config DB Enhancements
+
+#### `CONFIG_DB:SFLOW` (modified, additive)
+
+```
+"SFLOW": {
+    "global": {
+        "admin_state": "up",
+        "polling_interval": "20",
+        "agent_id": "Loopback0",
+        "sample_direction": "rx",
+        "drop_monitor_limit": "0",
+
+        "mode": "auto"                  // NEW, optional, default "auto";
+                                        // values: auto | hw-accelerated | cpu-path
+                                        // debug/override only — absent in the
+                                        // normal workflow
+    }
+}
+```
+
+#### `CONFIG_DB:SFLOW_COLLECTOR` (unchanged in Phase I)
+
+Phase I uses orchagent-driven encap resolution. Phase II MAY add
+optional overrides (`override_dst_mac`, `override_src_ip`,
+`override_tos`, `override_ttl`, `override_udp_src_port`); these MUST
+default to "unset" so existing config remains valid.
+
+#### `STATE_DB:SWITCH_CAPABILITY` (modified, additive)
+
+```
+"SWITCH_CAPABILITY|switch": {
+    "value": {
+        "PORT_EGRESS_SAMPLE_CAPABLE": "true",
+        "MIRROR_ON_DROP_CAPABLE": "true",
+        "INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE": "true",  // NEW
+        "EGRESS_SAMPLE_MIRROR_SESSION_CAPABLE": "true"    // NEW (Phase I, §5 req 2)
+    }
+}
+```
+
+#### `STATE_DB:SFLOW_STATE` (new)
+
+System-wide path observability. One row, key `SFLOW_STATE|global`.
+Populated by `SflowOrch`.
+
+```
+key             = SFLOW_STATE|global
+MODE            = "auto" / "hw-accelerated" / "cpu-path"   ; mirrors CONFIG_DB (default "auto")
+ACTIVE_PATH     = "hw" / "cpu" / "failed"                  ; resolved system path
+                                                           ; ("failed" only under forced
+                                                           ;  mode=hw-accelerated — auto never fails)
+PATH_REASON     = string                                   ; why HW is not active: e.g.
+                                                           ; "platform_not_capable",
+                                                           ; "egress_sample_not_capable", ""
+                                                           ; (set both on forced-mode failure and
+                                                           ;  when auto resolves to CPU;
+                                                           ;  collector over-subscription is NOT a
+                                                           ;  global failure — see SFLOW_COLLECTOR_STATE)
+LAST_UPDATED    = timestamp
+```
+
+#### `STATE_DB:SFLOW_COLLECTOR_STATE` (new)
+
+Per-collector resolution detail. Populated by `SflowOrch::HwSflow` only
+when `SFLOW_STATE.ACTIVE_PATH = hw`; absent in CPU mode.
+
+```
+key             = SFLOW_COLLECTOR_STATE|<collector_name>
+TAM_SESSION_OID = OID                         ; SAI OID of the sFlow session
+                                              ; (today: SAI_OBJECT_TYPE_MIRROR_SESSION; future: TAM-namespace successor)
+                                              ; empty when PROGRAMMED=false
+PROGRAMMED      = "true" / "false"            ; false when the collector exceeds the
+                                              ; hardware concurrent-session limit (see §12 item 12)
+RESOLVED_DST_MAC  = MACaddress
+RESOLVED_SRC_IP   = IPaddress
+RESOLVED_SRC_MAC  = MACaddress
+EGRESS_PORT       = ifname
+LAST_ERROR      = string                      ; empty if healthy; e.g. "hw_session_limit_exceeded"
+LAST_UPDATED    = timestamp
+```
+
+#### DB Migration
+
+All new fields are additive with documented defaults. Existing config
+without `mode` is treated as `auto` (the YANG default); `db_migrator.py`
+adds no field. Platforms that do not advertise the new capability bits
+remain on the CPU path with no behavioral change. **Deliberate upgrade
+behavior:** a capable platform with pre-existing sFlow config moves
+from the CPU path to the HW path on first boot of an image with this
+feature — the operator-visible sample stream is equivalent, but the
+datapath changes (flow samples no longer transit the CPU path, §7.8;
+sequence numbers reset). An operator who wants the old datapath
+pins `mode=cpu-path` before upgrading.
+
+### 9.4 End-to-end CONFIG_DB walkthrough
+
+Walkthrough of the path from operator CLI to silicon for a single
+collector `ts1` at `198.51.100.5` with sample rate 1-in-2048.
+
+1. **Operator** (no datapath configuration — `mode` stays at its
+   default `auto`):
+   ```
+   config sflow enable
+   config sflow collector add ts1 198.51.100.5
+   config sflow interface enable Ethernet0
+   ```
+2. **CONFIG_DB writes:**
+   ```
+   SFLOW|global:        admin_state=up, agent_id=Loopback0,
+                        sample_direction=rx
+   SFLOW_COLLECTOR|ts1: collector_ip=198.51.100.5, collector_port=6343
+   SFLOW_SESSION|Ethernet0: admin_state=up, sample_rate=2048
+   ```
+3. **SflowOrch read + resolve:** `SflowOrch` reads
+   `STATE_DB:SWITCH_CAPABILITY:INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE=true`;
+`mode=auto` + capable → effective path = HW. `HwSflow` resolves
+`198.51.100.5` against `NeighOrch` / `RouteOrch` → `dst_mac`, `src_mac`,
+`egress_port`; encap `src_ip` is pinned to `agent_id` (Loopback0)'s IP.
+4. **SAI calls (from SflowOrch):** `create_tam_transport(SRC/DST_MAC,
+   SRC/DST_PORT)` → `create_tam_collector(SRC/DST_IP, TRANSPORT, DSCP)`
+→ `create_mirror_session(TYPE=SFLOW, SAMPLE_RATE=2048, TRUNCATE_SIZE,
+SRC/DST_IP, SRC/DST_MAC, UDP_*)` → returns `session_oid`.
+5. **Port binding:** `set_port_attribute(Ethernet0,
+   INGRESS_SAMPLE_MIRROR_SESSION, [session_oid])` for each enabled port
+(honoring `sample_direction`).
+6. **STATE_DB writes:** `SFLOW_STATE|global active_path=hw`,
+   `SFLOW_COLLECTOR_STATE|ts1` populated with resolved encap and OID.
+
+## 10\. Warmboot and Fastboot Design Impact
+
+Warmboot preserves the HW sFlow silicon state (sampling session, encap,
+sample-rate divisor) on capable platforms; the orchagent reconciles
+in-memory state against the ASIC without tearing sessions down when
+CONFIG_DB attributes match. Fastboot tears sampling down on shutdown and
+resumes once collector encap is resolved and ports are operationally up
+— typically bounded by ARP/ND resolution to the configured collector(s).
+No new boot-critical-path stalls are introduced. Vendor-specific
+behavior on session recreate (e.g., sequence-number reset) is documented
+in §7.12.
+
+## 11\. Memory Consumption
+
+- When the feature is **disabled at compile time**: zero impact.
+- When the system **resolves to the CPU path** (`auto` on an incapable
+platform, or forced `mode=cpu-path`): zero additional resident memory
+in the orchagent.
+- When the feature is **active**: per-collector memory in CONFIG_DB
+scales linearly with the configured collector count (§5 requirement 3
+caps this at 4, further bounded by the hardware-advertised maximum
+concurrent HW sFlow sessions). One `TAM_COLLECTOR` and one
+(refcount-shared) `TAM_TRANSPORT` per active HW collector, plus the per-session SAI sFlow object — roughly
+equivalent in cost to one additional MOD session per collector.
+`SflowOrch` adds bookkeeping for port→collector bindings and STATE_DB
+entries (bounded by port count × collector count).
+
+## 12\. Restrictions / Limitations
+
+| # | Limitation | Detail |
+| :---- | :---- | :---- |
+| 1 | LAG (PortChannel) support is Phase I; the session-programming model (per-member sessions vs. one LAG-bound session) is vendor-specific and unresolved. | §5 req 9, §14 items 5, 11 |
+| 2 | HW path emits flow samples only; counter samples and MOD stay on the `hsflowd` CPU path. | |
+| 3 | HW-path `sample_direction=tx`/`both` requires the platform to advertise `EGRESS_SAMPLE_MIRROR_SESSION_CAPABLE`. The path is system-wide, not per-port: under `auto`, *any* tx/both port on a platform lacking the egress bit resolves the whole system to CPU (`path_reason=egress_sample_not_capable`) — one egress-sampling port keeps every port off HW. Under forced `hw-accelerated` the same config fails instead (`active_path=failed`, admin-down, WARN). Ingress-only configs run on HW normally. | §7.3, §7.5 |
+| 4 | HW has one silicon field for both encap source IP and the v5 Agent Address, so it can't reproduce a CPU-path config that decoupled `agent_id` from transport source; both are pinned to `agent_id`'s IP. Usually both `Loopback0`, so invisible. | §7.5 |
+| 5 | ERSPAN and HW sFlow coexist on a port — distinct SAI port attributes (`INGRESS_MIRROR_SESSION` vs `INGRESS_SAMPLE_MIRROR_SESSION`), no exclusivity. MirrorOrch unmodified. | |
+| 6 | Sample-rate or encap change = tear-down + recreate: sampling outage (vendor-specific, typically ms to tens of ms) plus a per-collector sequence-number reset. Collectors must tolerate resets. | §7.5, §14 |
+| 7 | Encap is refreshed on next-hop / source-IP change; rapidly flapping reachability causes repeated gaps and sequence resets. | |
+| 8 | Linux packet-capture WILL NOT see HW-emitted datagrams — debug via collector-side SPAN or vendor tools. Egress-port TX counters *do* count them, so "missing samples" is not a TX-counter symptom. | §7.8 |
+| 9 | `hsflowd` keeps running for counter/MOD; the `psample` flow stream is naturally idle (no port binds `INGRESS_SAMPLEPACKET_ENABLE`). No config change needed. | |
+| 10 | `sub_agent_id` disambiguation between silicon- and hsflowd-emitted streams is unresolved (`mod_sonic.c` exposes no `sub_agent_id`); collectors keying on `(agent_address, sub_agent_id)` may see two streams with the same sub-agent. | §14 item 2 |
+| 11 | `/etc/hsflowd.conf` MUST NOT be edited manually; SONiC owns it. | |
+| 12 | Collector over-subscription is partial, not fatal: first N (by name) programmed, the rest flagged `hw_session_limit_exceeded`; system stays `active_path=hw`. | §7.5 |
+
+## 13\. Testing Requirements / Design
+
+### 13.1 Unit test cases
+
+| \# | Test |
+| :---- | :---- |
+| 1 | Capability bits `INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE` and `EGRESS_SAMPLE_MIRROR_SESSION_CAPABLE` correctly populated from SAI |
+| 2 | Under default `mode=auto`, `SflowOrch` selects HW path on capable platform, CPU path otherwise (with `path_reason` recording why); `auto` never yields `active_path=failed` |
+| 3 | `SflowOrch` honors forced `mode=cpu-path` and uses CPU path even when capable |
+| 4 | `SflowOrch` honors forced `mode=hw-accelerated` and reports failure on incapable platform |
+| 5 | `SflowOrch::HwSflow` resolves the HW sFlow session from `SFLOW` / `SFLOW_COLLECTOR` + `mode` and produces the correct SAI attribute list (`TAM_TRANSPORT`, `TAM_COLLECTOR`, and the sFlow session object) |
+| 6 | `HwSflow`'s resolver re-resolves on `NEIGH_TABLE` change; observer callbacks fire and the session refreshes |
+| 7 | `SflowOrch` binds OID via `INGRESS_SAMPLE_MIRROR_SESSION` / `EGRESS_SAMPLE_MIRROR_SESSION` after the session becomes active |
+| 8 | `SflowOrch` skips `create_samplepacket()` for ports on the HW path |
+| 9 | Encap `src_ip` is pinned to `agent_id`'s resolved IP for every collector regardless of the per-collector route; the resolver derives only `dst_mac`/`src_mac`/`egress_port` from routing, and no `agent_id`/source-IP failure path is taken |
+| 10 | Config without `mode` treated as `auto` (YANG default); no migrator rewrite |
+| 11 | `STATE_DB:SFLOW_STATE` exposes a single system-wide `active_path`; `SFLOW_COLLECTOR_STATE` populated only in HW mode |
+| 12 | Any `mode` change that flips the resolved path (incl. `auto` ↔ forced values) tears down the old path's SAI state before standing up the new path's state; no overlap of `INGRESS_SAMPLE_MIRROR_SESSION` and `INGRESS_SAMPLEPACKET_ENABLE` is ever observed on any port |
+| 13 | `show sflow` output reflects new fields |
+| 14 | YANG validation accepts new `sonic-sflow.yang` fields and rejects malformed values |
+| 15 | With a port configured `sample_direction=tx`/`both` on a platform lacking `EGRESS_SAMPLE_MIRROR_SESSION_CAPABLE`: under `mode=auto` the system resolves to CPU with `path_reason=egress_sample_not_capable`; under forced `mode=hw-accelerated` it fails (`SFLOW_STATE.active_path=failed`, same reason); an ingress-only config on the same platform resolves to HW in both modes |
+| 16 | Collector over-subscription: with collectors > hardware max, the first N (by name order) get `PROGRAMMED=true` with a `TAM_SESSION_OID`; the rest get `PROGRAMMED=false, LAST_ERROR=hw_session_limit_exceeded`; `active_path` stays `hw`; ordering is stable across reconcile |
+| 17 | LAG: `SFLOW_SESSION` on a PortChannel programs HW sFlow per the chosen model (§14 item 5); member add/remove updates the session binding accordingly |
+
+### 13.2 System test cases
+
+| \# | Test |
+| :---- | :---- |
+| 1 | End-to-end: configure sFlow with no `mode` set on a capable platform; system auto-selects the HW path and the collector receives sFlow v5 datagrams |
+| 2 | Sequence numbers are monotonic within a steady-state HW-emitted stream (resets only on attribute updates) |
+| 3 | Sample rate matches configured 1-in-N within ±5% over a 60-second 100 Gbps sustained line-rate ingress test |
+| 4 | Egress sampling (`sample_direction=tx`) on HW path produces wire-format sFlow v5 datagrams; rate matches configured 1-in-N |
+| 5 | Counter samples and MOD continue to arrive via the CPU stream |
+| 6 | Agent Address field in HW-emitted datagrams equals resolved IP of `SFLOW|global:agent_id` interface |
+| 7 | Next-hop change (induced via static route flap) triggers tear-down + recreate; sampling resumes; sequence-number reset observed (honesty test); measured outage logged for regression tracking |
+| 8 | Source-IP change (loopback edit) triggers encap refresh |
+| 9 | ERSPAN coexistence: configure a `MIRROR_SESSION_TYPE_ENHANCED_REMOTE` (MirrorOrch) and HW sFlow on the same port; both work simultaneously; removing one does not disturb the other |
+| 10 | Fast warmboot preserves sampling on unchanged sessions; sequence number preserved for unchanged sessions |
+| 11 | Fastboot resumes sampling after collector reachability is restored |
+| 12 | Sample-rate change applied while sampling is active; brief outage observed; sequence-number reset observed; stream resumes |
+| 13 | On an incapable platform: default `mode=auto` resolves to CPU (sampling works, `path_reason=platform_not_capable`); forced `mode=hw-accelerated` surfaces `SFLOW_STATE.active_path=failed`, same reason, sFlow admin-down system-wide |
+| 14 | Stress: ~580K samples/sec from a single 800G ingress port at line rate with 1-in-2048 sampling, no CPU saturation (motivation validation per §4) |
+| 15 | Collector over-subscription end-to-end: configure more collectors than the hardware maximum; the programmed collectors receive sFlow v5 datagrams while the over-limit collectors receive none and are flagged in `SFLOW_COLLECTOR_STATE`; the system as a whole stays up |
+| 16 | LAG end-to-end: HW sFlow on a PortChannel samples ingress and egress traffic across all members at the configured 1-in-N; sampling survives member add/remove and link flap |
+
+## 14\. Open / Action items
+
+1. **Resolver consolidation across orchagents.** `MirrorOrch` and now
+   `SflowOrch::HwSflow` each carry their own `NeighOrch` / `RouteOrch`
+resolver for next-hop / encap fields. A follow-up should extract this
+resolver into a shared helper that both orchagents call. Worth
+discussing with the `MirrorOrch` maintainers.
+2. **`sub_agent_id` configurability in `hsflowd`.** The SONiC `hsflowd`
+   integration
+([`mod_sonic.c:50-65`](https://github.com/sflow/host-sflow/blob/master/src/Linux/mod_sonic.c))
+exposes `agent_id` but **not** `sub_agent_id`. To let collectors
+disambiguate the silicon-emitted flow-sample stream from the
+hsflowd-emitted counter/MOD stream, either: (a) add `sub_agent_id` to
+the SONiC hsflowd config and the CONFIG_DB schema; or (b) define a
+different disambiguation mechanism. Needs vendor input on whether the
+silicon's emitted `sub_agent_id` is configurable on a per-sFlow-session
+basis.
+3. **UDP source port stability.** See item 10 below.
+4. **Capability granularity.** SAI's
+   `sai_query_attribute_capability(SAI_OBJECT_TYPE_PORT, ...)` is
+per-port by signature, but this HLD consumes a single switch-wide
+capability bit (uniform support is expected). The implementation should
+treat capability as switch-wide: any per-port disagreement on a capable
+platform is a vendor bug. Worth raising with vendors that expose
+per-port-variable capability.
+5. **LAG support.** Multiple member ports → multiple HW sFlow sessions
+   vs. one LAG-bound session, vendor-specific. Must be resolved for
+Phase I (§5 requirement 9). (The resolver inherits a "first member only"
+pattern for LAG egress today — see item 11.)
+6. **Per-session HW emit counter.** SAI does not standardize a
+   `samples_generated` counter on either the existing `MIRROR_SESSION`
+surface or the TAM family. Raise in SAI community; out of scope here.
+7. **SAI namespace alignment.** Monitor SAI TAM WG direction; the
+   in-silicon sFlow primitive's long-term namespace is unsettled (detail
+in §7.12 "SAI surface caveat"). If a future migration of
+`MIRROR_SESSION_TYPE_SFLOW` lands, re-validate the §7.12 vendor contract.
+8. **`set_*_attribute()` fast path for hw-sflow.** `HwSflow` plans a
+   tear-down + recreate lifecycle on next-hop / encap / sample-rate
+change. A future enhancement should add an in-place fast path where the
+silicon supports it, avoiding the per-change recreate cost (§7.9, §12
+item 6). Scope is platform-dependent — on current silicon the in-place
+path covers only `sample_rate`; encap fields need a vendor-side change
+(detail in §7.5, §7.12).
+9. **Egress port programming.** Confirm with each vendor whether HW sFlow
+    needs explicit egress-port pinning (resolver doesn't pass it today —
+§7.5, §7.12 item 5). If yes: add the egress-port SAI attribute
+(vendor-specific) to `HwSflow`'s SAI calls.
+10. **L4 source port stability.** Phase I accepts random-ephemeral per
+    session. Stable-port (collector-side 5-tuple stability) is a
+follow-up enhancement.
+11. **LAG distribution.** The resolver's "first member only" pattern for
+    LAG egress is incompatible with the Phase I portchannel goal (§5
+requirement 9).
+Phase I must either teach the resolver to distribute across members,
+or constrain HW sFlow to single-link egress.
+12. **Orchagent-maintainer alignment.** Confirm direction with the
+    `SflowOrch` maintainers and the sonic-swss#3970 author (Edge-core),
+since `HwSflow` lives alongside `SflowDropMonitor` as a sibling class
+under `SflowOrch`.
+13. **Community alignment.** Schedule a SONiC sFlow / Datapath / TAM WG
+    discussion before merge. Identify silicon vendors interested in
+implementing the SAI side beyond the initial integrator.
+14. **Single-platform validation risk.** Initial development and
+    validation is on a single platform family. The
+vendor-contract section (§7.12) documents the SAI contract precisely so
+second-platform integration surfaces gaps in the abstraction rather
+than gaps in the implementation.

--- a/doc/sflow/hw_sflow_hld.md
+++ b/doc/sflow/hw_sflow_hld.md
@@ -44,28 +44,23 @@
 ### 2\. Scope
 
 This document describes the addition of an optional sFlow feature in
-SONiC, hardware accelerated sFlow. The design proposes new paths through
-existing orchagents to wire the relevant SAI attribute with their
-underlying hardware-capable platforms, while reusing logic from existing
-implementations. The goals are to:
-- Add a new path through SONiC for sFlow telemetry to configure an
-increasingly-supported silicon feature
-- Limit drastic changes to the fundamental SONiC behavior while doing so
+SONiC - hardware accelerated sFlow. In ASICs that support hardware accelerated sflow, 
+the sflow packets will be sent directly from the ASIC to the collector. This design 
+document explains how SflowOrch will be modified to support this sflow mode.
 
 ### 3\. Definitions/Abbreviations
 
 | Term | Definition |
 | :---- | :---- |
 | sFlow | Sampled flow, RFC 3176 / sflow.org v5 |
-| HW sFlow | Hardware accelerated sFlow |
+| HW sFlow | Hardware accelerated sFlow, packets sent from ASIC to collector directly |
 | CPU sFlow | The existing sample-and-punt sFlow path documented in SONiC’s [`sflow_hld.md`](https://github.com/sonic-net/SONiC/blob/master/doc/sflow/sflow_hld.md) |
 | SAI | Switch Abstraction Interface |
 | MOD | Mirror-on-Drop |
 | COPP | Control Plane Policing (host-interface trap rate limiter) |
-| `MIRROR_SESSION_TYPE_SFLOW` | SAI mirror session type that builds sFlow v5 datagrams in silicon ([`saimirror.h:51`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h)). Today's SAI surface; subject to change. |
-| `INGRESS_SAMPLE_MIRROR_SESSION` | SAI port attribute binding a list of sampled mirror sessions for ingress sampling ([`saiport.h:1399-1423`](https://github.com/opencomputeproject/SAI/blob/master/inc/saiport.h)) |
-| TAM | Telemetry and Monitoring |
-| TamOrch | Orchagent in `sonic-swss` that owns SAI TAM objects. Proposed in unmerged [sonic-swss#4370](https://github.com/sonic-net/sonic-swss/pull/4370); not present on `master`. |
+| `MIRROR_SESSION_TYPE_SFLOW` | SAI mirror session type that builds sFlow v5 datagrams in silicon ([`saimirror.h:51`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h)). |
+| TAM | Telemetry and Monitoring, a SAI namespace for telemetry-related objects and attributes |
+| TamOrch | Orchagent in `sonic-swss` that programs TAM features like Mirror-on-drop. Proposed in unmerged [sonic-swss#4370](https://github.com/sonic-net/sonic-swss/pull/4370); not present on `master`. |
 | hsflowd | InMon's host-sflow agent (`https://github.com/sflow/host-sflow`) |
 
 ### 4\. Overview
@@ -73,25 +68,12 @@ increasingly-supported silicon feature
 In the existing SONiC sFlow architecture, all sampled packets are punted
 to the CPU over a generic-netlink channel and `hsflowd` performs sFlow
 datagram construction in userspace. This works well at moderate sampling
-rates and link speeds, but is sharply rate-limited on multi-Tbps
-platforms: every sample must cross the COPP policer, the kernel
-genetlink path, the userspace agent, and the kernel UDP send path.
+rates and link speeds, but is rate-limited on higher speed
+platforms.
 
-Concretely: the SONiC default COPP configuration installs the
-`sample_packet` trap at 1000 packets per second (see
-[`copp_cfg.j2:76-88,
-135-138`](https://github.com/sonic-net/sonic-buildimage/blob/master/files/image_config/copp/copp_cfg.j2)).
-For comparison, a single 800G port at line rate with 64-byte frames
-produces ~1.19 Gpps; sampling at 1-in-2048 yields ~580K samples per
-second, well over the COPP cap on one port alone. Operators who raise
-the cap trade CPU saturation for sample completeness; neither outcome
-is desirable.
+With hardware acceleration, the forwarding ASIC:
 
-Multi-Tbps platforms increasingly support an alternative model in which
-a hardware block:
-
-1. Performs the 1-in-N sampling decision in the ingress (and/or egress)
-   pipeline.
+1. Performs the 1-in-N sampling decision in the pipeline (ingress or egress).
 2. Truncates the sampled packet to the configured header size.
 3. Prepends sFlow flow-record fields (using preserved system metadata to
    recover ingress / egress port info).
@@ -107,84 +89,48 @@ into silicon) and at re-program time (to refresh the encap when the
 next-hop or source IP changes). Steady-state sample throughput is
 decoupled from CPU and COPP capacity.
 
-This document describes the high-level design for hardware accelerated
-sFlow in SONiC: an alternative datapath in which sampled packets are
-encapsulated and emitted as wire-format sFlow v5 UDP datagrams by the
-forwarding silicon itself.
-
-This HLD proposes to wire this path by extending the existing
-`SflowOrch` with a new sibling class, `HwSflow`, that owns the HW sFlow
-lifecycle. The CPU-based path documented in
-[`doc/sflow/sflow_hld.md`](https://github.com/sonic-net/SONiC/blob/master/doc/sflow/sflow_hld.md)
-remains the default path on platforms that lack the necessary silicon
-support.
-
 ### 5\. Requirements
-
-#### Phase I
 
 1. Detect platform capability for HW sFlow via SAI capability query, and
    reflect it in `STATE_DB:SWITCH_CAPABILITY`.
-2. Support configuring HW sFlow on physical interfaces in both ingress
-   and egress directions, reusing the existing per-port
-`sample_direction: rx | tx | both` setting on `SFLOW_SESSION` rows.
-3. Support up to 4 concurrent sFlow collectors, subject to the
-   hardware-advertised session maximum.
-4. Support IPv4 and IPv6 collectors.
-5. Select the sFlow datapath automatically from platform capability:
-   HW sFlow on platforms that advertise it, CPU sFlow otherwise,
-uniformly across all sFlow-enabled ports and collectors. The operator
-does not configure the datapath in the normal workflow. A system-wide
-`mode` override knob (`auto` / `hw-accelerated` / `cpu-path`, default
-`auto`) exists for debug and forced-path scenarios only.
-6. Resolve the destination MAC, source MAC, source IP, and other
+2. Support configuring HW sFlow on physical interfaces in ingress
+   direction only, reusing the existing per-port
+`sample_direction: rx ` setting on `SFLOW_SESSION` rows.
+3. Support IPv4 and IPv6 collectors.
+4. Select the sFlow datapath based on configuration. Default mode is
+`cpu-path` and hardware acceleration can be enabled if `mode` is set 
+to `hw-accelerated`.
+5. Resolve the destination MAC, source MAC, source IP, and other
    encapsulation parameters automatically from kernel routing/neighbor
 state.
-7. Automatically refresh the silicon encap when the resolved next-hop
+6. Automatically refresh the silicon encap when the resolved next-hop
    MAC, source IP, or routing changes.
-8. Counter samples and MOD notifications (when MOD is performed via
-   sFlow) continue to be produced by the existing CPU path even when HW
-sFlow is active.
-9. Portchannel (LAG) interface support, including LAG-egress sampling.
-
-#### Phase II
-
-10. Operator configuration of resolved encap fields (manual TOS/TTL).
+7. Portchannel (LAG) interface support, including LAG-egress sampling.
 
 #### Not planned to be supported
 
 1. HW-accelerated counter samples (out of scope).
 2. ACL-driven HW sFlow sessions (support is be port-level only).
+3. Egress sampling.
 
 ### 6\. Architecture Design
 
 This change extends `SflowOrch` in `sonic-swss` with a new `HwSflow`
 sibling class and adds CLI / YANG / CONFIG_DB fields. SAI TAM APIs are
-called directly from `SflowOrch::HwSflow`. The sibling-class shape is
-identical to `SflowDropMonitor` in the unmerged
+called directly from `SflowOrch::HwSflow`. This design is
+similar to `SflowDropMonitor` in the
 [`sonic-net/sonic-swss#3970`](https://github.com/sonic-net/sonic-swss/pull/3970).
 
 HW sFlow is the same operator-facing feature as CPU sFlow with a
 different datapath, so it stays under the `sflow` CLI/CONFIG_DB namespace
-and `SflowOrch` owns both paths. The operator never configures or sees
-TAM rows; platform capability selects the datapath (with `mode` as a
-debug override, §7.5). The cost is that
-`SflowOrch::HwSflow` carries its own `NeighOrch` / `RouteOrch` resolver,
-duplicating logic also present in `MirrorOrch` (resolver consolidation is
-tracked in §14 item 1).
+and `SflowOrch` owns both paths. 
 
 ### 7\. High-Level Design
 
-The design extends `SflowOrch` in `sonic-swss` with a new `HwSflow`
-sibling class that owns the HW sFlow lifecycle: collector/encap
+`HwSflow` owns the HW sFlow lifecycle: collector/encap
 resolution against `NeighOrch` / `RouteOrch`, SAI TAM object create /
 update / delete, the sFlow session SAI object, and per-port binding via
-`INGRESS_SAMPLE_MIRROR_SESSION` / `EGRESS_SAMPLE_MIRROR_SESSION`.
-
-The current design gates on silicon SAI support
-(`SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` and the egress
-equivalent, plus `SAI_MIRROR_SESSION_TYPE_SFLOW` or its TAM-namespace
-successor - see §7.12).
+`INGRESS_SAMPLE_MIRROR_SESSION`.
 
 ### 7.1 Built-in vs Application Extension
 
@@ -194,10 +140,10 @@ Built-in feature modification.
 
 | Repository | Component | Change |
 | :---- | :---- | :---- |
-| `sonic-swss` | `SflowOrch` | New `HwSflow` sibling class that consumes `SFLOW_COLLECTOR`, attaches `Observer`s to `NeighOrch` and `RouteOrch`, resolves `(dst_mac, src_mac, egress_port)` against kernel routing/neighbor state and pins encap `src_ip` to `SFLOW|global:agent_id`'s IP (see §7.5) on session create and on observer-callback refresh, calls SAI TAM APIs directly to create `TAM_TRANSPORT` / `TAM_COLLECTOR` / sFlow session, and binds the result via `INGRESS_SAMPLE_MIRROR_SESSION` / `EGRESS_SAMPLE_MIRROR_SESSION`. |
+| `sonic-swss` | `SflowOrch` | Added `HwSflow`; consumes `SFLOW_COLLECTOR`, attaches `Observer`s to `NeighOrch` and `RouteOrch`, resolves `(dst_mac, src_mac, egress_port)` against kernel routing/neighbor state and pins encap `src_ip` to `SFLOW|global:agent_id`'s IP (see §7.5) on session create and on observer-callback refresh, calls SAI TAM APIs directly to create `TAM_TRANSPORT` / `TAM_COLLECTOR` / sFlow session, and binds the result via `INGRESS_SAMPLE_MIRROR_SESSION`. |
 | `sonic-swss` | `SflowOrch::HwSflow` resolver | New. |
-| `sonic-swss` | `SwitchOrch` | Expose `INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE` (and the egress equivalent) from `sai_query_attribute_capability()` in `STATE_DB:SWITCH_CAPABILITY`. |
-| `sonic-utilities` | `config sflow` / `show sflow` | New `mode` override knob (debug; default `auto`) and diagnostic output. HW sFlow is fully driven through `config sflow` (single operator CLI surface); the normal workflow needs no datapath config. |
+| `sonic-swss` | `SwitchOrch` | Expose `INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE`from `sai_query_attribute_capability()` in `STATE_DB:SWITCH_CAPABILITY`. |
+| `sonic-utilities` | `config sflow` / `show sflow` | New `mode` override knob (debug; default `cpu-path`) and diagnostic output. |
 | `sonic-yang-models` | `sonic-sflow.yang` | Add `mode` field. |
 | `sonic-buildimage` | sflow container | hsflowd config template: optional `sub_agent_id` field (open issue, see §14). |
 | `sonic-buildimage` | `db_migrator.py` | Migrate existing config to new schema (additive, absent `mode` = `auto`). |
@@ -206,31 +152,18 @@ Built-in feature modification.
 ### 7.3 Module interfaces and dependencies
 
 * `SflowOrch::HwSflow` consumes
-`STATE_DB:SWITCH_CAPABILITY:INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE` (and
-the egress equivalent) to gate the HW path globally. The selected path
-applies to the entire system.
+`STATE_DB:SWITCH_CAPABILITY:INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE` 
+to gate the capability. The selected path applies to the entire system.
 * `SflowOrch::HwSflow` consumes `APP_DB:SFLOW_SESSION_TABLE` and
 `CONFIG_DB:SFLOW_COLLECTOR`. It performs collector resolution using a
 new resolver attached to `NeighOrch` and `RouteOrch`, modeled on
-resolvers from `MirrorOrch` and `TamOrch` (unmerged).
+resolvers from `MirrorOrch` and `TamOrch`.
 It then calls SAI TAM APIs directly to create one
 `SAI_OBJECT_TYPE_TAM_TRANSPORT` (refcounted across collectors) and one
 `SAI_OBJECT_TYPE_TAM_COLLECTOR` per collector, plus the sFlow session
 SAI object.
 * `SflowOrch::HwSflow` binds the resulting session OID via
-`SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` (or its TAM-namespace
-successor; see §7.12) on each enabled port, honoring `sample_direction`
-to also bind `EGRESS_SAMPLE_MIRROR_SESSION` when configured.
-
-### 7.4 SWSS changes
-
-A new sibling class `HwSflow` is added inside `SflowOrch` (same shape as
-`SflowDropMonitor` in
-[sonic-swss#3970](https://github.com/sonic-net/sonic-swss/pull/3970)),
-plus a `mode` knob in `SFLOW|global`. The `HwSflow` class consumes
-`SFLOW_COLLECTOR`, attaches a new resolver to `NeighOrch` / `RouteOrch`,
-calls SAI TAM APIs directly, and binds the resulting session via port
-attributes.
+`SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` on each enabled port.
 
 ### 7.5 SWSS and Syncd changes in detail
 
@@ -252,63 +185,24 @@ flowchart TB
     HwSflow -->|creates| SES["sFlow session SAI object<br/>today: SAI_OBJECT_TYPE_MIRROR_SESSION<br/>TYPE=SFLOW<br/>future: TAM-namespaced object"]
     SES -.->|carries SAMPLE_RATE,<br/>TRUNCATE_SIZE, UDP_*,<br/>encap fields| TC
 
-    HwSflow -->|binds OID| PORT["Port:<br/>SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION<br/>and/or _EGRESS_SAMPLE_MIRROR_SESSION"]
+    HwSflow -->|binds OID| PORT["Port:<br/>SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION<br/>]
     SES -.->|bound to| PORT
 ```
 
-#### Producer / consumer split
+On session create, `HwSflow` walks `NeighOrch` / `RouteOrch` to populate `(dst_mac, src_mac,
+egress_port)` and pins `src_ip` to `agent_id`'s IP and registers as a neighbor / next-hop observer to
+refresh on kernel state changes. The resolver picks the first nexthop and
+the first LAG member if the resolution is over a ECMP or LAG. 
 
-`SflowOrch::HwSflow` is both the producer (consuming `SFLOW` /
-`SFLOW_COLLECTOR`, resolving encap) and the consumer (calling SAI TAM
-APIs, binding port attributes). The operator never sees `TAM_SESSION`
-rows because HW sFlow is fully encapsulated under the `sflow` CLI
-namespace.
-
-`HwSflow` handles address resolution as well. On session create, it
-walks `NeighOrch` / `RouteOrch` to populate `(dst_mac, src_mac,
-egress_port)` and pins `src_ip` to `agent_id`'s IP (see §7.5 "Agent
-address coupling"), and registers as a neighbor / next-hop observer to
-refresh on kernel state changes. A future refactor extracting this
-resolver into a shared helper is tracked in §14; it is out of scope for
-this work.
-
-`SflowOrch` resolves the system-wide effective path from platform
-capability and `SFLOW|global:mode` (default `auto`; explicit values are
-a debug/override facility, not the normal workflow):
-
-  | `mode` | Capable | Effective path |
-  | :---- | :---- | :---- |
-  | `auto` (default) | yes | HW |
-  | `auto` (default) | no | CPU (`STATE_DB:SFLOW_STATE.path_reason` records why, e.g. `platform_not_capable`) |
-  | `cpu-path` | (any) | CPU (forced) |
-  | `hw-accelerated` | yes | HW (forced) |
-  | `hw-accelerated` | no | **failed** (sFlow admin-down, WARN syslog, `STATE_DB:SFLOW_STATE.path_reason=platform_not_capable`) |
-
-"Capable" means the platform advertises the capability bits required by
-the *current config*: ingress support always, plus egress support when
-any port is configured `sample_direction=tx`/`both`. Under `auto` a
-config that demands egress sampling on an ingress-only platform
-therefore resolves to CPU (uniform system-wide path, reason
-`egress_sample_not_capable`), never to `failed`. Capability selection
-happens at path-selection time only — `auto` is not an error-driven
-runtime fallback. If the HW path is selected and later hits a
-structural failure, the system reports `active_path=failed` (see
-below) rather than silently reverting to CPU.
-
-On entering HW path, `SflowOrch` creates one `TAM_TRANSPORT` + one
+When hw-acceleration is enabled and supported, `SflowOrch` creates one `TAM_TRANSPORT` + one
 `TAM_COLLECTOR` per configured collector, plus the sFlow session SAI
-object, then binds the session OID via the appropriate port attribute(s)
-honoring `sample_direction`. On entering CPU path it uses the existing
-`SAI_OBJECT_TYPE_SAMPLEPACKET` flow unchanged. Mode transitions tear
-down the old path's SAI state before standing up the new path's; a brief
-sampling outage is expected.
+object, then binds the session OID to the port. Mode transitions from `cpu-mode` 
+to `hw-acceleration` or vice versa tear down the old path's SAI state before 
+standing up the new path's; a brief sampling outage is expected.
 
-**Collector over-subscription.** When the configured collector count
-exceeds the supported maximum (the lesser of the 4-collector scaling
-target, §5 requirement 3, and the platform's advertised limit),
-`SflowOrch::HwSflow` programs
-the first N collectors (sorted by name, so the set is stable across
-restarts and reconciles) and leaves the rest unprogrammed —
+When the configured collector count exceeds the supported maximum (the platform's advertised limit),
+`SflowOrch::HwSflow` programs the first N collectors (sorted by name, so the 
+set is stable across restarts and reconciles) and leaves the rest unprogrammed —
 `SFLOW_COLLECTOR_STATE.PROGRAMMED=false,
 LAST_ERROR=hw_session_limit_exceeded`, plus a WARN syslog naming them. The
 system stays `active_path=hw` rather than failing wholesale for one excess
@@ -327,34 +221,14 @@ attributes support it on every platform — see §7.12) and is tracked as a
 
 #### Partial-create failure handling
 
-Programming a collector is a sequence: `TAM_TRANSPORT` (or a refcount bump
-on an existing one) → `TAM_COLLECTOR` → sFlow session object → port
-binding. If any step fails, `HwSflow` unwinds in reverse, deleting only
-what this collector created and decrementing the shared `TAM_TRANSPORT`
-refcount (objects shared with other collectors stay intact) — so no
-partial graph is ever left bound to a port. The failed collector is
+`HwSflow` must handle partial-create failure. The failed collector is
 flagged `SFLOW_COLLECTOR_STATE.PROGRAMMED=false` with the SAI error in
-`LAST_ERROR`; others are unaffected. A structural failure (e.g. capability
-lost) escalates to the system-wide `SFLOW_STATE.active_path=failed` path
-instead.
-
-Lifecycle gaps in the resolver, not specific to HW sFlow:
-
-* **Egress port programming.** The resolver resolves the egress port but
-does not pass it into a SAI attribute today; silicon IP route lookup
-determines egress at emit time. Whether HW sFlow needs explicit
-egress-port pinning is a vendor-contract question (§7.12, §14).
-* **ECMP and LAG distribution.** The resolver picks the first nexthop and
-the first LAG member. Must be resolved in Phase I alongside LAG support
-(§5 requirement 9, §14 open item).
-* **L4 source port stability.** The resolver uses a random ephemeral port
-per session. Phase I HW sFlow accepts random-per-session; stable-port is
-tracked in §14.
+`LAST_ERROR`; others are unaffected. 
 
 #### Agent address coupling
 
 Every sFlow v5 datagram carries an *Agent Address*: the IP the collector
-uses as primary key to group a switch's samples (distinct from the
+uses a primary key to group a switch's samples (distinct from the
 arbitrary-integer `sub_agent_id` — §14 item 2). In the CPU path, `hsflowd`
 sets it from `SFLOW|global:agent_id`, decoupled from transport. On the HW
 path the silicon reuses the encap source IP and exposes no separate Agent
@@ -373,15 +247,6 @@ routes to any collector normally. The cost is a documented limitation
 from transport source; such a config still works, it just emits with both
 equal to `agent_id`'s IP.
 
-#### Syncd
-
-No SAI API additions are needed today. The relevant enums and attributes
-(`SAI_MIRROR_SESSION_TYPE_SFLOW`,
-`SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION`,
-`SAI_MIRROR_SESSION_ATTR_SAMPLE_RATE`), and the TAM transport/collector
-attributes are all existing standard enums. If the SAI surface for
-sampling migrates to the TAM namespace, `HwSflow` picks up the new APIs
-through the standard sairedis surface; no syncd changes are anticipated.
 
 ### 7.6 DB and Schema changes
 

--- a/doc/sflow/hw_sflow_hld.md
+++ b/doc/sflow/hw_sflow_hld.md
@@ -29,7 +29,7 @@
 
 | Revision | Date | Author | Change Description |
 | ----- | ----- | ----- | ----- |
-| 0.1 | 2026-06-01 | darius-nexthop | Initial Proposal |
+| 0.1 | 2026-08-15 | darius-nexthop | Initial Proposal |
 
 ### 2. Scope
 
@@ -50,17 +50,18 @@ unchanged on the CPU path regardless of the selected mode.
 | HW sFlow | Hardware accelerated sFlow: the ASIC builds and sends the datagram |
 | CPU sFlow | The existing sample-and-punt datapath described in [`sflow_hld.md`](https://github.com/sonic-net/SONiC/blob/master/doc/sflow/sflow_hld.md) |
 | SAI | Switch Abstraction Interface |
-| TAM | Telemetry and Monitoring, the SAI namespace for telemetry objects |
 | hsflowd | [InMon host-sflow](https://github.com/sflow/host-sflow) agent, SONiC's userspace sFlow agent |
 
 ### 4. Overview
 
-This document proposes a hardware accelerated sFlow datapath for SONiC.
-`SflowOrch` now programs a SAI TAM telemetry graph, rather than a samplepacket
-object. Also, because a datagram built in silicon needs its encapsulation
-supplied up front, it takes a dependency on `NeighOrch` and `RouteOrch` to
-provide automatic next-hop resolution. The path also verifies the platform is
-capable.
+This document proposes an alternative flow-sampling datapath for SONiC:
+hardware accelerated sFlow. When it is selected, `SflowOrch` creates a SAI
+mirror session of type sFlow and binds it to sampled ports; the ASIC then
+samples, aggregates, and emits sFlow v5 datagrams without CPU involvement.
+Because the datagram is built in silicon, its encapsulation must be supplied
+up front, so `SflowOrch` takes a dependency on `NeighOrch` and `RouteOrch` to
+resolve the path to the collector and to refresh it on change. The path is
+gated on platform capability.
 
 ### 5. Requirements
 
@@ -83,71 +84,75 @@ Not supported:
 ### 6. Architecture Design
 
 This design does not change the SONiC architecture. `SflowOrch` gains a
-`HwSflow` class that owns the SAI TAM objects and the per-port binding for the
-hardware datapath. The existing CPU path is untouched and remains the default.
-Other sFlow features, such as counter samples and MOD, will remain unimpacted on
-the CPU path regardless of `mode` configuration.
+`HwSflow` class that owns the sFlow mirror session and the per-port sample
+bindings for the hardware datapath. The existing CPU path is untouched and
+remains the default. Other sFlow features, such as counter samples and MOD,
+will remain unimpacted on the CPU path regardless of `mode` configuration.
 
 ### 7. High-Level Design
 
 #### 7.1 SAI object flow
 
-For each collector, `HwSflow` creates the TAM objects below and binds the
-resulting `SAI_OBJECT_TYPE_TAM` object to every sampled port.
+For each collector, `HwSflow` creates one mirror session of type sFlow and
+binds it to every sampled port.
+
+Throughout this document, the **collector-facing port** is the port sFlow
+datagrams egress towards the collector on. It is programmed as
+`SAI_MIRROR_SESSION_ATTR_MONITOR_PORT` and is unrelated to egress sampling,
+which the hardware path does not support.
 
 ```mermaid
 flowchart TB
     CFG["CONFIG_DB<br/>SFLOW · SFLOW_COLLECTOR · SFLOW_SESSION"] --> ORCH
-    NR["NeighOrch / RouteOrch"] -->|"next-hop MAC, src MAC, egress port"| ORCH
-    ORCH["HwSflow (SflowOrch, sonic-swss)"] ==>|creates| TAM
-    TAM["TAM<br/>BIND_POINT_TYPE_LIST = PORT"] --> TLM["TAM_TELEMETRY"]
-    TLM --> TT["TAM_TEL_TYPE<br/>TELEMETRY_TYPE = FLOW"]
-    TLM --> COL["TAM_COLLECTOR<br/>SRC/DST_IP, SRC/DST_MAC<br/>TRUNCATE_SIZE, DSCP<br/>DESTINATION = port or LAG"]
-    TT --> RPT["TAM_REPORT<br/>TYPE = SFLOW<br/>REPORT_MODE = SAMPLING<br/>SAMPLE_RATE = 1-in-N"]
-    COL --> TRN["TAM_TRANSPORT<br/>UDP, DST_PORT = 6343"]
-    ORCH ==>|"binds TAM oid"| PORT["Sampled port<br/>SAI_PORT_ATTR_TAM_OBJECT"]
+    NR["NeighOrch / RouteOrch"] -->|"collector-facing port,<br/>next-hop MAC, src MAC"| ORCH
+    ORCH["HwSflow (SflowOrch, sonic-swss)"] ==>|creates| MS
+    subgraph MS["MIRROR_SESSION — TYPE = sFlow"]
+        direction LR
+        SMP["<b>Sampling</b><br/>rate = 1-in-N<br/>truncate size"]
+        ENC["<b>Encapsulation</b><br/>src/dst IP<br/>src/dst MAC<br/>UDP src/dst port"]
+        DLV["<b>Delivery</b><br/>collector-facing port<br/>(MONITOR_PORT)"]
+    end
+    ORCH ==>|"binds session"| PORT["Sampled port<br/>SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION"]
     PORT ==> WIRE(["Silicon emits sFlow v5 UDP<br/>datagrams to the collector"])
 ```
 
 Creation order:
 
-1. `create_tam_transport()`: UDP transport, destination port from
-   `SFLOW_COLLECTOR` (6343 by default).
-2. `create_tam_collector()`: source and destination IP and MAC, egress
-   destination, truncation size and DSCP, referencing the transport.
-3. `create_tam_report()`: `TYPE = SAI_TAM_REPORT_TYPE_SFLOW`,
-   `REPORT_MODE = SAI_TAM_REPORT_MODE_SAMPLING` and the configured 1-in-N
-   `SAMPLE_RATE`.
-4. `create_tam_tel_type()`: `TAM_TELEMETRY_TYPE = SAI_TAM_TELEMETRY_TYPE_FLOW`,
-   referencing the report.
-5. `create_tam_telemetry()`: joins the telemetry type to the collector.
-6. `create_tam()`: references the telemetry object and declares a port bind
-   point.
-7. `set_port_attribute(port, SAI_PORT_ATTR_TAM_OBJECT, [tam])` for every port
-   whose `SFLOW_SESSION` row is enabled.
+1. Resolve the collector against `NeighOrch` and `RouteOrch` to
+   obtain the collector-facing port, next-hop MAC and source MAC.
+2. `create_mirror_session()`: `TYPE = SAI_MIRROR_SESSION_TYPE_SFLOW`, the
+   collector-facing port as `MONITOR_PORT`, source and destination IP and MAC,
+   UDP source and destination port (6343 by default, from `SFLOW_COLLECTOR`),
+   the configured 1-in-N `SAMPLE_RATE` and `TRUNCATE_SIZE`.
+3. `set_port_attribute(port, SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION,
+   [session])` for every port whose `SFLOW_SESSION` row is enabled. Passing an
+   empty list unbinds the port.
 
-Teardown reverses that order. Two consequences:
+Teardown reverses that order: unbind every port, then remove the session. Two
+consequences for `SflowOrch` bookkeeping:
 
-- SONiC configures the sample rate per port but the rate lives on `TAM_REPORT`,
-  so one graph is created per (collector, sample rate) pair and shared by the
-  ports using it.
-- For a PortChannel the graph is bound to each member port, with
-  `SAI_TAM_COLLECTOR_ATTR_DESTINATION` set to the resolved port or LAG object;
-  member changes rebind.
+- SAI puts the sample rate on the session, but SONiC configures it per port.
+  Ports that share a collector and a rate share one session; a port with a
+  different rate needs its own session.
+- SAI binds sessions to physical ports only. Enabling sFlow on a PortChannel
+  binds every member port, and a membership change rebinds.
+
+Optionally, `MONITOR_PORT` can be set to a recirc port instead of a
+front-panel port. The datagram then takes a second pass through the pipeline
+and the FIB forwards it to the collector, so delivery follows route changes.
 
 #### 7.2 Collector resolution
 
 `HwSflow` resolves each collector address against `NeighOrch` and `RouteOrch`
-for the next-hop MAC, source MAC and egress port, and observes both so a
-neighbor or route change re-resolves it. The encapsulation source IP is the
-address of the interface named by `SFLOW|global:agent_id`, which is also the
-Agent Address carried in every emitted datagram.
+and re-resolves on any route or neighbor change. The result — collector-facing
+port, next-hop MAC, source MAC — is applied to the live session with
+`set_mirror_session_attribute()`; nothing is recreated. The encapsulation
+source IP is the address of the interface named by `SFLOW|global:agent_id`,
+which is also the Agent Address carried in every emitted datagram.
 
-Encapsulation and sample-rate changes recreate the affected TAM objects rather
-than editing them in place, since in-place attribute updates are not uniformly
-supported. Recreation costs a short sampling gap and restarts the datagram
-sequence number, so `HwSflow` coalesces changes over a short window (about
-100 ms) and reprograms once.
+A sample-rate change is also an attribute set, but a vendor SAI may implement
+it with a brief sampling pause and a datagram sequence-number reset, so
+`HwSflow` coalesces bursts of changes (about 100 ms) into one reprogram.
 
 #### 7.3 Serviceability and debug
 
@@ -159,11 +164,13 @@ sequence number, so `HwSflow` coalesces changes over a short window (about
 
 ### 8. SAI API
 
-No new SAI API is required. Every object and attribute in section 7.1 exists in
-SAI today; they are defined in
-[`inc/saitam.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saitam.h)
-and described in
-[SAI-Proposal-TAM2.0](https://github.com/opencomputeproject/SAI/blob/master/doc/TAM/SAI-Proposal-TAM2.0-v2.0.docx).
+No new SAI API is required. Every object and attribute used here exists in
+SAI today: `SAI_MIRROR_SESSION_TYPE_SFLOW` and the sFlow-conditional
+`UDP_SRC_PORT`/`UDP_DST_PORT` attributes are defined in
+[`inc/saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h),
+and the per-port binding attribute
+`SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` in
+[`inc/saiport.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saiport.h).
 
 ### 9. Configuration and management
 
@@ -233,11 +240,14 @@ leaf mode {
 }
 ```
 
-`STATE_DB:SWITCH_CAPABILITY` gains one bit:
+`STATE_DB:SWITCH_CAPABILITY` gains one bit, sourced from
+`sai_query_attribute_enum_values_capability()` on
+`SAI_MIRROR_SESSION_ATTR_TYPE` (the platform is capable when the returned list
+contains `SAI_MIRROR_SESSION_TYPE_SFLOW`):
 
 ```json
 "SWITCH_CAPABILITY|switch": {
-    "TAM_SFLOW_CAPABLE": "true"
+    "HW_SFLOW_CAPABLE": "true"
 }
 ```
 
@@ -267,20 +277,19 @@ HW sFlow packet sampling should not be affected after a warm reboot.
 
 ### 11. Memory Consumption
 
-One TAM object graph of six objects per (collector, sample rate) pair, plus
-port-to-graph bookkeeping in `SflowOrch` and one STATE_DB row per collector.
-Nothing is allocated while `mode` is `cpu-path`.
+One mirror session per (collector, sample rate) pair, plus port-to-session
+bookkeeping in `SflowOrch` and one STATE_DB row per collector. Nothing is
+allocated while `mode` is `cpu-path`.
 
 ### 12. Restrictions/Limitations
 
-1. An encapsulation or sample-rate change recreates the TAM objects, costing a
-   brief sampling gap and a sequence-number reset, so collectors must tolerate
+1. A sample-rate change may pause sampling briefly and reset the datagram
+   sequence number, depending on the vendor SAI, so collectors must tolerate
    resets. Bursts coalesce into one reprogram.
-2. Concurrent collectors are bounded by platform TAM resources; those beyond
-   the limit are flagged in `SFLOW_COLLECTOR_STATE` while the rest keep running.
-3. PortChannel support binds each member port, since SAI has no LAG attribute
-   for TAM objects (section 14).
-4. Ports configured `sample_direction tx` or `both` are not programmed on the
+2. PortChannel support binds each member port, since
+   `SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` is a port attribute with no
+   LAG-level equivalent.
+3. Ports configured `sample_direction tx` or `both` are not programmed on the
    hardware path and are logged at WARN.
 
 ### 13. Testing Requirements/Design
@@ -289,12 +298,12 @@ Nothing is allocated while `mode` is `cpu-path`.
 
 | # | Test |
 | :---- | :---- |
-| 1 | `TAM_SFLOW_CAPABLE` is published from the SAI capability query |
-| 2 | Default `mode=cpu-path` uses the CPU path and creates no TAM objects |
-| 3 | `mode=hw-accelerated` on a capable platform creates the six-object graph with expected attributes and binds it to enabled ports |
+| 1 | `HW_SFLOW_CAPABLE` is published from the SAI capability query |
+| 2 | Default `mode=cpu-path` uses the CPU path and creates no mirror session |
+| 3 | `mode=hw-accelerated` on a capable platform creates the mirror session with expected attributes and binds it to enabled ports |
 | 4 | `mode=hw-accelerated` on an incapable platform: config is retained, flow sampling stops (no CPU fallback), `SFLOW_STATE|global` reports non-operational with a reason, and a WARN is logged |
-| 5 | A neighbor or route change re-resolves and reprograms the collector; a burst collapses into one reprogram |
-| 6 | Two ports at the same sample rate share one graph; different rates get distinct graphs |
+| 5 | A neighbor or route change re-resolves and updates the session in place; a burst collapses into one reprogram |
+| 6 | Two ports at the same sample rate share one session; different rates get distinct sessions |
 | 7 | Bindings are removed on session delete; a mode change tears down one path before standing up the other |
 
 #### 13.2 System test cases
@@ -312,6 +321,7 @@ We will evaluate:
 
 ### 14. Open/Action items - if any
 
-- SAI has no LAG bind point or LAG destination attribute for TAM objects, so
-  PortChannel support binds each member port (section 12). A SAI enhancement
-  request to add one is worth raising.
+- SAI has no LAG-level equivalent of
+  `SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION`, so PortChannel support binds
+  each member port. A SAI enhancement request to add one is worth
+  raising.

--- a/doc/sflow/hw_sflow_hld.md
+++ b/doc/sflow/hw_sflow_hld.md
@@ -38,6 +38,10 @@ accelerated sFlow. On ASICs that support it, the switch builds sFlow v5
 datagrams in silicon and sends them straight to the collector rather than
 punting every sampled packet to the CPU.
 
+Hardware acceleration applies to **flow samples only**. Counter samples, the
+hsflowd agent, and every other part of the sFlow subsystem continue to operate
+unchanged on the CPU path regardless of the selected mode.
+
 ### 3. Definitions/Abbreviations
 
 | Term | Definition |
@@ -184,16 +188,20 @@ sFlow Global Information:
   sFlow Sample Direction:     rx
   sFlow Polling Interval:     default
   sFlow AgentID:              Loopback0
-  sFlow Datapath Mode:        hw-accelerated
+  sFlow Sampling Mode:        hw-accelerated
+  sFlow Sampling Status:      operational
 
   1 Collectors configured:
     Name: collector0          IP addr: 10.0.0.1       UDP port: 6343   VRF: default
       Programmed: true        Dst MAC: 0c:42:a1:5e:3b:07   Src IP: 10.1.0.32   Egress: Ethernet48
 ```
 
-Selecting `hw-accelerated` on a platform that does not support it is rejected:
-`config sflow mode` reports the reason, `mode` stays `cpu-path`, and the failure
-is logged to syslog.
+On a platform that cannot support the configured mode:
+
+```text
+  sFlow Sampling Mode:        hw-accelerated
+  sFlow Sampling Status:      non-operational (platform not capable)
+```
 
 `sonic-sflow.yang`:
 
@@ -233,7 +241,7 @@ leaf mode {
 }
 ```
 
-One new STATE_DB table, written by `SflowOrch`:
+Two new STATE_DB tables, written by `SflowOrch`:
 
 ```text
 key           = SFLOW_COLLECTOR_STATE|<collector_name>
@@ -241,6 +249,12 @@ programmed    = "true" / "false"
 resolved_dst_mac, resolved_src_mac, resolved_src_ip, egress_port
 last_error    = string
 last_updated  = timestamp
+```
+
+```text
+key          = SFLOW_STATE|global
+operational  = "true" / "false"
+reason       = string (empty when operational)
 ```
 
 Configuration without `mode` behaves as `cpu-path`, so nothing is migrated and
@@ -278,7 +292,7 @@ Nothing is allocated while `mode` is `cpu-path`.
 | 1 | `TAM_SFLOW_CAPABLE` is published from the SAI capability query |
 | 2 | Default `mode=cpu-path` uses the CPU path and creates no TAM objects |
 | 3 | `mode=hw-accelerated` on a capable platform creates the six-object graph with expected attributes and binds it to enabled ports |
-| 4 | `mode=hw-accelerated` on an incapable platform is rejected: `mode` stays `cpu-path` and the reason is logged |
+| 4 | `mode=hw-accelerated` on an incapable platform: config is retained, flow sampling stops (no CPU fallback), `SFLOW_STATE|global` reports non-operational with a reason, and a WARN is logged |
 | 5 | A neighbor or route change re-resolves and reprograms the collector; a burst collapses into one reprogram |
 | 6 | Two ports at the same sample rate share one graph; different rates get distinct graphs |
 | 7 | Bindings are removed on session delete; a mode change tears down one path before standing up the other |

--- a/doc/sflow/hw_sflow_hld.md
+++ b/doc/sflow/hw_sflow_hld.md
@@ -9,877 +9,295 @@
 - [5. Requirements](#5-requirements)
 - [6. Architecture Design](#6-architecture-design)
 - [7. High-Level Design](#7-high-level-design)
-  - [7.1 Built-in vs Application Extension](#71-built-in-vs-application-extension)
-  - [7.2 Modified modules / repositories](#72-modified-modules--repositories)
-  - [7.3 Module interfaces and dependencies](#73-module-interfaces-and-dependencies)
-  - [7.4 SWSS changes](#74-swss-changes)
-  - [7.5 SWSS and Syncd changes in detail](#75-swss-and-syncd-changes-in-detail)
-  - [7.6 DB and Schema changes](#76-db-and-schema-changes)
-  - [7.7 Sequence diagrams](#77-sequence-diagrams)
-  - [7.8 Linux dependencies and interface](#78-linux-dependencies-and-interface)
-  - [7.9 Scalability and performance](#79-scalability-and-performance)
-  - [7.10 Management interfaces](#710-management-interfaces)
-  - [7.11 Serviceability and Debug](#711-serviceability-and-debug)
-  - [7.12 Platform-specific considerations](#712-platform-specific-considerations)
+  - [7.1 SAI object flow](#71-sai-object-flow)
+  - [7.2 Collector resolution](#72-collector-resolution)
+  - [7.3 Serviceability and debug](#73-serviceability-and-debug)
 - [8. SAI API](#8-sai-api)
 - [9. Configuration and management](#9-configuration-and-management)
-  - [9.1 Manifest (if the feature is an Application Extension)](#91-manifest-if-the-feature-is-an-application-extension)
-  - [9.2 CLI / YANG model Enhancements](#92-cli--yang-model-enhancements)
-  - [9.3 Config DB Enhancements](#93-config-db-enhancements)
-  - [9.4 End-to-end CONFIG_DB walkthrough](#94-end-to-end-config_db-walkthrough)
+  - [9.1 Manifest](#91-manifest)
+  - [9.2 CLI and YANG model enhancements](#92-cli-and-yang-model-enhancements)
+  - [9.3 Config DB enhancements](#93-config-db-enhancements)
 - [10. Warmboot and Fastboot Design Impact](#10-warmboot-and-fastboot-design-impact)
 - [11. Memory Consumption](#11-memory-consumption)
-- [12. Restrictions / Limitations](#12-restrictions--limitations)
-- [13. Testing Requirements / Design](#13-testing-requirements--design)
+- [12. Restrictions/Limitations](#12-restrictionslimitations)
+- [13. Testing Requirements/Design](#13-testing-requirementsdesign)
   - [13.1 Unit test cases](#131-unit-test-cases)
   - [13.2 System test cases](#132-system-test-cases)
-- [14. Open / Action items](#14-open--action-items)
+- [14. Open/Action items](#14-openaction-items---if-any)
 
-### 1\. Revision
+### 1. Revision
 
 | Revision | Date | Author | Change Description |
 | ----- | ----- | ----- | ----- |
-| 0.1 | 2026-06-01 | Darius Grassi | Initial Proposal |
+| 0.1 | 2026-06-01 | darius-nexthop | Initial Proposal |
 
-### 2\. Scope
+### 2. Scope
 
-This document describes the addition of an optional sFlow feature in
-SONiC - hardware accelerated sFlow. In ASICs that support hardware accelerated sflow, 
-the sflow packets will be sent directly from the ASIC to the collector. This design 
-document explains how SflowOrch will be modified to support this sflow mode.
+This document describes an optional sFlow datapath for SONiC: hardware
+accelerated sFlow. On ASICs that support it, the switch builds sFlow v5
+datagrams in silicon and sends them straight to the collector rather than
+punting every sampled packet to the CPU.
 
-### 3\. Definitions/Abbreviations
+### 3. Definitions/Abbreviations
 
 | Term | Definition |
 | :---- | :---- |
-| sFlow | Sampled flow, RFC 3176 / sflow.org v5 |
-| HW sFlow | Hardware accelerated sFlow, packets sent from ASIC to collector directly |
-| CPU sFlow | The existing sample-and-punt sFlow path documented in SONiC’s [`sflow_hld.md`](https://github.com/sonic-net/SONiC/blob/master/doc/sflow/sflow_hld.md) |
+| sFlow | Sampled flow, sFlow v5 (sflow.org) |
+| HW sFlow | Hardware accelerated sFlow: the ASIC builds and sends the datagram |
+| CPU sFlow | The existing sample-and-punt datapath described in [`sflow_hld.md`](https://github.com/sonic-net/SONiC/blob/master/doc/sflow/sflow_hld.md) |
 | SAI | Switch Abstraction Interface |
-| MOD | Mirror-on-Drop |
-| COPP | Control Plane Policing (host-interface trap rate limiter) |
-| `MIRROR_SESSION_TYPE_SFLOW` | SAI mirror session type that builds sFlow v5 datagrams in silicon ([`saimirror.h:51`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h)). |
-| TAM | Telemetry and Monitoring, a SAI namespace for telemetry-related objects and attributes |
-| TamOrch | Orchagent in `sonic-swss` that programs TAM features like Mirror-on-drop. Proposed in unmerged [sonic-swss#4370](https://github.com/sonic-net/sonic-swss/pull/4370); not present on `master`. |
-| hsflowd | InMon's host-sflow agent (`https://github.com/sflow/host-sflow`) |
+| TAM | Telemetry and Monitoring, the SAI namespace for telemetry objects |
+| hsflowd | [InMon host-sflow](https://github.com/sflow/host-sflow) agent, SONiC's userspace sFlow agent |
 
-### 4\. Overview
+### 4. Overview
 
-In the existing SONiC sFlow architecture, all sampled packets are punted
-to the CPU over a generic-netlink channel and `hsflowd` performs sFlow
-datagram construction in userspace. This works well at moderate sampling
-rates and link speeds, but is rate-limited on higher speed
-platforms.
+This document proposes a hardware accelerated sFlow datapath for SONiC.
+`SflowOrch` now programs a SAI TAM telemetry graph, rather than a samplepacket
+object. Also, because a datagram built in silicon needs its encapsulation
+supplied up front, it takes a dependency on `NeighOrch` and `RouteOrch` to
+provide automatic next-hop resolution. The path also verifies the platform is
+capable.
 
-With hardware acceleration, the forwarding ASIC:
+### 5. Requirements
 
-1. Performs the 1-in-N sampling decision in the pipeline (ingress or egress).
-2. Truncates the sampled packet to the configured header size.
-3. Prepends sFlow flow-record fields (using preserved system metadata to
-   recover ingress / egress port info).
-4. Prepends the sFlow datagram header, with an HW-maintained sequence
-   number.
-5. Prepends an Ethernet/IP/UDP encapsulation toward the configured
-   collector, stamping the UDP checksum.
-6. Emits the resulting sFlow v5 UDP datagram out a normal egress port.
+Supported:
 
-In this model, the host CPU is involved only at session-create time (to
-load the sample rate, the encap template, and the datagram-header layout
-into silicon) and at re-program time (to refresh the encap when the
-next-hop or source IP changes). Steady-state sample throughput is
-decoupled from CPU and COPP capacity.
+- Opt-in through a new `mode` field via CLI, reflected in `CONFIG_DB:SFLOW|global`.
+- Gated on platform capability, published in `STATE_DB:SWITCH_CAPABILITY`.
+- Ingress sampling on physical ports and PortChannels.
+- IPv4 and IPv6 collectors.
+- Per-port sample rate and header truncation size.
+- Encapsulation (destination MAC, source MAC, source IP, egress port) resolved
+  automatically from routing and neighbor state, refreshed on change.
+- Selected mode and per-collector resolution visible in `show sflow`.
 
-### 5\. Requirements
+Not supported:
 
-1. Detect platform capability for HW sFlow via SAI capability query, and
-   reflect it in `STATE_DB:SWITCH_CAPABILITY`.
-2. Support configuring HW sFlow on physical interfaces in ingress
-   direction only, reusing the existing per-port
-`sample_direction: rx ` setting on `SFLOW_SESSION` rows.
-3. Support IPv4 and IPv6 collectors.
-4. Select the sFlow datapath based on configuration. Default mode is
-`cpu-path` and hardware acceleration can be enabled if `mode` is set 
-to `hw-accelerated`.
-5. Resolve the destination MAC, source MAC, source IP, and other
-   encapsulation parameters automatically from kernel routing/neighbor
-state.
-6. Automatically refresh the silicon encap when the resolved next-hop
-   MAC, source IP, or routing changes.
-7. Portchannel (LAG) interface support, including LAG-egress sampling.
+- Egress sampling (`tx`, `both`).
+- Hardware counter samples (still egress via CPU path).
 
-#### Not planned to be supported
+### 6. Architecture Design
 
-1. HW-accelerated counter samples (out of scope).
-2. ACL-driven HW sFlow sessions (support is be port-level only).
-3. Egress sampling.
+This design does not change the SONiC architecture. `SflowOrch` gains a
+`HwSflow` class that owns the SAI TAM objects and the per-port binding for the
+hardware datapath. The existing CPU path is untouched and remains the default.
+Other sFlow features, such as counter samples and MOD, will remain unimpacted on
+the CPU path regardless of `mode` configuration.
 
-### 6\. Architecture Design
+### 7. High-Level Design
 
-This change extends `SflowOrch` in `sonic-swss` with a new `HwSflow`
-sibling class and adds CLI / YANG / CONFIG_DB fields. SAI TAM APIs are
-called directly from `SflowOrch::HwSflow`. This design is
-similar to `SflowDropMonitor` in the
-[`sonic-net/sonic-swss#3970`](https://github.com/sonic-net/sonic-swss/pull/3970).
+#### 7.1 SAI object flow
 
-HW sFlow is the same operator-facing feature as CPU sFlow with a
-different datapath, so it stays under the `sflow` CLI/CONFIG_DB namespace
-and `SflowOrch` owns both paths. 
-
-### 7\. High-Level Design
-
-`HwSflow` owns the HW sFlow lifecycle: collector/encap
-resolution against `NeighOrch` / `RouteOrch`, SAI TAM object create /
-update / delete, the sFlow session SAI object, and per-port binding via
-`INGRESS_SAMPLE_MIRROR_SESSION`.
-
-### 7.1 Built-in vs Application Extension
-
-Built-in feature modification.
-
-### 7.2 Modified modules / repositories
-
-| Repository | Component | Change |
-| :---- | :---- | :---- |
-| `sonic-swss` | `SflowOrch` | Added `HwSflow`; consumes `SFLOW_COLLECTOR`, attaches `Observer`s to `NeighOrch` and `RouteOrch`, resolves `(dst_mac, src_mac, egress_port)` against kernel routing/neighbor state and pins encap `src_ip` to `SFLOW|global:agent_id`'s IP (see §7.5) on session create and on observer-callback refresh, calls SAI TAM APIs directly to create `TAM_TRANSPORT` / `TAM_COLLECTOR` / sFlow session, and binds the result via `INGRESS_SAMPLE_MIRROR_SESSION`. |
-| `sonic-swss` | `SflowOrch::HwSflow` resolver | New. |
-| `sonic-swss` | `SwitchOrch` | Expose `INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE`from `sai_query_attribute_capability()` in `STATE_DB:SWITCH_CAPABILITY`. |
-| `sonic-utilities` | `config sflow` / `show sflow` | New `mode` override knob (debug; default `cpu-path`) and diagnostic output. |
-| `sonic-yang-models` | `sonic-sflow.yang` | Add `mode` field. |
-| `sonic-buildimage` | sflow container | hsflowd config template: optional `sub_agent_id` field (open issue, see §14). |
-| `sonic-buildimage` | `db_migrator.py` | Migrate existing config to new schema (additive, absent `mode` = `auto`). |
-| `sonic-mgmt` | tests | New PTF tests for HW path (see §13). |
-
-### 7.3 Module interfaces and dependencies
-
-* `SflowOrch::HwSflow` consumes
-`STATE_DB:SWITCH_CAPABILITY:INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE` 
-to gate the capability. The selected path applies to the entire system.
-* `SflowOrch::HwSflow` consumes `APP_DB:SFLOW_SESSION_TABLE` and
-`CONFIG_DB:SFLOW_COLLECTOR`. It performs collector resolution using a
-new resolver attached to `NeighOrch` and `RouteOrch`, modeled on
-resolvers from `MirrorOrch` and `TamOrch`.
-It then calls SAI TAM APIs directly to create one
-`SAI_OBJECT_TYPE_TAM_TRANSPORT` (refcounted across collectors) and one
-`SAI_OBJECT_TYPE_TAM_COLLECTOR` per collector, plus the sFlow session
-SAI object.
-* `SflowOrch::HwSflow` binds the resulting session OID via
-`SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` on each enabled port.
-
-### 7.5 SWSS and Syncd changes in detail
-
-#### Object graph diagram
-
-The diagram below shows the SAI object graph that `SflowOrch::HwSflow`
-creates per configured collector.
+For each collector, `HwSflow` creates the TAM objects below and binds the
+resulting `SAI_OBJECT_TYPE_TAM` object to every sampled port.
 
 ```mermaid
 flowchart TB
-    subgraph SFO["SflowOrch (sonic-swss)"]
-        HwSflow["HwSflow sibling class<br/>(includes NeighOrch/RouteOrch resolver)"]
-        SP["SAI_OBJECT_TYPE_SAMPLEPACKET<br/>(CPU path only — idle when HW active)"]
-    end
-
-    HwSflow -->|creates| TT["SAI_OBJECT_TYPE_TAM_TRANSPORT<br/>SRC/DST_MAC, SRC/DST_PORT<br/>refcounted across collectors"]
-    HwSflow -->|creates| TC["SAI_OBJECT_TYPE_TAM_COLLECTOR<br/>SRC/DST_IP, DSCP"]
-    TC -.->|references| TT
-    HwSflow -->|creates| SES["sFlow session SAI object<br/>today: SAI_OBJECT_TYPE_MIRROR_SESSION<br/>TYPE=SFLOW<br/>future: TAM-namespaced object"]
-    SES -.->|carries SAMPLE_RATE,<br/>TRUNCATE_SIZE, UDP_*,<br/>encap fields| TC
-
-    HwSflow -->|binds OID| PORT["Port:<br/>SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION<br/>]
-    SES -.->|bound to| PORT
+    CFG["CONFIG_DB<br/>SFLOW · SFLOW_COLLECTOR · SFLOW_SESSION"] --> ORCH
+    NR["NeighOrch / RouteOrch"] -->|"next-hop MAC, src MAC, egress port"| ORCH
+    ORCH["HwSflow (SflowOrch, sonic-swss)"] ==>|creates| TAM
+    TAM["TAM<br/>BIND_POINT_TYPE_LIST = PORT"] --> TLM["TAM_TELEMETRY"]
+    TLM --> TT["TAM_TEL_TYPE<br/>TELEMETRY_TYPE = FLOW"]
+    TLM --> COL["TAM_COLLECTOR<br/>SRC/DST_IP, SRC/DST_MAC<br/>TRUNCATE_SIZE, DSCP<br/>DESTINATION = port or LAG"]
+    TT --> RPT["TAM_REPORT<br/>TYPE = SFLOW<br/>REPORT_MODE = SAMPLING<br/>SAMPLE_RATE = 1-in-N"]
+    COL --> TRN["TAM_TRANSPORT<br/>UDP, DST_PORT = 6343"]
+    ORCH ==>|"binds TAM oid"| PORT["Sampled port<br/>SAI_PORT_ATTR_TAM_OBJECT"]
+    PORT ==> WIRE(["Silicon emits sFlow v5 UDP<br/>datagrams to the collector"])
 ```
 
-On session create, `HwSflow` walks `NeighOrch` / `RouteOrch` to populate `(dst_mac, src_mac,
-egress_port)` and pins `src_ip` to `agent_id`'s IP and registers as a neighbor / next-hop observer to
-refresh on kernel state changes. The resolver picks the first nexthop and
-the first LAG member if the resolution is over a ECMP or LAG. 
+Creation order:
 
-When hw-acceleration is enabled and supported, `SflowOrch` creates one `TAM_TRANSPORT` + one
-`TAM_COLLECTOR` per configured collector, plus the sFlow session SAI
-object, then binds the session OID to the port. Mode transitions from `cpu-mode` 
-to `hw-acceleration` or vice versa tear down the old path's SAI state before 
-standing up the new path's; a brief sampling outage is expected.
+1. `create_tam_transport()`: UDP transport, destination port from
+   `SFLOW_COLLECTOR` (6343 by default).
+2. `create_tam_collector()`: source and destination IP and MAC, egress
+   destination, truncation size and DSCP, referencing the transport.
+3. `create_tam_report()`: `TYPE = SAI_TAM_REPORT_TYPE_SFLOW`,
+   `REPORT_MODE = SAI_TAM_REPORT_MODE_SAMPLING` and the configured 1-in-N
+   `SAMPLE_RATE`.
+4. `create_tam_tel_type()`: `TAM_TELEMETRY_TYPE = SAI_TAM_TELEMETRY_TYPE_FLOW`,
+   referencing the report.
+5. `create_tam_telemetry()`: joins the telemetry type to the collector.
+6. `create_tam()`: references the telemetry object and declares a port bind
+   point.
+7. `set_port_attribute(port, SAI_PORT_ATTR_TAM_OBJECT, [tam])` for every port
+   whose `SFLOW_SESSION` row is enabled.
 
-When the configured collector count exceeds the supported maximum (the platform's advertised limit),
-`SflowOrch::HwSflow` programs the first N collectors (sorted by name, so the 
-set is stable across restarts and reconciles) and leaves the rest unprogrammed —
-`SFLOW_COLLECTOR_STATE.PROGRAMMED=false,
-LAST_ERROR=hw_session_limit_exceeded`, plus a WARN syslog naming them. The
-system stays `active_path=hw` rather than failing wholesale for one excess
-row.
+Teardown reverses that order. Two consequences:
 
-#### Lifecycle implications
+- SONiC configures the sample rate per port but the rate lives on `TAM_REPORT`,
+  so one graph is created per (collector, sample rate) pair and shared by the
+  ports using it.
+- For a PortChannel the graph is bound to each member port, with
+  `SAI_TAM_COLLECTOR_ATTR_DESTINATION` set to the resolved port or LAG object;
+  member changes rebind.
 
-`HwSflow` must handle next-hop / encap changes and operator-driven
-sample-rate changes. The current plan is **tear-down + recreate**: delete
-the `TAM_COLLECTOR`, decrement the `TAM_TRANSPORT` refcount, recreate — so
-the vendor driver sees a delete-then-create on every attribute change,
-costing a sampling gap and a sequence-number reset. An in-place
-`set_*_attribute()` fast path is not uniformly available (not all
-attributes support it on every platform — see §7.12) and is tracked as a
-§14 enhancement.
+#### 7.2 Collector resolution
 
-#### Partial-create failure handling
+`HwSflow` resolves each collector address against `NeighOrch` and `RouteOrch`
+for the next-hop MAC, source MAC and egress port, and observes both so a
+neighbor or route change re-resolves it. The encapsulation source IP is the
+address of the interface named by `SFLOW|global:agent_id`, which is also the
+Agent Address carried in every emitted datagram.
 
-`HwSflow` must handle partial-create failure. The failed collector is
-flagged `SFLOW_COLLECTOR_STATE.PROGRAMMED=false` with the SAI error in
-`LAST_ERROR`; others are unaffected. 
+Encapsulation and sample-rate changes recreate the affected TAM objects rather
+than editing them in place, since in-place attribute updates are not uniformly
+supported. Recreation costs a short sampling gap and restarts the datagram
+sequence number, so `HwSflow` coalesces changes over a short window (about
+100 ms) and reprograms once.
 
-#### Agent address coupling
+#### 7.3 Serviceability and debug
 
-Every sFlow v5 datagram carries an *Agent Address*: the IP the collector
-uses a primary key to group a switch's samples (distinct from the
-arbitrary-integer `sub_agent_id` — §14 item 2). In the CPU path, `hsflowd`
-sets it from `SFLOW|global:agent_id`, decoupled from transport. On the HW
-path the silicon reuses the encap source IP and exposes no separate Agent
-Address field, so identity and transport source are *coupled by
-construction* (per the §7.12 item 1 contract, the Agent Address is the
-session source-IP attribute `SAI_MIRROR_SESSION_ATTR_SRC_IP_ADDRESS`).
+- `STATE_DB:SFLOW_COLLECTOR_STATE|<name>`: resolved encapsulation, last error
+  and last update time.
+- `show sflow` reports the selected mode and the above. Syslog records mode
+  transitions at INFO, and a rejected mode selection or a resolution failure at
+  WARN.
 
-`SflowOrch::HwSflow` resolves this in the operator's favor: the encap
-source IP is **pinned to `agent_id`'s resolved IP for every collector**
-(only `dst_mac`, `src_mac`, `egress_port` come from the route lookup).
-With the §7.12 item 1 vendor contract that the v5 Agent Address *is* the
-session source IP, the Agent Address equals `agent_id`'s IP by
-construction — nothing to detect or fail on, and a loopback source still
-routes to any collector normally. The cost is a documented limitation
-(§12 item 4): unlike the CPU path, HW cannot decouple advertised identity
-from transport source; such a config still works, it just emits with both
-equal to `agent_id`'s IP.
+### 8. SAI API
 
+No new SAI API is required. Every object and attribute in section 7.1 exists in
+SAI today; they are defined in
+[`inc/saitam.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saitam.h)
+and described in
+[SAI-Proposal-TAM2.0](https://github.com/opencomputeproject/SAI/blob/master/doc/TAM/SAI-Proposal-TAM2.0-v2.0.docx).
 
-### 7.6 DB and Schema changes
+### 9. Configuration and management
 
-**Existing tables (unchanged in Phase I):**
+#### 9.1 Manifest
 
-* `CONFIG_DB:SFLOW_COLLECTOR`: unchanged in Phase I. (Phase II MAY add
-optional manual-override fields for encap.)
-* `APP_DB:SFLOW_SESSION_TABLE`: unchanged. The per-port
-`sample_direction: rx | tx | both` field is honored on the HW path in
-both directions.
-* `APP_DB`: no new tables.
+Not applicable. This is a built-in feature, not an Application Extension.
 
-**New / extended tables:**
+#### 9.2 CLI and YANG model enhancements
 
-* `STATE_DB:SWITCH_CAPABILITY`: NEW
-`INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE` (and the egress equivalent).
-Attribute names preserved across the SAI-namespace question; if the
-capability query migrates, the bits are renamed in lockstep.
-* `CONFIG_DB:SFLOW`: add optional `mode` field (`auto` |
-`hw-accelerated` | `cpu-path`; default `auto`). Absent in the normal
-workflow — explicit values are a debug/override facility.
-* `STATE_DB:SFLOW_STATE`: NEW single `|global` row exposing configured
-`mode`, resolved system-wide `active_path` (`hw` / `cpu` / `failed`),
-`path_reason`, and last update timestamp. Populated by `SflowOrch`.
-* `STATE_DB:SFLOW_COLLECTOR_STATE`: NEW per-collector view: resolved
-encap fields, SAI session OID, last error, last update timestamp.
-Populated by `SflowOrch::HwSflow` only when the system is in HW mode.
+One new command selects the datapath; every existing sFlow command is unchanged.
 
-`SflowOrch::HwSflow` calls SAI TAM APIs directly; no `CFG_TAM_*` rows
-are introduced. The HW sFlow session is implicit in the `SFLOW` /
-`SFLOW_COLLECTOR` configuration plus the `mode` knob.
-
-### 7.7 Sequence diagrams
-
-#### Initial enablement, HW path
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant Op as Operator (CLI)
-    participant Redis as CONFIG_DB / STATE_DB
-    participant SO as SflowOrch::HwSflow
-    participant NO as NeighOrch + RouteOrch
-    participant SAI as SAI / vendor driver
-    participant HW as Silicon
-    participant Col as Collector
-
-    Op->>Redis: config sflow enable<br/>config sflow collector add ts1 198.51.100.5
-    Note right of Redis: SFLOW|global (mode absent = auto)<br/>SFLOW_COLLECTOR|ts1
-
-    Redis-->>SO: SFLOW + SFLOW_COLLECTOR updates
-    SO->>Redis: read STATE_DB:SWITCH_CAPABILITY<br/>INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE = true
-    SO->>SO: mode=auto + platform capable → HW path selected
-
-    SO->>NO: resolve(198.51.100.5)
-    NO-->>SO: dst_mac, src_mac, egress_port<br/>(src_ip pinned to agent_id IP)
-
-    SO->>SAI: create_tam_transport(SRC/DST_MAC, SRC/DST_PORT)
-    SO->>SAI: create_tam_collector(SRC/DST_IP, TRANSPORT, DSCP)
-    SO->>SAI: create sFlow session<br/>(TYPE=SFLOW, SAMPLE_RATE, TRUNCATE_SIZE,<br/>SRC/DST_IP, SRC/DST_MAC, UDP_SRC/DST_PORT)
-    Note right of SAI: Today: SAI_OBJECT_TYPE_MIRROR_SESSION<br/>Future: TAM-namespaced object<br/>(see §7.12)
-    SAI->>HW: program sampler + encap
-    SAI-->>SO: session_oid
-
-    loop for each enabled port
-        SO->>SAI: set_port_attribute(port,<br/>INGRESS_SAMPLE_MIRROR_SESSION and/or<br/>EGRESS_SAMPLE_MIRROR_SESSION, [oid])
-        SAI->>HW: enable 1-in-N sampler on port
-    end
-
-    SO->>Redis: STATE_DB:SFLOW_STATE|global<br/>mode=auto, active_path=hw
-    SO->>Redis: STATE_DB:SFLOW_COLLECTOR_STATE|ts1<br/>session_oid, resolved_*
-
-    Note over HW: ASIC samples 1-in-N, builds<br/>sFlow v5 datagram in silicon
-    HW->>Col: sFlow v5 UDP datagrams (front-panel egress)
+```text
+config sflow mode <cpu-path|hw-accelerated>
 ```
 
-#### Next-hop change
+`show sflow` gains the selected mode, and per collector the resolved
+encapsulation. Existing fields and layout are unchanged:
 
-The HW-side outcome is a sampling gap with a sequence-number reset. The
-diagram below traces the tear-down + recreate path.
+```text
+sFlow Global Information:
+  sFlow Admin State:          up
+  sFlow Sample Direction:     rx
+  sFlow Polling Interval:     default
+  sFlow AgentID:              Loopback0
+  sFlow Datapath Mode:        hw-accelerated
 
-```mermaid
-sequenceDiagram
-    autonumber
-    participant K as Kernel (rtnetlink)
-    participant NO as NeighOrch
-    participant Owner as SflowOrch::HwSflow
-    participant SAI as SAI / vendor driver
-    participant HW as Silicon
-    participant Col as Collector
-
-    Note over HW,Col: Steady state — silicon emits sFlow v5<br/>with current DST_MAC
-
-    K->>NO: NEIGH update (ARP refresh / route change)
-    NO->>NO: update APP_NEIGH_TABLE
-    NO-->>Owner: NeighborUpdate / NextHopUpdate
-
-    Owner->>Owner: re-resolve → new dst_mac
-
-    rect rgb(245,245,235)
-        Note over Owner,HW: Tear-down + recreate path<br/>(set_*_attribute fast path is a future enhancement —<br/>see §7.9 and §12 item 6)
-        Owner->>SAI: delete sFlow session OID
-        Owner->>SAI: delete_tam_collector(old_oid)
-        Owner->>SAI: tam_transport refcount--<br/>(delete if last user)
-        Owner->>SAI: create_tam_transport(new SRC/DST_MAC)
-        Owner->>SAI: create_tam_collector(new SRC/DST_IP, TRANSPORT)
-        Owner->>SAI: create sFlow session<br/>(SAMPLE_RATE, TRUNCATE_SIZE, UDP_*, ...)
-        SAI->>HW: tear down old HW sFlow session + encap<br/>(sampling stops — destination gone)
-        SAI->>HW: program new session with new DST_MAC<br/>(sequence number resets to base)
-        SAI->>HW: sampling resumes on the recreated session
-    end
-
-    SAI-->>Owner: new session_oid
-
-    Note over HW,Col: Sampling gap during tear-down + recreate<br/>(vendor-specific, see §7.9). Sequence number<br/>restarts from 0.
-    HW->>Col: sFlow v5 datagrams resume
+  1 Collectors configured:
+    Name: collector0          IP addr: 10.0.0.1       UDP port: 6343   VRF: default
+      Programmed: true        Dst MAC: 0c:42:a1:5e:3b:07   Src IP: 10.1.0.32   Egress: Ethernet48
 ```
 
-### 7.8 Linux dependencies and interface
+Selecting `hw-accelerated` on a platform that does not support it is rejected:
+`config sflow mode` reports the reason, `mode` stays `cpu-path`, and the failure
+is logged to syslog.
 
-* Collector resolution consumes the same kernel interfaces SONiC already
-uses for routing/neighbor state (rtnetlink via `NeighOrch` /
-`RouteOrch`). No new kernel modules and no new subscriptions specific
-to sFlow.
-* `psample` and `NET_DM` genetlink remain in use for counter samples and
-MOD respectively.
-* Outbound sFlow datagrams on the HW path do not pass through any Linux
-netdev. Standard packet-capture tools on the management / front-panel
-netdevs WILL NOT see HW sFlow traffic; vendor-specific debug tools are
-required. (Egress-port TX counters do count HW-emitted datagrams.)
+`sonic-sflow.yang`:
 
-### 7.9 Scalability and performance
-
-* HW path supports flow-sample rates limited by silicon (typically full
-line-rate at the configured 1-in-N divisor).
-* Sample-rate or encap changes on the HW path trigger a tear-down +
-recreate of the SAI session (lifecycle detail in §7.5), costing a
-sampling gap and sequence-number reset per change.
-
-Because each change costs a gap, `HwSflow` owns a short coalescing window
-(debounce) over config-driven changes: rapid successive writes to
-`sample_rate` or encap-affecting fields for a given collector collapse
-into a single tear-down + recreate once the window settles, rather than
-one recreate per write. The default window is a small fixed interval
-(~100 ms, tunable), well under operator-perceptible latency while
-absorbing bursts of CLI or route churn. A `set_*_attribute()` fast path,
-where the silicon supports it, would shrink the per-change cost further
-(tracked in §14).
-
-### 7.10 Management interfaces
-
-* CLI: see [Section 9.2](#92-cli--yang-model-enhancements) (`config
-sflow` / `show sflow`).
-* gNMI / REST: derived from the YANG model, additive.
-
-### 7.11 Serviceability and Debug
-
-* `STATE_DB:SFLOW_STATE|global` exposes the configured `mode`, the
-resolved system-wide active path, and the `path_reason` on forced-mode
-failure or when `auto` resolves to CPU.
-* Per-collector resolution (encap fields, SAI session OID, last error)
-is exposed via `STATE_DB:SFLOW_COLLECTOR_STATE`.
-* `show sflow` CLI reports the system active path, the configured
-`mode`, and per-collector resolved encap. See §9.2.
-* `SflowOrch` emits syslog at INFO on mode transitions and at
-WARN/ERROR on capability mismatches and resolution failures.
-* **Egress port TX counters MAY include HW-emitted sFlow datagrams**
-(vendor-specific, not HLD-mandated). Operators
-troubleshooting "collector sees nothing" should not expect a missing-TX
-symptom on the egress port (§7.8).
-* **Per-session HW emit counter**: neither SAI's `MIRROR_SESSION`
-surface nor the `TAM_COLLECTOR` / `TAM_TRANSPORT` surface standardizes a
-`samples_generated` counter. Vendor-specific counters MAY be exposed via
-debug CLI. Capture as §14 open item for the SAI community.
-
-### 7.12 Platform-specific considerations
-
-This feature is **only effective on platforms whose SAI advertises**
-`SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` capability (and the egress
-equivalent for §5 requirement 2) AND maps
-`SAI_MIRROR_SESSION_TYPE_SFLOW` (or its forthcoming TAM-namespace
-successor — see SAI surface caveat below) to in-silicon sFlow datagram
-construction. Under the default `mode=auto`, platforms without this
-capability resolve to the existing CPU path unchanged — no breakage, no
-behavioral change, and nothing for the operator to configure
-(`STATE_DB:SFLOW_STATE.path_reason` records why HW was not selected).
-Capability drives selection at path-selection time only; there is no
-error-driven runtime fall-through after a path is selected (§7.5). If
-an operator forces `mode=hw-accelerated` on a platform that does not
-advertise the capability, sFlow fails closed
-(`STATE_DB:SFLOW_STATE.active_path=failed,
-path_reason=platform_not_capable`, WARN syslog) rather than silently
-reverting to CPU — the forced value is an explicit debug/override
-choice. To recover, the operator returns `mode` to `auto` (or
-`cpu-path`).
-
-**SAI surface caveat.** Today's SAI hosts the in-silicon sFlow primitive
-under `SAI_OBJECT_TYPE_MIRROR_SESSION`. The 2025-03 SAI TAM enhancements
-([PR #2141](https://github.com/opencomputeproject/SAI/pull/2141)) added
-sampling primitives in the TAM namespace but did **not** migrate
-`MIRROR_SESSION_TYPE_SFLOW`, so its long-term namespace is unsettled. This
-HLD is forward-compatible with either landing; the vendor-contract items
-below apply to whichever SAI object type currently hosts the sFlow
-primitive on a given platform/version.
-
-The community SHOULD be informed in advance of merge. Silicon vendors
-who want their platforms to use the HW path MUST:
-
-1. Implement the sFlow-builder SAI primitive (today:
-   `SAI_MIRROR_SESSION_TYPE_SFLOW`; future: the TAM-namespace successor)
-such that the silicon emits wire-format sFlow v5 UDP datagrams. The Agent
-Address field **MUST** equal the session source-IP attribute (today:
-`SAI_MIRROR_SESSION_ATTR_SRC_IP_ADDRESS`); SONiC pins that IP to
-`SFLOW|global:agent_id`, so any other derivation silently breaks operator
-identity (§7.5 "Agent address coupling").
-2. Advertise capability via `sai_query_attribute_capability()` on
-   `SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` and the egress
-equivalent (or their successor port-binding attributes).
-3. Ideally, apply attribute changes via `set_*_attribute()` on the
-   relevant session SAI object without requiring the application to tear
-down and recreate it. **This is a desired vendor behavior, not a SAI spec
-guarantee, and is not uniformly available across attributes or
-platforms.** `HwSflow` plans a tear-down + recreate lifecycle that
-sidesteps this gap; a per-field fast path is tracked in §14.
-4. **Sequence-number behavior on attribute updates**: vendors MAY reset
-   the sFlow datagram sequence number on attribute updates. SONiC's HLD
-does not require preservation. Collectors are expected to
-tolerate sequence-number resets, which most modern sFlow collectors do.
-With tear-down + recreate, sequence-number resets are the norm (a
-recreated session always starts at 0); collectors that depend on
-continuous sequencing across topology change will need to tolerate this.
-5. **Egress port programming.** `HwSflow` does not currently pass the
-   resolved egress port into a SAI attribute, relying on silicon IP route
-lookup at emit time. Vendors whose HW sFlow path requires explicit
-egress-port pinning MUST advertise that requirement (tracked in §14).
-
-## 8\. SAI API
-
-No new SAI APIs are introduced. All referenced enums and attributes
-exist in standard SAI today (verified against
-[`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h),
-[`saiport.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saiport.h),
-[`saitam.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saitam.h),
-and a shipping vendor SAI implementation).
-
-**SAI surface note.** The table reflects today's surface, where the
-in-silicon sFlow datagram-builder lives under
-`SAI_OBJECT_TYPE_MIRROR_SESSION`; its long-term namespace is unsettled
-(see §7.12 "SAI surface caveat"). Where the table cites
-`SAI_MIRROR_SESSION_ATTR_*`, the equivalent TAM-namespaced attribute (if
-it lands) is the substitute; the *semantics* in the "Use" column don't
-change. The `SAI_TAM_*` rows reflect the objects `SflowOrch::HwSflow`
-creates per configured collector.
-
-| API / Object / Attribute | Use | Reference |
-| :---- | :---- | :---- |
-| `SAI_OBJECT_TYPE_TAM_TRANSPORT` | Per-collector L2 encap container (SRC/DST_MAC, SRC/DST_PORT). Refcounted across collectors. | [`saitam.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saitam.h) |
-| `SAI_OBJECT_TYPE_TAM_COLLECTOR` | Per-collector L3 encap container (SRC/DST_IP, TRANSPORT ref, DSCP). | [`saitam.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saitam.h) |
-| `SAI_OBJECT_TYPE_MIRROR_SESSION` | Per-collector sFlow session container (today's SAI surface; may migrate to TAM namespace) | standard |
-| `SAI_MIRROR_SESSION_ATTR_TYPE = SAI_MIRROR_SESSION_TYPE_SFLOW` | Selects the HW sFlow datagram-builder path | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
-| `SAI_MIRROR_SESSION_ATTR_MONITOR_PORT` | Vendor-specified internal/monitor port | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
-| `SAI_MIRROR_SESSION_ATTR_TRUNCATE_SIZE` | Sample truncation size (default 128) | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
-| `SAI_MIRROR_SESSION_ATTR_SAMPLE_RATE` | 1-in-N divisor on the mirror session | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
-| `SAI_MIRROR_SESSION_ATTR_SRC_MAC_ADDRESS` | Encap source MAC (resolved by the orchagent's collector resolver) | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
-| `SAI_MIRROR_SESSION_ATTR_DST_MAC_ADDRESS` | Encap destination MAC (resolved next-hop) | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
-| `SAI_MIRROR_SESSION_ATTR_SRC_IP_ADDRESS` | Encap source IP — **also embedded as v5 Agent Address** (see §7.5) | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
-| `SAI_MIRROR_SESSION_ATTR_DST_IP_ADDRESS` | Encap destination IP (collector) | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
-| `SAI_MIRROR_SESSION_ATTR_IPHDR_VERSION` | IPv4 / IPv6 | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
-| `SAI_MIRROR_SESSION_ATTR_TOS`, `_TTL` | IP header fields | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
-| `SAI_MIRROR_SESSION_ATTR_UDP_SRC_PORT`, `_UDP_DST_PORT` | UDP header fields | [`saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h) |
-| `SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` | Bind session(s) to ingress port | [`saiport.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saiport.h) |
-| `SAI_PORT_ATTR_EGRESS_SAMPLE_MIRROR_SESSION` | Bind session(s) to egress port (Phase I, §5 requirement 2) | [`saiport.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saiport.h) |
-
-Capability discovery uses the standard
-`sai_query_attribute_capability()` against `SAI_OBJECT_TYPE_PORT` for
-`SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` (and the egress
-equivalent). If the SAI port-binding attribute migrates to the TAM
-namespace, the capability query target migrates with it; SwitchOrch's
-exposed `STATE_DB:SWITCH_CAPABILITY` bit name is preserved for backward
-compatibility.
-
-The existing `SAI_OBJECT_TYPE_SAMPLEPACKET` API continues to be used
-unchanged whenever the system resolves to the CPU path (`auto` on a
-platform without HW sFlow capability, or forced `cpu-path`), and for
-counter-sample / MOD paths.
-
-## 9\. Configuration and management
-
-### 9.1 Manifest (if the feature is an Application Extension)
-
-Not applicable — this is a built-in feature modification to swss and
-configuration tooling (see §7.1).
-
-### 9.2 CLI / YANG model Enhancements
-
-The CPU-path CLI (`config sflow enable/disable`, `config sflow
-collector ...`, `config sflow agent-id ...`, per-port `config sflow
-interface sample-rate/sample-direction`) is unchanged.
-
-#### CLI additions
-
-1. `config sflow mode <auto|hw-accelerated|cpu-path>`
-   - Debug/override knob only; the normal workflow never sets it.
-   - Default `auto`: the datapath is selected from platform capability
-   (§7.5) — HW where advertised, CPU otherwise. Zero configuration.
-   - `cpu-path`: force the CPU path (e.g. to isolate a suspected HW
-   sampling problem, or to preserve exact pre-existing behavior).
-   - `hw-accelerated`: force the HW path. If unavailable on the
-   platform, sFlow is administratively failed with a syslog error and
-   `STATE_DB` reflects the failure (fail-closed, not silent CPU
-   fallback).
-
-2. `show sflow` is extended to display:
-   - Platform capability (`hw_sflow_capable: true|false`)
-   - Configured mode (`mode: auto|hw-accelerated|cpu-path`)
-   - System active path (`active_path: hw|cpu|failed`) and `path_reason`
-   on failure
-   - When `active_path=hw`, per-collector resolved encap summary
-   (`resolved_dst_mac`, `resolved_src_ip`, `egress_port`) and SAI
-   session OID
-   - Last resolution timestamp and last error
-
-No existing CLI is removed or changed in incompatible ways.
-
-#### YANG model
-
-`sonic-sflow.yang` gains:
-
-```
+```yang
 leaf mode {
     type enumeration {
-        enum auto;
-        enum hw-accelerated;
         enum cpu-path;
+        enum hw-accelerated;
     }
-
-    default "auto";
-    description "sFlow datapath override. Default 'auto' selects
-                 hardware-accelerated sFlow when the platform is capable,
-                 CPU-based sFlow otherwise. Explicit values force a path
-                 for debug.";
+    default "cpu-path";
+    description "Where sFlow datagrams are built. 'cpu-path' builds them
+                 in hsflowd in userspace; 'hw-accelerated' builds them
+                 in the ASIC.";
 }
 ```
 
-The enum literals (`auto`, `hw-accelerated`, `cpu-path`) are identical across
-the CLI token, the YANG enum, and the value stored in
-`CONFIG_DB:SFLOW|global:mode` — there is no underscore variant and no
-CLI-to-DB translation. `show sflow` and `STATE_DB` echo the same
-spelling. (YANG validation rejects config whose stored value does not
-match an enum literal, so the three must agree exactly.)
+#### 9.3 Config DB enhancements
 
-### 9.3 Config DB Enhancements
+`CONFIG_DB:SFLOW` gains `mode`:
 
-#### `CONFIG_DB:SFLOW` (modified, additive)
-
-```
+```json
 "SFLOW": {
     "global": {
         "admin_state": "up",
-        "polling_interval": "20",
         "agent_id": "Loopback0",
         "sample_direction": "rx",
-        "drop_monitor_limit": "0",
-
-        "mode": "auto"                  // NEW, optional, default "auto";
-                                        // values: auto | hw-accelerated | cpu-path
-                                        // debug/override only — absent in the
-                                        // normal workflow
+        "mode": "hw-accelerated"
     }
 }
 ```
 
-#### `CONFIG_DB:SFLOW_COLLECTOR` (unchanged in Phase I)
+`STATE_DB:SWITCH_CAPABILITY` gains one bit:
 
-Phase I uses orchagent-driven encap resolution. Phase II MAY add
-optional overrides (`override_dst_mac`, `override_src_ip`,
-`override_tos`, `override_ttl`, `override_udp_src_port`); these MUST
-default to "unset" so existing config remains valid.
-
-#### `STATE_DB:SWITCH_CAPABILITY` (modified, additive)
-
-```
+```json
 "SWITCH_CAPABILITY|switch": {
-    "value": {
-        "PORT_EGRESS_SAMPLE_CAPABLE": "true",
-        "MIRROR_ON_DROP_CAPABLE": "true",
-        "INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE": "true",  // NEW
-        "EGRESS_SAMPLE_MIRROR_SESSION_CAPABLE": "true"    // NEW (Phase I, §5 req 2)
-    }
+    "TAM_SFLOW_CAPABLE": "true"
 }
 ```
 
-#### `STATE_DB:SFLOW_STATE` (new)
+One new STATE_DB table, written by `SflowOrch`:
 
-System-wide path observability. One row, key `SFLOW_STATE|global`.
-Populated by `SflowOrch`.
-
-```
-key             = SFLOW_STATE|global
-MODE            = "auto" / "hw-accelerated" / "cpu-path"   ; mirrors CONFIG_DB (default "auto")
-ACTIVE_PATH     = "hw" / "cpu" / "failed"                  ; resolved system path
-                                                           ; ("failed" only under forced
-                                                           ;  mode=hw-accelerated — auto never fails)
-PATH_REASON     = string                                   ; why HW is not active: e.g.
-                                                           ; "platform_not_capable",
-                                                           ; "egress_sample_not_capable", ""
-                                                           ; (set both on forced-mode failure and
-                                                           ;  when auto resolves to CPU;
-                                                           ;  collector over-subscription is NOT a
-                                                           ;  global failure — see SFLOW_COLLECTOR_STATE)
-LAST_UPDATED    = timestamp
+```text
+key           = SFLOW_COLLECTOR_STATE|<collector_name>
+programmed    = "true" / "false"
+resolved_dst_mac, resolved_src_mac, resolved_src_ip, egress_port
+last_error    = string
+last_updated  = timestamp
 ```
 
-#### `STATE_DB:SFLOW_COLLECTOR_STATE` (new)
+Configuration without `mode` behaves as `cpu-path`, so nothing is migrated and
+an upgrade does not change an existing deployment's datapath.
+`SFLOW_COLLECTOR_STATE` exists only while the hardware path is active.
 
-Per-collector resolution detail. Populated by `SflowOrch::HwSflow` only
-when `SFLOW_STATE.ACTIVE_PATH = hw`; absent in CPU mode.
+### 10. Warmboot and Fastboot Design Impact
 
-```
-key             = SFLOW_COLLECTOR_STATE|<collector_name>
-TAM_SESSION_OID = OID                         ; SAI OID of the sFlow session
-                                              ; (today: SAI_OBJECT_TYPE_MIRROR_SESSION; future: TAM-namespace successor)
-                                              ; empty when PROGRAMMED=false
-PROGRAMMED      = "true" / "false"            ; false when the collector exceeds the
-                                              ; hardware concurrent-session limit (see §12 item 12)
-RESOLVED_DST_MAC  = MACaddress
-RESOLVED_SRC_IP   = IPaddress
-RESOLVED_SRC_MAC  = MACaddress
-EGRESS_PORT       = ifname
-LAST_ERROR      = string                      ; empty if healthy; e.g. "hw_session_limit_exceeded"
-LAST_UPDATED    = timestamp
-```
+HW sFlow packet sampling should not be affected after a warm reboot.
 
-#### DB Migration
+### 11. Memory Consumption
 
-All new fields are additive with documented defaults. Existing config
-without `mode` is treated as `auto` (the YANG default); `db_migrator.py`
-adds no field. Platforms that do not advertise the new capability bits
-remain on the CPU path with no behavioral change. **Deliberate upgrade
-behavior:** a capable platform with pre-existing sFlow config moves
-from the CPU path to the HW path on first boot of an image with this
-feature — the operator-visible sample stream is equivalent, but the
-datapath changes (flow samples no longer transit the CPU path, §7.8;
-sequence numbers reset). An operator who wants the old datapath
-pins `mode=cpu-path` before upgrading.
+One TAM object graph of six objects per (collector, sample rate) pair, plus
+port-to-graph bookkeeping in `SflowOrch` and one STATE_DB row per collector.
+Nothing is allocated while `mode` is `cpu-path`.
 
-### 9.4 End-to-end CONFIG_DB walkthrough
+### 12. Restrictions/Limitations
 
-Walkthrough of the path from operator CLI to silicon for a single
-collector `ts1` at `198.51.100.5` with sample rate 1-in-2048.
+1. An encapsulation or sample-rate change recreates the TAM objects, costing a
+   brief sampling gap and a sequence-number reset, so collectors must tolerate
+   resets. Bursts coalesce into one reprogram.
+2. Concurrent collectors are bounded by platform TAM resources; those beyond
+   the limit are flagged in `SFLOW_COLLECTOR_STATE` while the rest keep running.
+3. PortChannel support binds each member port, since SAI has no LAG attribute
+   for TAM objects (section 14).
+4. Ports configured `sample_direction tx` or `both` are not programmed on the
+   hardware path and are logged at WARN.
 
-1. **Operator** (no datapath configuration — `mode` stays at its
-   default `auto`):
-   ```
-   config sflow enable
-   config sflow collector add ts1 198.51.100.5
-   config sflow interface enable Ethernet0
-   ```
-2. **CONFIG_DB writes:**
-   ```
-   SFLOW|global:        admin_state=up, agent_id=Loopback0,
-                        sample_direction=rx
-   SFLOW_COLLECTOR|ts1: collector_ip=198.51.100.5, collector_port=6343
-   SFLOW_SESSION|Ethernet0: admin_state=up, sample_rate=2048
-   ```
-3. **SflowOrch read + resolve:** `SflowOrch` reads
-   `STATE_DB:SWITCH_CAPABILITY:INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE=true`;
-`mode=auto` + capable → effective path = HW. `HwSflow` resolves
-`198.51.100.5` against `NeighOrch` / `RouteOrch` → `dst_mac`, `src_mac`,
-`egress_port`; encap `src_ip` is pinned to `agent_id` (Loopback0)'s IP.
-4. **SAI calls (from SflowOrch):** `create_tam_transport(SRC/DST_MAC,
-   SRC/DST_PORT)` → `create_tam_collector(SRC/DST_IP, TRANSPORT, DSCP)`
-→ `create_mirror_session(TYPE=SFLOW, SAMPLE_RATE=2048, TRUNCATE_SIZE,
-SRC/DST_IP, SRC/DST_MAC, UDP_*)` → returns `session_oid`.
-5. **Port binding:** `set_port_attribute(Ethernet0,
-   INGRESS_SAMPLE_MIRROR_SESSION, [session_oid])` for each enabled port
-(honoring `sample_direction`).
-6. **STATE_DB writes:** `SFLOW_STATE|global active_path=hw`,
-   `SFLOW_COLLECTOR_STATE|ts1` populated with resolved encap and OID.
+### 13. Testing Requirements/Design
 
-## 10\. Warmboot and Fastboot Design Impact
+#### 13.1 Unit test cases
 
-Warmboot preserves the HW sFlow silicon state (sampling session, encap,
-sample-rate divisor) on capable platforms; the orchagent reconciles
-in-memory state against the ASIC without tearing sessions down when
-CONFIG_DB attributes match. Fastboot tears sampling down on shutdown and
-resumes once collector encap is resolved and ports are operationally up
-— typically bounded by ARP/ND resolution to the configured collector(s).
-No new boot-critical-path stalls are introduced. Vendor-specific
-behavior on session recreate (e.g., sequence-number reset) is documented
-in §7.12.
-
-## 11\. Memory Consumption
-
-- When the feature is **disabled at compile time**: zero impact.
-- When the system **resolves to the CPU path** (`auto` on an incapable
-platform, or forced `mode=cpu-path`): zero additional resident memory
-in the orchagent.
-- When the feature is **active**: per-collector memory in CONFIG_DB
-scales linearly with the configured collector count (§5 requirement 3
-caps this at 4, further bounded by the hardware-advertised maximum
-concurrent HW sFlow sessions). One `TAM_COLLECTOR` and one
-(refcount-shared) `TAM_TRANSPORT` per active HW collector, plus the per-session SAI sFlow object — roughly
-equivalent in cost to one additional MOD session per collector.
-`SflowOrch` adds bookkeeping for port→collector bindings and STATE_DB
-entries (bounded by port count × collector count).
-
-## 12\. Restrictions / Limitations
-
-| # | Limitation | Detail |
-| :---- | :---- | :---- |
-| 1 | LAG (PortChannel) support is Phase I; the session-programming model (per-member sessions vs. one LAG-bound session) is vendor-specific and unresolved. | §5 req 9, §14 items 5, 11 |
-| 2 | HW path emits flow samples only; counter samples and MOD stay on the `hsflowd` CPU path. | |
-| 3 | HW-path `sample_direction=tx`/`both` requires the platform to advertise `EGRESS_SAMPLE_MIRROR_SESSION_CAPABLE`. The path is system-wide, not per-port: under `auto`, *any* tx/both port on a platform lacking the egress bit resolves the whole system to CPU (`path_reason=egress_sample_not_capable`) — one egress-sampling port keeps every port off HW. Under forced `hw-accelerated` the same config fails instead (`active_path=failed`, admin-down, WARN). Ingress-only configs run on HW normally. | §7.3, §7.5 |
-| 4 | HW has one silicon field for both encap source IP and the v5 Agent Address, so it can't reproduce a CPU-path config that decoupled `agent_id` from transport source; both are pinned to `agent_id`'s IP. Usually both `Loopback0`, so invisible. | §7.5 |
-| 5 | ERSPAN and HW sFlow coexist on a port — distinct SAI port attributes (`INGRESS_MIRROR_SESSION` vs `INGRESS_SAMPLE_MIRROR_SESSION`), no exclusivity. MirrorOrch unmodified. | |
-| 6 | Sample-rate or encap change = tear-down + recreate: sampling outage (vendor-specific, typically ms to tens of ms) plus a per-collector sequence-number reset. Collectors must tolerate resets. | §7.5, §14 |
-| 7 | Encap is refreshed on next-hop / source-IP change; rapidly flapping reachability causes repeated gaps and sequence resets. | |
-| 8 | Linux packet-capture WILL NOT see HW-emitted datagrams — debug via collector-side SPAN or vendor tools. Egress-port TX counters *do* count them, so "missing samples" is not a TX-counter symptom. | §7.8 |
-| 9 | `hsflowd` keeps running for counter/MOD; the `psample` flow stream is naturally idle (no port binds `INGRESS_SAMPLEPACKET_ENABLE`). No config change needed. | |
-| 10 | `sub_agent_id` disambiguation between silicon- and hsflowd-emitted streams is unresolved (`mod_sonic.c` exposes no `sub_agent_id`); collectors keying on `(agent_address, sub_agent_id)` may see two streams with the same sub-agent. | §14 item 2 |
-| 11 | `/etc/hsflowd.conf` MUST NOT be edited manually; SONiC owns it. | |
-| 12 | Collector over-subscription is partial, not fatal: first N (by name) programmed, the rest flagged `hw_session_limit_exceeded`; system stays `active_path=hw`. | §7.5 |
-
-## 13\. Testing Requirements / Design
-
-### 13.1 Unit test cases
-
-| \# | Test |
+| # | Test |
 | :---- | :---- |
-| 1 | Capability bits `INGRESS_SAMPLE_MIRROR_SESSION_CAPABLE` and `EGRESS_SAMPLE_MIRROR_SESSION_CAPABLE` correctly populated from SAI |
-| 2 | Under default `mode=auto`, `SflowOrch` selects HW path on capable platform, CPU path otherwise (with `path_reason` recording why); `auto` never yields `active_path=failed` |
-| 3 | `SflowOrch` honors forced `mode=cpu-path` and uses CPU path even when capable |
-| 4 | `SflowOrch` honors forced `mode=hw-accelerated` and reports failure on incapable platform |
-| 5 | `SflowOrch::HwSflow` resolves the HW sFlow session from `SFLOW` / `SFLOW_COLLECTOR` + `mode` and produces the correct SAI attribute list (`TAM_TRANSPORT`, `TAM_COLLECTOR`, and the sFlow session object) |
-| 6 | `HwSflow`'s resolver re-resolves on `NEIGH_TABLE` change; observer callbacks fire and the session refreshes |
-| 7 | `SflowOrch` binds OID via `INGRESS_SAMPLE_MIRROR_SESSION` / `EGRESS_SAMPLE_MIRROR_SESSION` after the session becomes active |
-| 8 | `SflowOrch` skips `create_samplepacket()` for ports on the HW path |
-| 9 | Encap `src_ip` is pinned to `agent_id`'s resolved IP for every collector regardless of the per-collector route; the resolver derives only `dst_mac`/`src_mac`/`egress_port` from routing, and no `agent_id`/source-IP failure path is taken |
-| 10 | Config without `mode` treated as `auto` (YANG default); no migrator rewrite |
-| 11 | `STATE_DB:SFLOW_STATE` exposes a single system-wide `active_path`; `SFLOW_COLLECTOR_STATE` populated only in HW mode |
-| 12 | Any `mode` change that flips the resolved path (incl. `auto` ↔ forced values) tears down the old path's SAI state before standing up the new path's state; no overlap of `INGRESS_SAMPLE_MIRROR_SESSION` and `INGRESS_SAMPLEPACKET_ENABLE` is ever observed on any port |
-| 13 | `show sflow` output reflects new fields |
-| 14 | YANG validation accepts new `sonic-sflow.yang` fields and rejects malformed values |
-| 15 | With a port configured `sample_direction=tx`/`both` on a platform lacking `EGRESS_SAMPLE_MIRROR_SESSION_CAPABLE`: under `mode=auto` the system resolves to CPU with `path_reason=egress_sample_not_capable`; under forced `mode=hw-accelerated` it fails (`SFLOW_STATE.active_path=failed`, same reason); an ingress-only config on the same platform resolves to HW in both modes |
-| 16 | Collector over-subscription: with collectors > hardware max, the first N (by name order) get `PROGRAMMED=true` with a `TAM_SESSION_OID`; the rest get `PROGRAMMED=false, LAST_ERROR=hw_session_limit_exceeded`; `active_path` stays `hw`; ordering is stable across reconcile |
-| 17 | LAG: `SFLOW_SESSION` on a PortChannel programs HW sFlow per the chosen model (§14 item 5); member add/remove updates the session binding accordingly |
+| 1 | `TAM_SFLOW_CAPABLE` is published from the SAI capability query |
+| 2 | Default `mode=cpu-path` uses the CPU path and creates no TAM objects |
+| 3 | `mode=hw-accelerated` on a capable platform creates the six-object graph with expected attributes and binds it to enabled ports |
+| 4 | `mode=hw-accelerated` on an incapable platform is rejected: `mode` stays `cpu-path` and the reason is logged |
+| 5 | A neighbor or route change re-resolves and reprograms the collector; a burst collapses into one reprogram |
+| 6 | Two ports at the same sample rate share one graph; different rates get distinct graphs |
+| 7 | Bindings are removed on session delete; a mode change tears down one path before standing up the other |
 
-### 13.2 System test cases
+#### 13.2 System test cases
 
-| \# | Test |
-| :---- | :---- |
-| 1 | End-to-end: configure sFlow with no `mode` set on a capable platform; system auto-selects the HW path and the collector receives sFlow v5 datagrams |
-| 2 | Sequence numbers are monotonic within a steady-state HW-emitted stream (resets only on attribute updates) |
-| 3 | Sample rate matches configured 1-in-N within ±5% over a 60-second 100 Gbps sustained line-rate ingress test |
-| 4 | Egress sampling (`sample_direction=tx`) on HW path produces wire-format sFlow v5 datagrams; rate matches configured 1-in-N |
-| 5 | Counter samples and MOD continue to arrive via the CPU stream |
-| 6 | Agent Address field in HW-emitted datagrams equals resolved IP of `SFLOW|global:agent_id` interface |
-| 7 | Next-hop change (induced via static route flap) triggers tear-down + recreate; sampling resumes; sequence-number reset observed (honesty test); measured outage logged for regression tracking |
-| 8 | Source-IP change (loopback edit) triggers encap refresh |
-| 9 | ERSPAN coexistence: configure a `MIRROR_SESSION_TYPE_ENHANCED_REMOTE` (MirrorOrch) and HW sFlow on the same port; both work simultaneously; removing one does not disturb the other |
-| 10 | Fast warmboot preserves sampling on unchanged sessions; sequence number preserved for unchanged sessions |
-| 11 | Fastboot resumes sampling after collector reachability is restored |
-| 12 | Sample-rate change applied while sampling is active; brief outage observed; sequence-number reset observed; stream resumes |
-| 13 | On an incapable platform: default `mode=auto` resolves to CPU (sampling works, `path_reason=platform_not_capable`); forced `mode=hw-accelerated` surfaces `SFLOW_STATE.active_path=failed`, same reason, sFlow admin-down system-wide |
-| 14 | Stress: ~580K samples/sec from a single 800G ingress port at line rate with 1-in-2048 sampling, no CPU saturation (motivation validation per §4) |
-| 15 | Collector over-subscription end-to-end: configure more collectors than the hardware maximum; the programmed collectors receive sFlow v5 datagrams while the over-limit collectors receive none and are flagged in `SFLOW_COLLECTOR_STATE`; the system as a whole stays up |
-| 16 | LAG end-to-end: HW sFlow on a PortChannel samples ingress and egress traffic across all members at the configured 1-in-N; sampling survives member add/remove and link flap |
+`test_sflow.py` already exists in sonic-mgmt and we will modify that test-case to
+also evaluate HW sFlow on supported platforms.
 
-## 14\. Open / Action items
+We will evaluate:
+- End to end: with `mode=hw-accelerated`, a collector receives and decodes sFlow v5 datagrams
+- IPv4/6 collectors function properly
+- Nexthop-flap reprograms the encapsulation and sampling resumes
+- PortChannel ingress is sampled across LAG members
+- Counter samples arrive while hardware path is active
+- Warmboot continues sampling on unchanged
 
-1. **Resolver consolidation across orchagents.** `MirrorOrch` and now
-   `SflowOrch::HwSflow` each carry their own `NeighOrch` / `RouteOrch`
-resolver for next-hop / encap fields. A follow-up should extract this
-resolver into a shared helper that both orchagents call. Worth
-discussing with the `MirrorOrch` maintainers.
-2. **`sub_agent_id` configurability in `hsflowd`.** The SONiC `hsflowd`
-   integration
-([`mod_sonic.c:50-65`](https://github.com/sflow/host-sflow/blob/master/src/Linux/mod_sonic.c))
-exposes `agent_id` but **not** `sub_agent_id`. To let collectors
-disambiguate the silicon-emitted flow-sample stream from the
-hsflowd-emitted counter/MOD stream, either: (a) add `sub_agent_id` to
-the SONiC hsflowd config and the CONFIG_DB schema; or (b) define a
-different disambiguation mechanism. Needs vendor input on whether the
-silicon's emitted `sub_agent_id` is configurable on a per-sFlow-session
-basis.
-3. **UDP source port stability.** See item 10 below.
-4. **Capability granularity.** SAI's
-   `sai_query_attribute_capability(SAI_OBJECT_TYPE_PORT, ...)` is
-per-port by signature, but this HLD consumes a single switch-wide
-capability bit (uniform support is expected). The implementation should
-treat capability as switch-wide: any per-port disagreement on a capable
-platform is a vendor bug. Worth raising with vendors that expose
-per-port-variable capability.
-5. **LAG support.** Multiple member ports → multiple HW sFlow sessions
-   vs. one LAG-bound session, vendor-specific. Must be resolved for
-Phase I (§5 requirement 9). (The resolver inherits a "first member only"
-pattern for LAG egress today — see item 11.)
-6. **Per-session HW emit counter.** SAI does not standardize a
-   `samples_generated` counter on either the existing `MIRROR_SESSION`
-surface or the TAM family. Raise in SAI community; out of scope here.
-7. **SAI namespace alignment.** Monitor SAI TAM WG direction; the
-   in-silicon sFlow primitive's long-term namespace is unsettled (detail
-in §7.12 "SAI surface caveat"). If a future migration of
-`MIRROR_SESSION_TYPE_SFLOW` lands, re-validate the §7.12 vendor contract.
-8. **`set_*_attribute()` fast path for hw-sflow.** `HwSflow` plans a
-   tear-down + recreate lifecycle on next-hop / encap / sample-rate
-change. A future enhancement should add an in-place fast path where the
-silicon supports it, avoiding the per-change recreate cost (§7.9, §12
-item 6). Scope is platform-dependent — on current silicon the in-place
-path covers only `sample_rate`; encap fields need a vendor-side change
-(detail in §7.5, §7.12).
-9. **Egress port programming.** Confirm with each vendor whether HW sFlow
-    needs explicit egress-port pinning (resolver doesn't pass it today —
-§7.5, §7.12 item 5). If yes: add the egress-port SAI attribute
-(vendor-specific) to `HwSflow`'s SAI calls.
-10. **L4 source port stability.** Phase I accepts random-ephemeral per
-    session. Stable-port (collector-side 5-tuple stability) is a
-follow-up enhancement.
-11. **LAG distribution.** The resolver's "first member only" pattern for
-    LAG egress is incompatible with the Phase I portchannel goal (§5
-requirement 9).
-Phase I must either teach the resolver to distribute across members,
-or constrain HW sFlow to single-link egress.
-12. **Orchagent-maintainer alignment.** Confirm direction with the
-    `SflowOrch` maintainers and the sonic-swss#3970 author (Edge-core),
-since `HwSflow` lives alongside `SflowDropMonitor` as a sibling class
-under `SflowOrch`.
-13. **Community alignment.** Schedule a SONiC sFlow / Datapath / TAM WG
-    discussion before merge. Identify silicon vendors interested in
-implementing the SAI side beyond the initial integrator.
-14. **Single-platform validation risk.** Initial development and
-    validation is on a single platform family. The
-vendor-contract section (§7.12) documents the SAI contract precisely so
-second-platform integration surfaces gaps in the abstraction rather
-than gaps in the implementation.
+### 14. Open/Action items - if any
+
+- SAI has no LAG bind point or LAG destination attribute for TAM objects, so
+  PortChannel support binds each member port (section 12). A SAI enhancement
+  request to add one is worth raising.

--- a/doc/sflow/hw_sflow_hld.md
+++ b/doc/sflow/hw_sflow_hld.md
@@ -10,9 +10,9 @@
 - [6. Architecture Design](#6-architecture-design)
 - [7. High-Level Design](#7-high-level-design)
   - [7.1 SAI object flow](#71-sai-object-flow)
-  - [7.2 Datagram delivery through the recirc port](#72-datagram-delivery-through-the-recirc-port)
-  - [7.3 PortChannel handling and member churn](#73-portchannel-handling-and-member-churn)
-  - [7.4 Future extension: non-recirc-port platforms](#74-future-extension-non-recirc-port-platforms)
+  - [7.2 Recycle port as Monitor Port](#72-recycle-port-as-monitor-port)
+  - [7.3 Future extension: non-recycle-port platforms](#73-future-extension-non-recycle-port-platforms)
+  - [7.4 PortChannel handling and member churn](#74-portchannel-handling-and-member-churn)
   - [7.5 Serviceability and debug](#75-serviceability-and-debug)
 - [8. SAI API](#8-sai-api)
 - [9. Configuration and management](#9-configuration-and-management)
@@ -42,7 +42,7 @@ punting every sampled packet to the CPU.
 
 Hardware acceleration applies to **flow samples only**. The existing CPU path
 remains responsible for interface counter samples and the other CPU-based
-sFlow functions that hsflowd provides, regardless of the selected mode.
+sFlow functions that hsflowd provides, regardless of if hardware acceleration is enabled.
 
 ### 3. Definitions/Abbreviations
 
@@ -64,40 +64,46 @@ samples, aggregates, and emits sFlow v5 datagrams without CPU involvement.
 
 ### 5. Requirements
 
-Supported:
-
-- Opt-in through a new `mode` field via CLI, reflected in `CONFIG_DB:SFLOW|global`.
-- Gated on platform capability, published in `STATE_DB:SWITCH_CAPABILITY`.
+- Backwards compatibility with existing SONiC sFlow design.
+- Design should be operational with both fixed and chassis VOQ systems.
 - Ingress sampling on physical ports and PortChannels.
-- A single IPv4 or IPv6 collector in the default VRF, reachable through the
+- IPv4 or IPv6 collector in the default VRF, reachable through the
   ASIC FIB.
-- Per-port sample rate and header truncation size.
-- Selected mode and operational status visible in `show sflow`.
+- Per-port sample rate.
+- Enhancements to `show sflow` command to indicate operational status.
 - All new configuration is modeled in YANG and manageable through GCU.
 
-Required by the design:
+Out of scope:
 
-- An L3-enabled recirc port. The hardware path emits datagrams through it;
-  a platform without one cannot enable `hw-accelerated` mode.
-
-Not supported:
-
-- Egress sampling (`tx`, `both`).
-- Hardware counter samples (still egress via CPU path).
-- More than one collector while `mode` is `hw-accelerated`.
-- A collector in the `mgmt` VRF while `mode` is `hw-accelerated`.
+- Egress sampling is not supported.
+- Hardware acceleration does not apply to counter samples (still egress via CPU path).
+- A collector in the `mgmt` VRF while `mode` is `hw-accelerated` is not supported.
 
 ### 6. Architecture Design
 
-`HwSflow` is a new implementation branch within `SflowOrch`: it owns the
-sFlow mirror session and the per-port sample bindings for the hardware
-datapath. It does not introduce a new daemon and does not replace the
-existing CPU path, which remains the default. Counter samples stay on the
-CPU path regardless of the `mode` configuration.
+We introduce a `mode` attribute in the global sFlow configuration that can be set to `hw-accelerated`.
+When `hw-accelerated` is set and the platform is capable, orchagent will configure the ASIC
+to sample incoming packets on enabled ports, aggregate and encapsulate them as sFlow datagrams and forward 
+them to the collector directly from the hardware, without CPU involvement.
+
+In this design, the sampled packets are sent to the recycle port before being routed to the
+collector in the second pass. For more details, see section 7.2.
 
 ### 7. High-Level Design
 
+`HwSflow` is a new class within `SflowOrch`: it owns the
+sFlow mirror session and the per-port sample bindings for the hardware
+datapath. It does not introduce a new daemon and does not replace the
+existing CPU path, which remains the default. Counter samples stay on the
+CPU path regardless of if `hw-accelerated` is enabled or disabled.
+
 #### 7.1 SAI object flow
+
+Platform capability is detected with
+`sai_query_attribute_enum_values_capability()` on
+`SAI_MIRROR_SESSION_ATTR_TYPE`: the platform is capable when the returned
+list contains `SAI_MIRROR_SESSION_TYPE_SFLOW`. The result is published to
+`STATE_DB:SWITCH_CAPABILITY|switch` as `HW_SFLOW_CAPABLE`.
 
 `HwSflow` creates one mirror session of type sFlow for the configured
 collector and binds it to every sampled port.
@@ -108,29 +114,29 @@ flowchart TB
     ORCH["HwSflow (SflowOrch, sonic-swss)"] ==>|creates| MS
     subgraph MS["MIRROR_SESSION — TYPE = sFlow"]
         direction LR
-        SMP["<b>Sampling</b><br/>rate = 1-in-N<br/>truncate size"]
+        SMP["<b>Sampling</b><br/>rate = 1-in-N"]
         ENC["<b>Encapsulation</b><br/>src/dst IP<br/>src/dst MAC<br/>UDP src/dst port"]
-        DLV["<b>Delivery</b><br/>recirc port<br/>(MONITOR_PORT)"]
+        DLV["<b>Delivery</b><br/>recycle port<br/>(MONITOR_PORT)"]
     end
     ORCH ==>|"binds session"| PORT["Sampled port<br/>SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION"]
-    PORT ==> RECIRC["Recirc port:<br/>second pipeline pass"]
-    RECIRC ==> FIB(["FIB routes the sFlow v5 UDP<br/>datagram to the collector"])
+    PORT ==> recycle["recycle port:<br/>second pipeline pass"]
+    recycle ==> FIB(["FIB routes the sFlow v5 UDP<br/>datagram to the collector"])
 ```
 
 Creation order:
 
 1. `create_mirror_session()`: `TYPE = SAI_MIRROR_SESSION_TYPE_SFLOW`, the
-   recirc port as `MONITOR_PORT`, source and destination IP, source and
+   recycle port as `MONITOR_PORT`, source and destination IP, source and
    destination MAC, UDP source and destination port (6343 by default, from
-   `SFLOW_COLLECTOR`), the configured 1-in-N `SAMPLE_RATE` and
-   `TRUNCATE_SIZE`.
+   `SFLOW_COLLECTOR`), the configured 1-in-N `SAMPLE_RATE`, and
+   `TRUNCATE_SIZE` set to the default 128 byte value.
 2. `set_port_attribute(port, SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION,
    [session])` for every port whose `SFLOW_SESSION` row is enabled. Passing an
    empty list unbinds the port.
 
 SAI puts the sample rate on the session, but SONiC configures it per port:
 ports with the same rate share one session; a port with a different rate needs
-its own session.
+its own session. HwSflow will create new sessions as needed.
 
 Every encapsulation attribute is static:
 
@@ -143,35 +149,43 @@ Every encapsulation attribute is static:
 - UDP destination port: from `SFLOW_COLLECTOR` (6343 by default); UDP source
   port likewise.
 
-#### 7.2 Datagram delivery through the recirc port
+#### 7.2 Recycle port as Monitor Port
 
-The design delivers datagrams exclusively through the recirc port; a
-front-panel `MONITOR_PORT` is not supported. The recirc port is therefore a
-platform requirement for the hardware path, the same approach the
-[Everflow for VOQ chassis HLD](https://github.com/sonic-net/SONiC/blob/master/doc/voq/everflow.md)
-takes for mirrored packets.
-
-Trade-offs of delivering through the recirc port:
+In this design, the sampled packets are sent to the recycle port. An alternative design
+would be to send samples directly to the monitor port. Here we discuss some of the tradeoffs
+of the recycle port approach.
 
 Positives:
 
 - Route and neighbor changes toward the collector are followed automatically
-  by the FIB, with no orchagent involvement.
-- ECMP toward the collector is load-balanced by the FIB.
-- Encapsulation is static and programmed once.
-- Orchagent stays simple: no resolution state machine, fewer failure states.
+  by the FIB, with no orchagent involvement. With a single pass approach, orchagent
+  would need to determine the egress port to reach the collector continuously and
+  reprogram the hardware when this changes. This can cause significant CPU usage under route churn.
+- ECMP and LAG toward the collector is load-balanced by the FIB.
+- HwSflow stays simple: no RouteOrch/NeighOrch dependency, fewer failure states.
+- Same sFlow implementation for fixed and chassis VOQ systems.
+- Consistent with Everflow design (per [Everflow for VOQ chassis HLD](https://github.com/sonic-net/SONiC/blob/master/doc/voq/everflow.md))
 
 Negatives:
 
-- Every datagram takes a second pipeline pass, consuming internal bandwidth
+- Every sFlow datagram takes a second pipeline pass, consuming internal bandwidth
   and adding latency.
-- An L3-enabled recirc port must exist on the platform.
+  - On our initial target platform, we estimate that a sample rate of 1/64K on all ports will consume only ~400 Mbps of bandwidth.
+- An L3-enabled recycle port must exist on the platform.
+  - On our initial target platform, this port already exists to support Everflow.
+- Collector must only be in `default` VRF.
 
-The collector must be in the default VRF, since the ASIC FIB routes the
-datagram. A `vrf mgmt` collector is not programmed: it is logged at WARN and
-reported non-operational (`collector_vrf_unsupported`).
+#### 7.3 Future extension: non-recycle-port platforms
 
-#### 7.3 PortChannel handling and member churn
+Platforms without a recycle port could be supported by a future extension:
+program `MONITOR_PORT` to the front-panel port facing the collector. `HwSflow`
+would resolve the collector address against `NeighOrch` and `RouteOrch` to
+obtain the egress port, next-hop MAC, and source MAC, program them into the
+session, and re-resolve on every route or neighbor change with
+`set_mirror_session_attribute()`. This choice could be made based on the presence
+or absence of the recycle port.
+
+#### 7.4 PortChannel handling and member churn
 
 `SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` has no LAG-level equivalent, so
 `HwSflow` performs member expansion: sFlow is still configured at PortChannel
@@ -179,30 +193,14 @@ granularity, and the session is bound to every member port. `HwSflow`
 subscribes to LAG membership updates and rebinds on churn: a joining member
 is bound to the session, a leaving member is unbound.
 
-#### 7.4 Future extension: non-recirc-port platforms
-
-Platforms without a recirc port could be supported by a future extension:
-point `MONITOR_PORT` at the front-panel port facing the collector. `HwSflow`
-would resolve the collector address against `NeighOrch` and `RouteOrch` to
-obtain the egress port, next-hop MAC, and source MAC, program them into the
-session, and re-resolve on every route or neighbor change with
-`set_mirror_session_attribute()`. This avoids the second pipeline pass, but
-imports a resolution state machine into `SflowOrch`, adds a collector-pending
-state during convergence, and pins delivery to a single next hop. It is out
-of scope for this design but composes with it cleanly if demand appears.
-
 #### 7.5 Serviceability and debug
 
 - `STATE_DB:SFLOW_STATE|global` reports whether the hardware path is
   operational: `mode=hw-accelerated`, a capable platform, and a default-VRF
-  collector. Non-operational states record the reason. Delivery itself needs
-  no tracked state; the FIB handles it.
+  collector. Delivery itself needs no tracked state since the FIB handles it.
 - `show sflow` reports the selected mode and operational status. Syslog
   records mode transitions at INFO, and a rejected mode selection at WARN.
-- An unreachable collector is not reported: datagrams drop on the second
-  pass while the path reads operational. Diagnose by verifying the route and
-  neighbor toward the collector and comparing recirc-port TX counters against
-  routing drop counters (`show dropcounters`).
+- For an unresolved collector, sFlow datagrams will be dropped in the second pass.
 
 ### 8. SAI API
 
@@ -212,13 +210,15 @@ SAI today: `SAI_MIRROR_SESSION_TYPE_SFLOW` and the sFlow-conditional
 [`inc/saimirror.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saimirror.h),
 and the per-port binding attribute
 `SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` in
-[`inc/saiport.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saiport.h).
+[`inc/saiport.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saiport.h). 
 
 Platform capability is detected with
 `sai_query_attribute_enum_values_capability()` on
 `SAI_MIRROR_SESSION_ATTR_TYPE`: the platform is capable when the returned
 list contains `SAI_MIRROR_SESSION_TYPE_SFLOW`. The result is published to
 `STATE_DB:SWITCH_CAPABILITY|switch` as `HW_SFLOW_CAPABLE`.
+
+For context, the SAI attribute for configuring sFlow today is via the SAI_SAMPLEPACKET API.
 
 ### 9. Configuration and management
 
@@ -231,14 +231,15 @@ Not applicable. This is a built-in feature, not an Application Extension.
 One new command selects the datapath; every existing sFlow command is unchanged.
 
 ```text
-config sflow mode <cpu-path|hw-accelerated>
+config sflow hw-accelerated <enable|disable>
 ```
 
-The knob defaults to `cpu-path`: when `mode` is absent from the
-configuration, sFlow behaves exactly as it does today.
+When `hw-accelerated` is enabled, the `mode` attribute of the global sFlow configuration will
+be set to `hw-accelerated`. On disable, the attribute will be deleted. When this
+attribute is not present, the default CPU path will be used for sFlow.
 
-Switching the mode tears down the active datapath before standing up the
-other: leaving `hw-accelerated` unbinds every sampled port and removes the
+Enabling or disabling tears down the active datapath before enabling the other: 
+leaving `hw-accelerated` unbinds every sampled port and removes the
 mirror session, then flow sampling reverts to the CPU path. Whether sampling
 actually resumes there depends on the platform's support for CPU-based sFlow;
 on hardware without it, flow samples stop until `hw-accelerated` is
@@ -268,24 +269,53 @@ collector):
   sFlow Sampling Status:      non-operational
 ```
 
-The reason is recorded in syslog (WARN) and in `STATE_DB:SFLOW_STATE|global`.
+The reason is recorded in syslog.
 
 `sonic-sflow.yang`:
 
 ```yang
 leaf mode {
     type enumeration {
-        enum cpu-path;
         enum hw-accelerated;
     }
-    default "cpu-path";
-    description "Where sFlow datagrams are built. 'cpu-path' builds them
-                 in hsflowd in userspace; 'hw-accelerated' builds them
-                 in the ASIC.";
+    description "hw-accelerated builds sFlow datagrams in the ASIC.";
 }
 ```
 
 #### 9.3 Config DB enhancements
+
+Example sFlow configuration in CONFIG_DB:
+
+```json
+{
+  "SFLOW": {
+    "global": {
+      "admin_state": "up",
+      "agent_id": "Ethernet384",
+      "polling_interval": "20"
+    }
+  },
+
+  "SFLOW_COLLECTOR": {
+    "Collector_1": {
+      "collector_ip": "10.20.16.19",
+      "collector_port": "6343",
+      "collector_vrf": "default"
+    }
+  },
+
+  "SFLOW_SESSION": {
+    "Ethernet0": {
+      "admin_state": "up",
+      "sample_direction": "rx",
+      "sample_rate": "4096"
+    },
+    "all": {
+      "admin_state": "down"
+    }
+  }
+}
+```
 
 `CONFIG_DB:SFLOW` gains `mode`:
 
@@ -314,20 +344,17 @@ One new STATE_DB table, written by `SflowOrch`:
 ```text
 key          = SFLOW_STATE|global
 operational  = "true" / "false"
-reason       = "platform_not_capable" / "collector_vrf_unsupported"
-               (empty when operational)
 ```
 
-Configuration without `mode` behaves as `cpu-path`, so nothing is migrated and
-an upgrade does not change an existing deployment's datapath. `SFLOW_STATE`
-exists only while `mode` is `hw-accelerated`.
+Configuration without `mode` uses CPU path sFlow, so an upgrade does not
+change an existing deployment's datapath.
 
 #### 9.4 Generic Config Updater
 
 The `mode` leaf is YANG-modeled, so GCU needs no feature-specific code: a
 JSON patch that adds, changes, or removes `SFLOW|global:mode` validates
 against `sonic-sflow.yang` and applies at runtime without a config reload.
-Removing the leaf falls back to the default `cpu-path`.
+Removing the leaf falls back to the default CPU path.
 
 ### 10. Warmboot and Fastboot Design Impact
 
@@ -336,8 +363,7 @@ HW sFlow packet sampling should not be affected after a warm reboot.
 ### 11. Memory Consumption
 
 One mirror session per sample rate in use, plus port-to-session bookkeeping in
-`SflowOrch` and one `SFLOW_STATE` row. Nothing is allocated while `mode` is
-`cpu-path`.
+`SflowOrch` and one `SFLOW_STATE` row.
 
 ### 12. Restrictions/Limitations
 
@@ -346,16 +372,13 @@ One mirror session per sample rate in use, plus port-to-session bookkeeping in
    the hardware path because the management port is not in the ASIC datapath:
    a `vrf mgmt` collector is not programmed while `mode=hw-accelerated`, is
    logged at WARN, and the path reports non-operational.
-2. A single collector is supported on the hardware path. If more than one
-   collector is configured while `mode=hw-accelerated`, only the first is
-   programmed and a WARN is logged.
-3. A sample-rate change may pause sampling briefly and reset the datagram
+2. A sample-rate change may pause sampling briefly and reset the datagram
    sequence number, depending on the vendor SAI, so collectors must tolerate
    resets. Bursts coalesce into one reprogram.
-4. PortChannel support binds each member port through LAG expansion,
+3. PortChannel support binds each member port through LAG expansion,
    since `SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` is a
    port attribute with no LAG-level equivalent.
-5. Ports configured `sample_direction tx` or `both` are not programmed on the
+4. Ports configured `sample_direction tx` or `both` are not programmed on the
    hardware path and are logged at WARN.
 
 ### 13. Testing Requirements/Design
@@ -365,14 +388,14 @@ One mirror session per sample rate in use, plus port-to-session bookkeeping in
 | # | Test |
 | :---- | :---- |
 | 1 | `HW_SFLOW_CAPABLE` is published from the SAI enum-capability query |
-| 2 | Default `mode=cpu-path` uses the CPU path and creates no mirror session |
-| 3 | `mode=hw-accelerated` on a capable platform creates the mirror session with the recirc port as `MONITOR_PORT` and binds it to enabled ports |
-| 4 | `mode=hw-accelerated` on an incapable platform: config is retained, flow sampling stops (no CPU fallback), `SFLOW_STATE\|global` reports non-operational with a reason, and a WARN is logged |
+| 2 | Default uses the CPU path and creates no mirror session |
+| 3 | `mode=hw-accelerated` on a capable platform creates the mirror session with the recycle port as `MONITOR_PORT` and binds it to enabled ports |
+| 4 | `mode=hw-accelerated` on an incapable platform: config is retained, flow sampling stops (no CPU fallback), `SFLOW_STATE\|global` reports non-operational, and a WARN is logged |
 | 5 | Two ports at the same sample rate share one session; different rates get distinct sessions |
 | 6 | Enabling sFlow on a PortChannel binds every member; a member join binds the new member and a member leave unbinds it |
 | 7 | Bindings are removed on session delete; a mode change tears down one path before standing up the other |
 | 8 | A GCU patch that sets, changes, or removes `SFLOW\|global:mode` validates against YANG and applies at runtime |
-| 9 | A `vrf mgmt` collector with `mode=hw-accelerated` is not programmed: `SFLOW_STATE\|global` reports non-operational with reason `collector_vrf_unsupported` and a WARN is logged |
+| 9 | A `vrf mgmt` collector with `mode=hw-accelerated` is not programmed: `SFLOW_STATE\|global` reports non-operational |
 
 #### 13.2 System test cases
 
@@ -383,6 +406,8 @@ We will evaluate:
 - End to end: a collector receives and decodes sFlow v5 datagrams
 - IPv4/6 collectors function properly
 - A route change toward the collector: delivery follows the FIB with no session reprogram
+- Unresolved collector route
 - PortChannel ingress is sampled across LAG members, including after a membership change
 - Counter samples arrive while hardware path is active
-- Warmboot continues sampling on unchanged
+- Warmboot continues sampling on unchanged config
+- Multiple collectors enabled

--- a/doc/sflow/hw_sflow_hld.md
+++ b/doc/sflow/hw_sflow_hld.md
@@ -10,26 +10,28 @@
 - [6. Architecture Design](#6-architecture-design)
 - [7. High-Level Design](#7-high-level-design)
   - [7.1 SAI object flow](#71-sai-object-flow)
-  - [7.2 Collector resolution](#72-collector-resolution)
-  - [7.3 Serviceability and debug](#73-serviceability-and-debug)
+  - [7.2 Datagram delivery through the recirc port](#72-datagram-delivery-through-the-recirc-port)
+  - [7.3 PortChannel handling and member churn](#73-portchannel-handling-and-member-churn)
+  - [7.4 Future extension: non-recirc-port platforms](#74-future-extension-non-recirc-port-platforms)
+  - [7.5 Serviceability and debug](#75-serviceability-and-debug)
 - [8. SAI API](#8-sai-api)
 - [9. Configuration and management](#9-configuration-and-management)
   - [9.1 Manifest](#91-manifest)
   - [9.2 CLI and YANG model enhancements](#92-cli-and-yang-model-enhancements)
   - [9.3 Config DB enhancements](#93-config-db-enhancements)
+  - [9.4 Generic Config Updater](#94-generic-config-updater)
 - [10. Warmboot and Fastboot Design Impact](#10-warmboot-and-fastboot-design-impact)
 - [11. Memory Consumption](#11-memory-consumption)
 - [12. Restrictions/Limitations](#12-restrictionslimitations)
 - [13. Testing Requirements/Design](#13-testing-requirementsdesign)
   - [13.1 Unit test cases](#131-unit-test-cases)
   - [13.2 System test cases](#132-system-test-cases)
-- [14. Open/Action items](#14-openaction-items---if-any)
 
 ### 1. Revision
 
 | Revision | Date | Author | Change Description |
 | ----- | ----- | ----- | ----- |
-| 0.1 | 2026-08-15 | darius-nexthop | Initial Proposal |
+| 0.1 | 2026-08-17 | darius-nexthop | Initial Proposal |
 
 ### 2. Scope
 
@@ -38,9 +40,9 @@ accelerated sFlow. On ASICs that support it, the switch builds sFlow v5
 datagrams in silicon and sends them straight to the collector rather than
 punting every sampled packet to the CPU.
 
-Hardware acceleration applies to **flow samples only**. Counter samples, the
-hsflowd agent, and every other part of the sFlow subsystem continue to operate
-unchanged on the CPU path regardless of the selected mode.
+Hardware acceleration applies to **flow samples only**. The existing CPU path
+remains responsible for interface counter samples and the other CPU-based
+sFlow functions that hsflowd provides, regardless of the selected mode.
 
 ### 3. Definitions/Abbreviations
 
@@ -51,6 +53,7 @@ unchanged on the CPU path regardless of the selected mode.
 | CPU sFlow | The existing sample-and-punt datapath described in [`sflow_hld.md`](https://github.com/sonic-net/SONiC/blob/master/doc/sflow/sflow_hld.md) |
 | SAI | Switch Abstraction Interface |
 | hsflowd | [InMon host-sflow](https://github.com/sflow/host-sflow) agent, SONiC's userspace sFlow agent |
+| GCU | Generic Config Updater |
 
 ### 4. Overview
 
@@ -58,10 +61,6 @@ This document proposes an alternative flow-sampling datapath for SONiC:
 hardware accelerated sFlow. When it is selected, `SflowOrch` creates a SAI
 mirror session of type sFlow and binds it to sampled ports; the ASIC then
 samples, aggregates, and emits sFlow v5 datagrams without CPU involvement.
-Because the datagram is built in silicon, its encapsulation must be supplied
-up front, so `SflowOrch` takes a dependency on `NeighOrch` and `RouteOrch` to
-resolve the path to the collector and to refresh it on change. The path is
-gated on platform capability.
 
 ### 5. Requirements
 
@@ -70,97 +69,140 @@ Supported:
 - Opt-in through a new `mode` field via CLI, reflected in `CONFIG_DB:SFLOW|global`.
 - Gated on platform capability, published in `STATE_DB:SWITCH_CAPABILITY`.
 - Ingress sampling on physical ports and PortChannels.
-- IPv4 and IPv6 collectors.
+- A single IPv4 or IPv6 collector in the default VRF, reachable through the
+  ASIC FIB.
 - Per-port sample rate and header truncation size.
-- Encapsulation (destination MAC, source MAC, source IP, egress port) resolved
-  automatically from routing and neighbor state, refreshed on change.
-- Selected mode and per-collector resolution visible in `show sflow`.
+- Selected mode and operational status visible in `show sflow`.
+- All new configuration is modeled in YANG and manageable through GCU.
+
+Required by the design:
+
+- An L3-enabled recirc port. The hardware path emits datagrams through it;
+  a platform without one cannot enable `hw-accelerated` mode.
 
 Not supported:
 
 - Egress sampling (`tx`, `both`).
 - Hardware counter samples (still egress via CPU path).
+- More than one collector while `mode` is `hw-accelerated`.
+- A collector in the `mgmt` VRF while `mode` is `hw-accelerated`.
 
 ### 6. Architecture Design
 
-This design does not change the SONiC architecture. `SflowOrch` gains a
-`HwSflow` class that owns the sFlow mirror session and the per-port sample
-bindings for the hardware datapath. The existing CPU path is untouched and
-remains the default. Other sFlow features, such as counter samples and MOD,
-will remain unimpacted on the CPU path regardless of `mode` configuration.
+`HwSflow` is a new implementation branch within `SflowOrch`: it owns the
+sFlow mirror session and the per-port sample bindings for the hardware
+datapath. It does not introduce a new daemon and does not replace the
+existing CPU path, which remains the default. Counter samples stay on the
+CPU path regardless of the `mode` configuration.
 
 ### 7. High-Level Design
 
 #### 7.1 SAI object flow
 
-For each collector, `HwSflow` creates one mirror session of type sFlow and
-binds it to every sampled port.
-
-Throughout this document, the **collector-facing port** is the port sFlow
-datagrams egress towards the collector on. It is programmed as
-`SAI_MIRROR_SESSION_ATTR_MONITOR_PORT` and is unrelated to egress sampling,
-which the hardware path does not support.
+`HwSflow` creates one mirror session of type sFlow for the configured
+collector and binds it to every sampled port.
 
 ```mermaid
 flowchart TB
     CFG["CONFIG_DB<br/>SFLOW · SFLOW_COLLECTOR · SFLOW_SESSION"] --> ORCH
-    NR["NeighOrch / RouteOrch"] -->|"collector-facing port,<br/>next-hop MAC, src MAC"| ORCH
     ORCH["HwSflow (SflowOrch, sonic-swss)"] ==>|creates| MS
     subgraph MS["MIRROR_SESSION — TYPE = sFlow"]
         direction LR
         SMP["<b>Sampling</b><br/>rate = 1-in-N<br/>truncate size"]
         ENC["<b>Encapsulation</b><br/>src/dst IP<br/>src/dst MAC<br/>UDP src/dst port"]
-        DLV["<b>Delivery</b><br/>collector-facing port<br/>(MONITOR_PORT)"]
+        DLV["<b>Delivery</b><br/>recirc port<br/>(MONITOR_PORT)"]
     end
     ORCH ==>|"binds session"| PORT["Sampled port<br/>SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION"]
-    PORT ==> WIRE(["Silicon emits sFlow v5 UDP<br/>datagrams to the collector"])
+    PORT ==> RECIRC["Recirc port:<br/>second pipeline pass"]
+    RECIRC ==> FIB(["FIB routes the sFlow v5 UDP<br/>datagram to the collector"])
 ```
 
 Creation order:
 
-1. Resolve the collector against `NeighOrch` and `RouteOrch` to
-   obtain the collector-facing port, next-hop MAC and source MAC.
-2. `create_mirror_session()`: `TYPE = SAI_MIRROR_SESSION_TYPE_SFLOW`, the
-   collector-facing port as `MONITOR_PORT`, source and destination IP and MAC,
-   UDP source and destination port (6343 by default, from `SFLOW_COLLECTOR`),
-   the configured 1-in-N `SAMPLE_RATE` and `TRUNCATE_SIZE`.
-3. `set_port_attribute(port, SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION,
+1. `create_mirror_session()`: `TYPE = SAI_MIRROR_SESSION_TYPE_SFLOW`, the
+   recirc port as `MONITOR_PORT`, source and destination IP, source and
+   destination MAC, UDP source and destination port (6343 by default, from
+   `SFLOW_COLLECTOR`), the configured 1-in-N `SAMPLE_RATE` and
+   `TRUNCATE_SIZE`.
+2. `set_port_attribute(port, SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION,
    [session])` for every port whose `SFLOW_SESSION` row is enabled. Passing an
    empty list unbinds the port.
 
-Teardown reverses that order: unbind every port, then remove the session. Two
-consequences for `SflowOrch` bookkeeping:
+SAI puts the sample rate on the session, but SONiC configures it per port:
+ports with the same rate share one session; a port with a different rate needs
+its own session.
 
-- SAI puts the sample rate on the session, but SONiC configures it per port.
-  Ports that share a collector and a rate share one session; a port with a
-  different rate needs its own session.
-- SAI binds sessions to physical ports only. Enabling sFlow on a PortChannel
-  binds every member port, and a membership change rebinds.
+Every encapsulation attribute is static:
 
-Optionally, `MONITOR_PORT` can be set to a recirc port instead of a
-front-panel port. The datagram then takes a second pass through the pipeline
-and the FIB forwards it to the collector, so delivery follows route changes.
+- Destination IP: the collector address.
+- Source IP: the address of the interface named by `SFLOW|global:agent_id`
+  (also the Agent Address carried in every datagram).
+- Source and destination MAC: both the switch MAC, since the second pipeline
+  pass routes the datagram by its destination IP and rewrites the Ethernet
+  header.
+- UDP destination port: from `SFLOW_COLLECTOR` (6343 by default); UDP source
+  port likewise.
 
-#### 7.2 Collector resolution
+#### 7.2 Datagram delivery through the recirc port
 
-`HwSflow` resolves each collector address against `NeighOrch` and `RouteOrch`
-and re-resolves on any route or neighbor change. The result — collector-facing
-port, next-hop MAC, source MAC — is applied to the live session with
-`set_mirror_session_attribute()`; nothing is recreated. The encapsulation
-source IP is the address of the interface named by `SFLOW|global:agent_id`,
-which is also the Agent Address carried in every emitted datagram.
+The design delivers datagrams exclusively through the recirc port; a
+front-panel `MONITOR_PORT` is not supported. The recirc port is therefore a
+platform requirement for the hardware path, the same approach the
+[Everflow for VOQ chassis HLD](https://github.com/sonic-net/SONiC/blob/master/doc/voq/everflow.md)
+takes for mirrored packets.
 
-A sample-rate change is also an attribute set, but a vendor SAI may implement
-it with a brief sampling pause and a datagram sequence-number reset, so
-`HwSflow` coalesces bursts of changes (about 100 ms) into one reprogram.
+Trade-offs of delivering through the recirc port:
 
-#### 7.3 Serviceability and debug
+Positives:
 
-- `STATE_DB:SFLOW_COLLECTOR_STATE|<name>`: resolved encapsulation, last error
-  and last update time.
-- `show sflow` reports the selected mode and the above. Syslog records mode
-  transitions at INFO, and a rejected mode selection or a resolution failure at
-  WARN.
+- Route and neighbor changes toward the collector are followed automatically
+  by the FIB, with no orchagent involvement.
+- ECMP toward the collector is load-balanced by the FIB.
+- Encapsulation is static and programmed once.
+- Orchagent stays simple: no resolution state machine, fewer failure states.
+
+Negatives:
+
+- Every datagram takes a second pipeline pass, consuming internal bandwidth
+  and adding latency.
+- An L3-enabled recirc port must exist on the platform.
+
+The collector must be in the default VRF, since the ASIC FIB routes the
+datagram. A `vrf mgmt` collector is not programmed: it is logged at WARN and
+reported non-operational (`collector_vrf_unsupported`).
+
+#### 7.3 PortChannel handling and member churn
+
+`SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` has no LAG-level equivalent, so
+`HwSflow` performs member expansion: sFlow is still configured at PortChannel
+granularity, and the session is bound to every member port. `HwSflow`
+subscribes to LAG membership updates and rebinds on churn: a joining member
+is bound to the session, a leaving member is unbound.
+
+#### 7.4 Future extension: non-recirc-port platforms
+
+Platforms without a recirc port could be supported by a future extension:
+point `MONITOR_PORT` at the front-panel port facing the collector. `HwSflow`
+would resolve the collector address against `NeighOrch` and `RouteOrch` to
+obtain the egress port, next-hop MAC, and source MAC, program them into the
+session, and re-resolve on every route or neighbor change with
+`set_mirror_session_attribute()`. This avoids the second pipeline pass, but
+imports a resolution state machine into `SflowOrch`, adds a collector-pending
+state during convergence, and pins delivery to a single next hop. It is out
+of scope for this design but composes with it cleanly if demand appears.
+
+#### 7.5 Serviceability and debug
+
+- `STATE_DB:SFLOW_STATE|global` reports whether the hardware path is
+  operational: `mode=hw-accelerated`, a capable platform, and a default-VRF
+  collector. Non-operational states record the reason. Delivery itself needs
+  no tracked state; the FIB handles it.
+- `show sflow` reports the selected mode and operational status. Syslog
+  records mode transitions at INFO, and a rejected mode selection at WARN.
+- An unreachable collector is not reported: datagrams drop on the second
+  pass while the path reads operational. Diagnose by verifying the route and
+  neighbor toward the collector and comparing recirc-port TX counters against
+  routing drop counters (`show dropcounters`).
 
 ### 8. SAI API
 
@@ -171,6 +213,12 @@ SAI today: `SAI_MIRROR_SESSION_TYPE_SFLOW` and the sFlow-conditional
 and the per-port binding attribute
 `SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` in
 [`inc/saiport.h`](https://github.com/opencomputeproject/SAI/blob/master/inc/saiport.h).
+
+Platform capability is detected with
+`sai_query_attribute_enum_values_capability()` on
+`SAI_MIRROR_SESSION_ATTR_TYPE`: the platform is capable when the returned
+list contains `SAI_MIRROR_SESSION_TYPE_SFLOW`. The result is published to
+`STATE_DB:SWITCH_CAPABILITY|switch` as `HW_SFLOW_CAPABLE`.
 
 ### 9. Configuration and management
 
@@ -186,8 +234,18 @@ One new command selects the datapath; every existing sFlow command is unchanged.
 config sflow mode <cpu-path|hw-accelerated>
 ```
 
-`show sflow` gains the selected mode, and per collector the resolved
-encapsulation. Existing fields and layout are unchanged:
+The knob defaults to `cpu-path`: when `mode` is absent from the
+configuration, sFlow behaves exactly as it does today.
+
+Switching the mode tears down the active datapath before standing up the
+other: leaving `hw-accelerated` unbinds every sampled port and removes the
+mirror session, then flow sampling reverts to the CPU path. Whether sampling
+actually resumes there depends on the platform's support for CPU-based sFlow;
+on hardware without it, flow samples stop until `hw-accelerated` is
+re-enabled.
+
+`show sflow` gains the selected mode and its operational status. Existing
+fields and layout are unchanged:
 
 ```text
 sFlow Global Information:
@@ -200,15 +258,17 @@ sFlow Global Information:
 
   1 Collectors configured:
     Name: collector0          IP addr: 10.0.0.1       UDP port: 6343   VRF: default
-      Programmed: true        Dst MAC: 0c:42:a1:5e:3b:07   Src IP: 10.1.0.32   Egress: Ethernet48
 ```
 
-On a platform that cannot support the configured mode:
+When the configured mode cannot operate (incapable platform, `mgmt` VRF
+collector):
 
 ```text
   sFlow Sampling Mode:        hw-accelerated
-  sFlow Sampling Status:      non-operational (platform not capable)
+  sFlow Sampling Status:      non-operational
 ```
+
+The reason is recorded in syslog (WARN) and in `STATE_DB:SFLOW_STATE|global`.
 
 `sonic-sflow.yang`:
 
@@ -240,10 +300,8 @@ leaf mode {
 }
 ```
 
-`STATE_DB:SWITCH_CAPABILITY` gains one bit, sourced from
-`sai_query_attribute_enum_values_capability()` on
-`SAI_MIRROR_SESSION_ATTR_TYPE` (the platform is capable when the returned list
-contains `SAI_MIRROR_SESSION_TYPE_SFLOW`):
+`STATE_DB:SWITCH_CAPABILITY` gains one bit, sourced from the capability query
+described in the SAI API section:
 
 ```json
 "SWITCH_CAPABILITY|switch": {
@@ -251,25 +309,25 @@ contains `SAI_MIRROR_SESSION_TYPE_SFLOW`):
 }
 ```
 
-Two new STATE_DB tables, written by `SflowOrch`:
-
-```text
-key           = SFLOW_COLLECTOR_STATE|<collector_name>
-programmed    = "true" / "false"
-resolved_dst_mac, resolved_src_mac, resolved_src_ip, egress_port
-last_error    = string
-last_updated  = timestamp
-```
+One new STATE_DB table, written by `SflowOrch`:
 
 ```text
 key          = SFLOW_STATE|global
 operational  = "true" / "false"
-reason       = string (empty when operational)
+reason       = "platform_not_capable" / "collector_vrf_unsupported"
+               (empty when operational)
 ```
 
 Configuration without `mode` behaves as `cpu-path`, so nothing is migrated and
-an upgrade does not change an existing deployment's datapath.
-`SFLOW_COLLECTOR_STATE` exists only while the hardware path is active.
+an upgrade does not change an existing deployment's datapath. `SFLOW_STATE`
+exists only while `mode` is `hw-accelerated`.
+
+#### 9.4 Generic Config Updater
+
+The `mode` leaf is YANG-modeled, so GCU needs no feature-specific code: a
+JSON patch that adds, changes, or removes `SFLOW|global:mode` validates
+against `sonic-sflow.yang` and applies at runtime without a config reload.
+Removing the leaf falls back to the default `cpu-path`.
 
 ### 10. Warmboot and Fastboot Design Impact
 
@@ -277,19 +335,27 @@ HW sFlow packet sampling should not be affected after a warm reboot.
 
 ### 11. Memory Consumption
 
-One mirror session per (collector, sample rate) pair, plus port-to-session
-bookkeeping in `SflowOrch` and one STATE_DB row per collector. Nothing is
-allocated while `mode` is `cpu-path`.
+One mirror session per sample rate in use, plus port-to-session bookkeeping in
+`SflowOrch` and one `SFLOW_STATE` row. Nothing is allocated while `mode` is
+`cpu-path`.
 
 ### 12. Restrictions/Limitations
 
-1. A sample-rate change may pause sampling briefly and reset the datagram
+1. The collector must be in the default VRF. sFlow accepts only the
+   `default` and `mgmt` collector VRFs today, and `mgmt` is not accepted on
+   the hardware path because the management port is not in the ASIC datapath:
+   a `vrf mgmt` collector is not programmed while `mode=hw-accelerated`, is
+   logged at WARN, and the path reports non-operational.
+2. A single collector is supported on the hardware path. If more than one
+   collector is configured while `mode=hw-accelerated`, only the first is
+   programmed and a WARN is logged.
+3. A sample-rate change may pause sampling briefly and reset the datagram
    sequence number, depending on the vendor SAI, so collectors must tolerate
    resets. Bursts coalesce into one reprogram.
-2. PortChannel support binds each member port, since
-   `SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` is a port attribute with no
-   LAG-level equivalent.
-3. Ports configured `sample_direction tx` or `both` are not programmed on the
+4. PortChannel support binds each member port through LAG expansion,
+   since `SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION` is a
+   port attribute with no LAG-level equivalent.
+5. Ports configured `sample_direction tx` or `both` are not programmed on the
    hardware path and are logged at WARN.
 
 ### 13. Testing Requirements/Design
@@ -298,13 +364,15 @@ allocated while `mode` is `cpu-path`.
 
 | # | Test |
 | :---- | :---- |
-| 1 | `HW_SFLOW_CAPABLE` is published from the SAI capability query |
+| 1 | `HW_SFLOW_CAPABLE` is published from the SAI enum-capability query |
 | 2 | Default `mode=cpu-path` uses the CPU path and creates no mirror session |
-| 3 | `mode=hw-accelerated` on a capable platform creates the mirror session with expected attributes and binds it to enabled ports |
-| 4 | `mode=hw-accelerated` on an incapable platform: config is retained, flow sampling stops (no CPU fallback), `SFLOW_STATE|global` reports non-operational with a reason, and a WARN is logged |
-| 5 | A neighbor or route change re-resolves and updates the session in place; a burst collapses into one reprogram |
-| 6 | Two ports at the same sample rate share one session; different rates get distinct sessions |
+| 3 | `mode=hw-accelerated` on a capable platform creates the mirror session with the recirc port as `MONITOR_PORT` and binds it to enabled ports |
+| 4 | `mode=hw-accelerated` on an incapable platform: config is retained, flow sampling stops (no CPU fallback), `SFLOW_STATE\|global` reports non-operational with a reason, and a WARN is logged |
+| 5 | Two ports at the same sample rate share one session; different rates get distinct sessions |
+| 6 | Enabling sFlow on a PortChannel binds every member; a member join binds the new member and a member leave unbinds it |
 | 7 | Bindings are removed on session delete; a mode change tears down one path before standing up the other |
+| 8 | A GCU patch that sets, changes, or removes `SFLOW\|global:mode` validates against YANG and applies at runtime |
+| 9 | A `vrf mgmt` collector with `mode=hw-accelerated` is not programmed: `SFLOW_STATE\|global` reports non-operational with reason `collector_vrf_unsupported` and a WARN is logged |
 
 #### 13.2 System test cases
 
@@ -312,16 +380,9 @@ allocated while `mode` is `cpu-path`.
 also evaluate HW sFlow on supported platforms.
 
 We will evaluate:
-- End to end: with `mode=hw-accelerated`, a collector receives and decodes sFlow v5 datagrams
+- End to end: a collector receives and decodes sFlow v5 datagrams
 - IPv4/6 collectors function properly
-- Nexthop-flap reprograms the encapsulation and sampling resumes
-- PortChannel ingress is sampled across LAG members
+- A route change toward the collector: delivery follows the FIB with no session reprogram
+- PortChannel ingress is sampled across LAG members, including after a membership change
 - Counter samples arrive while hardware path is active
 - Warmboot continues sampling on unchanged
-
-### 14. Open/Action items - if any
-
-- SAI has no LAG-level equivalent of
-  `SAI_PORT_ATTR_INGRESS_SAMPLE_MIRROR_SESSION`, so PortChannel support binds
-  each member port. A SAI enhancement request to add one is worth
-  raising.


### PR DESCRIPTION
Adds the HLD for hardware accelerated sFlow.

sFlow is a flow sampling-based approach to network telemetry. Traditionally, hardware will statistically sample 1-in-N packets per flow, where N is configurable. Sampled packets will be punted to the CPU, where they are aggregated and encapsulated into sFlow datagrams, and egressed (typically out of the management port) to a remote collector.

Hardware accelerated sFlow (HW sFlow) is an increasingly supported silicon feature which offloads the tasks of sFlow to the network processor. However, SONiC today implicitly assumes sFlow adheres to the traditional path, limiting operators' abilities to reap the CPU overhead reduction and sampling speed improvements from HW sFlow.

This HLD proposes the SONiC changes necessary to enable HW sFlow support.

The HLD covers:
- Platform capability detection via SAI capability query, reflected in `STATE_DB:SWITCH_CAPABILITY`
- A new `HwSflow` sibling class under `SflowOrch` owning the HW sFlow lifecycle (collector resolution, sFlow mirror session management, per-port sample binding)
- Opt-in datapath selection through a new `mode` field (`cpu-path` / `hw-accelerated`), gated on platform capability
- CONFIG_DB / STATE_DB schema, CLI and YANG additions, and testing requirements