### PR TITLE
[tsc/repo-maintainer] sonic-redfish Maintainer Nominations

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -82,3 +82,5 @@
 | sonic-host-services | sonic-host-services-maintainer | Qi Luo(Microsoft) | qiluo-msft |  |
 | sonic-formal-infra | sonic-formal-infra-maintainer | Mengqi Liu (Alibaba) | mengqiliu20 | enabled |
 |  | sonic-formal-infra-maintainer | Ali Kheradmand (Google) | kheradmandG |enabled  |
+| sonic-redfish | sonic-redfish-maintainer | Chinmoy Dey (Nexthop AI) | chinmoy-nexthop | enabled |
+|  | sonic-redfish-maintainer | Shreyansh Jain (Nexthop AI) | shreyansh-nexthop | enabled |

--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -82,5 +82,6 @@
 | sonic-host-services | sonic-host-services-maintainer | Qi Luo(Microsoft) | qiluo-msft |  |
 | sonic-formal-infra | sonic-formal-infra-maintainer | Mengqi Liu (Alibaba) | mengqiliu20 | enabled |
 |  | sonic-formal-infra-maintainer | Ali Kheradmand (Google) | kheradmandG |enabled  |
-| sonic-redfish | sonic-redfish-maintainer | Chinmoy Dey (Nexthop AI) | chinmoy-nexthop | enabled |
+| sonic-redfish | sonic-redfish-maintainer | Judy Joseph (Microsoft) | judyjoseph | enabled |
+|  | sonic-redfish-maintainer | Chinmoy Dey (Nexthop AI) | chinmoy-nexthop | enabled |
 |  | sonic-redfish-maintainer | Shreyansh Jain (Nexthop AI) | shreyansh-nexthop | enabled |


### PR DESCRIPTION
#### Why I did it
sonic-redfish repository has no current maintainers and is expected to have further development to support liquid cooled platforms. 

We would like to propose Chinmoy Dey (chinmoy-nexthop) and Shreyansh Jain (shreyansh-nexthop) from Nexthop AI as maintainers for sonic-redfish repo given that they have built the initial framework and implemented the core Redfish functionality for SONiC BMC.

chinmoy-nexthop PRs:
[Redfish HLD](https://github.com/sonic-net/SONiC/pull/2281)
[sonic-redfish PRs](https://github.com/sonic-net/sonic-redfish/pulls?q=is%3Apr+author%3Achinmoy-nexthop)
https://github.com/sonic-net/sonic-mgmt/pull/23346


shreyansh-nexthop PRs:
https://github.com/sonic-net/sonic-buildimage/pull/26003
https://github.com/sonic-net/sonic-buildimage/pull/27349
https://github.com/sonic-net/sonic-mgmt/pull/23678
https://github.com/sonic-net/sonic-mgmt/pull/25430
https://github.com/sonic-net/sonic-host-services/pull/380

CC: @yxieca 

#### What I did
Updated SONiC_Repo_Maintainer.md to nominate chinmoy-nexthop and shreyansh-nexthop as maintainers for sonic-redfish.

#### How to verify it
- Verify markdown renders correctly.

#### Which release branch to backport (provide reason below if selected)
None — documentation change for master.
