### PR TITLE
[HLD] EOL and Deprecation Plan for 202611 (Security WG)

### DIFF
--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -99,7 +99,7 @@ Rules of thumb:
 
 | # | Candidate | Remove in | Why wait |
 |---|-----------|-----------|----------|
-| B1 | Kubernetes worker (`INCLUDE_KUBERNETES`) | 202711 | Off by default, not in CI, ancient pins. Recent commits are security fixes, not feature work — no real sign the worker feature is used. We just can't prove zero users, so deprecate with notice instead of removing now. Confirm with Microsoft. **Keep the ctrmgrd wrapper — it is not k8s-only.** |
+| B1 | Kubernetes worker (`INCLUDE_KUBERNETES`) | 202711 | Off by default, not in CI, ancient pins. Recent commits are security fixes, not feature work — but they predate any org-wide security push, so someone hardening k8s-worker on their own points to a real user. Likely in use: deprecate with notice, don't remove yet. Confirm with Microsoft. **Keep the ctrmgrd wrapper — it is not k8s-only.** |
 | B2 | Bullseye base containers (`docker-base-bullseye`, `docker-config-engine-bullseye`, `docker-swss-layer-bullseye`) | 202705 | Debian 11. May still be a live base for some containers. Move them to bookworm/trixie, then remove. |
 | B3 | FRR `split-unified` config mode (operator writes `frr.conf`) | 202705 | The manual mode. No hot reload — the bgp container runs supervisord, not systemd, so any `frr.conf` change forces a full FRR restart. Consolidate on `unified` (bgpcfgd + `config_db.json`). Confirm bgpcfgd/config_db covers the needed FRR features before removal. |
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -93,7 +93,7 @@ Rules of thumb:
 | A7 | `docker-basic_router` | Dead SAI demo container. Wired into no build. Never shipped. | Nothing uses it. |
 | A8 | System Telemetry (`docker-sonic-telemetry`) | Off by default. Redundant — the gnmi container runs the **same binary**. | Keep the `telemetry` binary (gnmi needs it). Remove the container + `INCLUDE_SYSTEM_TELEMETRY` flag. See A8 note. |
 | A9 | Broken FRR modes (`separated`, `split`) | Both write per-daemon FRR config files. FRR 10.5.4 (shipped) dropped support for those. They no longer work. | Default becomes `unified`. `minigraph.py` still hardcodes `separated` — flip it. See A9 note. |
-| A10 | Old Debian build leftovers (jessie, stretch, buster) | Debian 8, 9, and 10. All long EOL. Risk: someone builds on a 6+ year old base. | jessie and stretch/buster are different shapes — see A10 note. Check nothing still `FROM`s a base before deleting. Bullseye is a separate case (B1). |
+| A10 | Old Debian build leftovers (jessie, stretch, buster) | Debian 8, 9, and 10. All long EOL. Risk: someone builds on a 6+ year old base. | jessie and stretch/buster are different — see A10 note. Check nothing still `FROM`s a base before deleting. Bullseye is a separate case (B1). |
 
 #### 7.2 Deprecate now, remove later
 
@@ -121,7 +121,7 @@ Short notes on the ones with real gaps or tricky scope.
 
 Catch: `minigraph.py` still hardcodes the default as `separated` (init_cfg doesn't set it, so it resolves to `separated` today). This change must flip the default to `unified`.
 
-**A10 — old Debian bases.** Two shapes. **stretch** and **buster** each have real `docker-base-*` / `docker-config-engine-*` / `docker-swss-layer-*` containers to delete. **jessie** does not — there is no `docker-base-jessie`. What's left of jessie is the `sonic-slave-jessie` build slave and its `make jessie` target (Debian 8), plus jessie strings in the generic `docker-base` (armhf/arm64 sources, `FROM ...:jessie`). Drop the jessie slave and its wiring; check the generic `docker-base` before touching it. Many other jessie strings sit in code we already remove (p4, nephos). Bullseye is not here — it's deprecated for later removal (B1).
+**A10 — old Debian bases.** Two cases here. **stretch** and **buster** each have real `docker-base-*` / `docker-config-engine-*` / `docker-swss-layer-*` containers to delete. **jessie** does not — there is no `docker-base-jessie`. What's left of jessie is the `sonic-slave-jessie` build slave and its `make jessie` target (Debian 8), plus jessie strings in the generic `docker-base` (armhf/arm64 sources, `FROM ...:jessie`). Drop the jessie slave and its wiring; check the generic `docker-base` before touching it. Many other jessie strings sit in code we already remove (p4, nephos). Bullseye is not here — it's deprecated for later removal (B1).
 
 **B3 — REST API.** Not a general REST interface — its spec calls it the "SONiC REST API for Baremetal Scenarios." An imperative agent for baremetal VNET/VXLAN/VLAN config over HTTPS. Off by default; gNMI is the go-forward. Two things gNMI does not replace: bulk route programming with per-route partial success (HTTP `207`), and route expiry (timed route aging). Deprecate now; before removal, confirm no baremetal control plane still drives it. Note: the mgmt-framework REST server is a different thing and stays.
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -89,19 +89,18 @@ Rules of thumb:
 | A3 | Nephos platform (`platform/nephos`) | Vendor gone (~2019). No real commits in years. No device tree. | Cleanup is mostly the pipeline YAML. |
 | A4 | GoBGP FPM (`docker-fpm-gobgp`, `src/gobgp`, `rules/gobgp.*`) | Not buildable as an image since 2021, yet still compiles a 2017-era Go deb every build. FRR replaced it. | Drop the dead `DOCKER_FPM_GOBGP` / `DOCKER_FPM_QUAGGA` refs in `docker-fpm.*` too. |
 | A5 | Python 2 packages (`swsssdk-py2`, `redis-dump-load-py2`) | Gated off on bullseye/bookworm/trixie. Never built on any current release. | None. The py3 version is a separate case — see [13](#13-additional-findings). |
-| A6 | Kubernetes master (`INCLUDE_KUBERNETES_MASTER`) | Runs a full k8s control plane on a switch. All pins are years EOL (k8s 1.22, etcd 3.5.0, coredns 1.8.4, dashboard 2.7.0) plus Azure creds. Off, no real CI. | Biggest CVE win. Master only — worker is separate (see B1). |
+| A6 | Kubernetes master (`INCLUDE_KUBERNETES_MASTER`) | Runs a full k8s control plane on a switch. All pins are years EOL (k8s 1.22, etcd 3.5.0, coredns 1.8.4, dashboard 2.7.0) plus Azure creds. Off, no real CI. | Biggest CVE win. Master only. The worker (`INCLUDE_KUBERNETES`) is a separate feature and **stays** — pre-WG security hardening on it points to a real (likely Microsoft) user. |
 | A7 | `docker-basic_router` | Dead SAI demo container. Wired into no build. Never shipped. | Nothing uses it. |
 | A8 | System Telemetry (`docker-sonic-telemetry`) | Off by default. Redundant — the gnmi container runs the **same binary**. | Keep the `telemetry` binary (gnmi needs it). Remove the container + `INCLUDE_SYSTEM_TELEMETRY` flag. See A8 note. |
 | A9 | Broken FRR modes (`separated`, `split`) | Both write per-daemon FRR config files. FRR 10.5.4 (shipped) dropped support for those. They no longer work. | Default becomes `unified`. `minigraph.py` still hardcodes `separated` — flip it. See A9 note. |
-| A10 | Old Debian build leftovers (jessie, stretch, buster) | Debian 8, 9, and 10. All long EOL. Risk: someone builds on a 6+ year old base. | jessie and stretch/buster are different shapes — see A10 note. Check nothing still `FROM`s a base before deleting. Bullseye is a separate case (B2). |
+| A10 | Old Debian build leftovers (jessie, stretch, buster) | Debian 8, 9, and 10. All long EOL. Risk: someone builds on a 6+ year old base. | jessie and stretch/buster are different shapes — see A10 note. Check nothing still `FROM`s a base before deleting. Bullseye is a separate case (B1). |
 
 #### 7.2 Deprecate now, remove later
 
 | # | Candidate | Remove in | Why wait |
 |---|-----------|-----------|----------|
-| B1 | Kubernetes worker (`INCLUDE_KUBERNETES`) | 202711 | Off by default, not in CI, ancient pins. Recent commits are security fixes, not feature work — but they predate any org-wide security push, so someone hardening k8s-worker on their own points to a real user. Likely in use: deprecate with notice, don't remove yet. Confirm with Microsoft. **Keep the ctrmgrd wrapper — it is not k8s-only.** |
-| B2 | Bullseye base containers (`docker-base-bullseye`, `docker-config-engine-bullseye`, `docker-swss-layer-bullseye`) | 202705 | Debian 11. May still be a live base for some containers. Move them to bookworm/trixie, then remove. |
-| B3 | FRR `split-unified` config mode (operator writes `frr.conf`) | 202705 | The manual mode. No hot reload — the bgp container runs supervisord, not systemd, so any `frr.conf` change forces a full FRR restart. Consolidate on `unified` (bgpcfgd + `config_db.json`). Confirm bgpcfgd/config_db covers the needed FRR features before removal. |
+| B1 | Bullseye base containers (`docker-base-bullseye`, `docker-config-engine-bullseye`, `docker-swss-layer-bullseye`) | 202705 | Debian 11. May still be a live base for some containers. Move them to bookworm/trixie, then remove. |
+| B2 | FRR `split-unified` config mode (operator writes `frr.conf`) | 202705 | The manual mode. No hot reload — the bgp container runs supervisord, not systemd, so any `frr.conf` change forces a full FRR restart. Consolidate on `unified` (bgpcfgd + `config_db.json`). Confirm bgpcfgd/config_db covers the needed FRR features before removal. |
 
 ### 8. Per-candidate detail
 
@@ -117,16 +116,16 @@ Short notes on the ones with real gaps or tricky scope.
 
 - `separated`, `split` — write per-daemon config files (`bgpd.conf`, `zebra.conf`, ...). FRR 10.5 dropped per-daemon config files, so both are broken. **Remove.**
 - `unified` — config comes from bgpcfgd and `config_db.json`. The supported path. **Keep, make it the default.**
-- `split-unified` — the operator writes `frr.conf` by hand. **Deprecate (B3).** No hot reload (supervisord, not systemd), so any change forces a full FRR restart — impractical for production.
+- `split-unified` — the operator writes `frr.conf` by hand. **Deprecate (B2).** No hot reload (supervisord, not systemd), so any change forces a full FRR restart — impractical for production.
 
 Catch: `minigraph.py` still hardcodes the default as `separated` (init_cfg doesn't set it, so it resolves to `separated` today). This change must flip the default to `unified`.
 
-**A10 — old Debian bases.** Two shapes. **stretch** and **buster** each have real `docker-base-*` / `docker-config-engine-*` / `docker-swss-layer-*` containers to delete. **jessie** does not — there is no `docker-base-jessie`. What's left of jessie is the `sonic-slave-jessie` build slave and its `make jessie` target (Debian 8), plus jessie strings in the generic `docker-base` (armhf/arm64 sources, `FROM ...:jessie`). Drop the jessie slave and its wiring; check the generic `docker-base` before touching it. Many other jessie strings sit in code we already remove (p4, nephos). Bullseye is not here — it's deprecated for later removal (B2).
+**A10 — old Debian bases.** Two shapes. **stretch** and **buster** each have real `docker-base-*` / `docker-config-engine-*` / `docker-swss-layer-*` containers to delete. **jessie** does not — there is no `docker-base-jessie`. What's left of jessie is the `sonic-slave-jessie` build slave and its `make jessie` target (Debian 8), plus jessie strings in the generic `docker-base` (armhf/arm64 sources, `FROM ...:jessie`). Drop the jessie slave and its wiring; check the generic `docker-base` before touching it. Many other jessie strings sit in code we already remove (p4, nephos). Bullseye is not here — it's deprecated for later removal (B1).
 
 ### 9. Config and management impact
 
-- **A6 / A8 / B1:** these are feature containers. Removing them drops their `FEATURE` table entries and build flags. No CLI change for users who never turned them on.
-- **A9 / B3:** drops the two broken modes (`separated`, `split`) and makes `unified` (bgpcfgd + `config_db.json`) the default (also flip the `minigraph.py` default). `split-unified` (the manual, hand-written `frr.conf` mode) is deprecated and removed later, leaving `unified` as the only mode.
+- **A6 / A8:** these are feature containers. Removing them drops their `FEATURE` table entries and build flags. No CLI change for users who never turned them on.
+- **A9 / B2:** drops the two broken modes (`separated`, `split`) and makes `unified` (bgpcfgd + `config_db.json`) the default (also flip the `minigraph.py` default). `split-unified` (the manual, hand-written `frr.conf` mode) is deprecated and removed later, leaving `unified` as the only mode.
 - **A2 / A3 / A1:** platform removals. No effect on other platforms.
 - No YANG changes beyond dropping models for removed features (e.g. `sonic-kubernetes_master.yang` with A6).
 
@@ -147,7 +146,6 @@ None. Every candidate is off by default, dead, or platform-specific to hardware 
 Held back until an owner confirms. Not proposed here.
 
 - **REST API** (`docker-sonic-restapi`): baremetal VNET config API. gNMI does not cover its bulk-route (207 partial) and route-expiry semantics. Needs Microsoft to confirm no live consumer.
-- **Kubernetes worker owner check:** confirm the user base before setting a firm removal date.
 - **PDE** (`docker-pde`): Broadcom bring-up tool. Confirm with Broadcom.
 - **clounix platform:** nearly inert but added under a year ago. Confirm intent with the vendor.
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -1,4 +1,4 @@
-# SONiC EOL & Deprecation Plan — 202611
+# SONiC EOL and Deprecation Plan for 202611
 
 ## Table of Content
 
@@ -10,20 +10,20 @@
 - [6. Process](#6-process)
 - [7. Candidates for 202611](#7-candidates-for-202611)
   - [7.1 Remove now](#71-remove-now)
-    - [Barefoot / Tofino platform (with DTEL)](#barefoot--tofino-platform-with-dtel)
-    - [Standalone P4 platform](#standalone-p4-platform)
-    - [Nephos platform](#nephos-platform)
-    - [GoBGP FPM container](#gobgp-fpm-container)
-    - [Python 2 packages](#python-2-packages)
-    - [Kubernetes master](#kubernetes-master)
-    - [docker-basic_router](#docker-basic_router)
-    - [System Telemetry container](#system-telemetry-container)
-    - [Broken FRR config modes](#broken-frr-config-modes)
-    - [Old Debian build leftovers](#old-debian-build-leftovers)
+    - [7.1.1 Barefoot / Tofino platform (with DTEL)](#711-barefoot--tofino-platform-with-dtel)
+    - [7.1.2 Standalone P4 platform](#712-standalone-p4-platform)
+    - [7.1.3 Nephos platform](#713-nephos-platform)
+    - [7.1.4 GoBGP FPM container](#714-gobgp-fpm-container)
+    - [7.1.5 Python 2 packages](#715-python-2-packages)
+    - [7.1.6 Kubernetes master](#716-kubernetes-master)
+    - [7.1.7 docker-basic_router](#717-docker-basic_router)
+    - [7.1.8 System Telemetry container](#718-system-telemetry-container)
+    - [7.1.9 Broken FRR config modes](#719-broken-frr-config-modes)
+    - [7.1.10 Old Debian build leftovers](#7110-old-debian-build-leftovers)
   - [7.2 Deprecate now, remove later](#72-deprecate-now-remove-later)
-    - [Bullseye base containers — remove in 202705](#bullseye-base-containers--remove-in-202705)
-    - [FRR split-unified config mode — remove in 202705](#frr-split-unified-config-mode--remove-in-202705)
-    - [REST API — remove in 202711](#rest-api--remove-in-202711)
+    - [7.2.1 Bullseye base containers](#721-bullseye-base-containers)
+    - [7.2.2 FRR split-unified config mode](#722-frr-split-unified-config-mode)
+    - [7.2.3 REST API](#723-rest-api)
 - [8. Config and management impact](#8-config-and-management-impact)
 - [9. Warmboot/Fastboot impact](#9-warmbootfastboot-impact)
 - [10. Testing](#10-testing)
@@ -39,18 +39,18 @@
 
 This HLD does two things:
 
-1. Sets up a repeatable, per-release process to deprecate and remove SONiC features.
-2. Lists the features we propose to act on in **202611**.
+1. It sets up a repeatable, per-release process to deprecate and remove SONiC features.
+2. It lists the features we propose to act on in 202611.
 
-It comes out of the SONiC Security Working Group. Goal: shrink the attack surface. Less code means fewer packages, fewer CVEs, less to build and test.
+The work comes from the SONiC Security Working Group, whose goal is to shrink the attack surface. Less code means fewer packages, fewer CVEs, and less to build and test.
 
-Releases ship twice a year: **November (`YYYY11`)** and **May (`YYYY05`)**. So the cycles here are 202611 (Nov 2026), 202705 (May 2027), 202711 (Nov 2027).
+Releases ship twice a year, in November (`YYYY11`) and in May (`YYYY05`). The cycles referenced here are 202611 (November 2026), 202705 (May 2027), and 202711 (November 2027).
 
 ### 3. Definitions/Abbreviations
 
 | Term | Meaning |
 |------|---------|
-| Deprecate | Mark a feature as going away. Still ships, but warns of removal. |
+| Deprecate | Mark a feature as going away. It still ships, but it warns of removal. |
 | Remove | Delete the code and its build wiring. |
 | SBOM | Software Bill of Materials. |
 | DTEL | Data-plane telemetry (in-band / INT). |
@@ -60,134 +60,151 @@ Releases ship twice a year: **November (`YYYY11`)** and **May (`YYYY05`)**. So t
 
 ### 4. Overview
 
-SONiC still ships features that few or no one runs. Some are dead. Some broke when a dependency moved on. Some were tied to hardware that no longer exists. Each one still adds packages to the image, findings to every CVE scan, and jobs to CI.
+SONiC still ships features that few or no one runs. Some of them are dead. Some broke when a dependency moved on. Some were tied to hardware that no longer exists. Each one still adds packages to the image, findings to every CVE scan, and jobs to CI.
 
-This HLD proposes a standing process to retire such features, plus the first batch to act on.
+This HLD proposes a standing process to retire those features, along with the first batch to act on.
 
 ### 5. Why remove code
 
 - The best fix for a CVE is to delete the code that carries it.
-- Unmaintained code is a standing risk. It rarely gets patched.
+- Unmaintained code is a standing risk, because it rarely gets patched.
 - Dead build wiring hides real problems and slows builds.
-- Fewer features = smaller image, fewer scans to triage, less CI.
+- Fewer features mean a smaller image, fewer scans to triage, and less CI.
 
 ### 6. Process
 
-Per release:
+For each release:
 
-1. **Propose.** File (or update) this HLD with candidates. Each candidate says what it is, what replaces it, the gap (what you lose), and a verdict.
-2. **Two verdicts:**
-   - **Remove now** — dead, broken, or EOL with no real users. Delete this cycle.
-   - **Deprecate now, remove later** — still has possible users or needs migration work. Name a removal release.
-3. **Review.** The community reviews it. This HLD gets scheduled at the weekly HLD review (Tuesdays). Component owners sign off. A feature is not removed without owner sign-off.
+1. **Propose.** File or update this HLD with candidates. Each candidate states what it is, what replaces it, the gap in what you lose, and a verdict.
+2. **Pick a verdict.** There are two:
+   - **Remove now:** dead, broken, or EOL with no real users. Delete it this cycle.
+   - **Deprecate now, remove later:** still has possible users or needs migration work. Name a removal release.
+3. **Review.** The community reviews it, and this HLD is scheduled at the weekly HLD review on Tuesdays. Component owners sign off. A feature is not removed without owner sign-off.
 4. **Announce.** Deprecations go in the release notes.
 5. **Remove** in the named release.
 
-Rules of thumb:
+A few rules of thumb guide the calls above:
 
-- "Not built by default" and "not in CI" are **hints**, not proof. We check real use before we call anything dead.
-- A forced bump (libyang, base image, submodule pointer, mass format) does **not** count as maintenance.
+- "Not built by default" and "not in CI" are hints, not proof. We check real use before calling anything dead.
+- A forced bump, such as a libyang, base image, submodule pointer, or mass format change, does not count as maintenance.
 - If a replacement has a gap, we name it so users can speak up.
 
 ### 7. Candidates for 202611
 
-Each candidate below stands on its own: what it is, why it goes, and anything to watch out for.
+Each candidate below stands on its own. It states what the feature is, why it should go, the paths to remove, and anything to watch out for.
 
 #### 7.1 Remove now
 
-##### Barefoot / Tofino platform (with DTEL)
+##### 7.1.1 Barefoot / Tofino platform (with DTEL)
 
-`platform/barefoot`. Intel ended the Tofino line, and the platform is absent from the CI build matrix (aspeed_arm64, broadcom, marvell-prestera, mellanox, nvidia_bluefield, vs, alpinevs, vpp) — so it is unbuilt and untested. It's about 7.7 MB / 880 files and pulls in the Barefoot SAI, saithrift, `docker-syncd-bfn`, `docker-saiserver-bfn`, and the ODM sub-platforms built on Tofino (Accton Wedge100BF, Arista 7170, Ingrasys, Netberg, WNC).
+Intel has ended the Tofino line, and the platform is not in the CI build matrix (aspeed_arm64, broadcom, marvell-prestera, mellanox, nvidia_bluefield, vs, alpinevs, and vpp). Because nothing builds it, nothing tests it. The platform is roughly 7.7 MB across about 880 files, and it pulls in the Barefoot SAI, saithrift, the `docker-syncd-bfn` and `docker-saiserver-bfn` containers, and the ODM sub-platforms built on Tofino (Accton Wedge100BF, Arista 7170, Ingrasys, Netberg, and WNC).
 
-Data-plane telemetry (DTEL, `dtelorch`) only ran on Tofino in practice, so it goes with the platform. TAM, added in 202605, covers the same need. Also delete the stale `barefoot` job still sitting in `azure-pipelines-build.yml`.
+Data-plane telemetry (DTEL, `dtelorch`) only ever ran on Tofino in practice, so it should be removed with the platform. TAM, which was added in 202605, already covers the same need.
 
-##### Standalone P4 platform
+**Remove:** `platform/barefoot/`; the Tofino `device/` folders (Accton Wedge100BF, Arista 7170, Ingrasys, Netberg, WNC); `src/sonic-swss/orchagent/dtelorch.{cpp,h}` and its wiring in `orchagent/orchdaemon.cpp`; the `barefoot` job in `.azure-pipelines/azure-pipelines-build.yml`; the `barefoot` filter in `rules/docker-platform-monitor.mk`.
 
-`platform/p4` — the old bmv2 software behavioral model (`docker-sonic-p4`, `sai-p4-bm`, `p4c-bm`, `tenjin`, `p4-hlir`). It's a reference target, not real hardware. Dead since around 2022, in no CI, about 12 MB / 920 files with 4 stale external submodules. The only thing referencing it outside `platform/p4/` is a Debian-8-era TODO in `rules/redis.mk`.
+##### 7.1.2 Standalone P4 platform
 
-Remove `platform/p4/*`, its submodules, and that TODO. Leave `rules/p4lang.mk` alone — the p4lang toolchain (bmv2/p4c/PI) it builds is a live dependency of DASH SAI, which ships in `sonic-vs.img.gz`, and of the PTF test containers.
+This is the old bmv2 software behavioral model. It is a reference target rather than real hardware, and it has been dead since roughly 2022. Nothing in CI builds it. It is about 12 MB across 920 files, and it pulls in four stale external submodules. The only thing that references it outside `platform/p4/` is a Debian 8 era TODO in `rules/redis.mk`.
 
-##### Nephos platform
+**Remove:** `platform/p4/` (which includes `docker-sonic-p4`, `sai-p4-bm`, `p4c-bm`, `tenjin`, and `p4-hlir`); the four P4 submodule entries in `.gitmodules` (`platform/p4/p4c-bm/p4c-bm`, `platform/p4/p4-hlir/p4-hlir`, `platform/p4/p4-hlir/p4-hlir-v1.1`, `platform/p4/SAI-P4-BM`); the stale TODO in `rules/redis.mk`.
+**Keep:** `rules/p4lang.mk`. The p4lang toolchain it builds (bmv2, p4c, and PI) is a live dependency of DASH SAI, which ships in `sonic-vs.img.gz`, and of the PTF test containers.
 
-`platform/nephos`. The Nephos/MediaTek silicon vendor left the market around 2019. About 2.3 MB / 160 files (`docker-syncd-nephos`, SAI, saithrift, ODM modules). There's no `device/nephos` tree, no genuine commit in years, and it isn't in CI. Cleanup is mostly its `azure-pipelines-build.yml` entry.
+##### 7.1.3 Nephos platform
 
-##### GoBGP FPM container
+The Nephos and MediaTek switch silicon vendor left the market around 2019. The platform is about 2.3 MB across 160 files. There is no `device/nephos` tree, there has been no genuine commit in years, and it is not in CI.
 
-`docker-fpm-gobgp`, `src/gobgp`, `rules/gobgp.*`. SONiC standardized on FRR (`SONIC_ROUTING_STACK = frr`). The gobgp image-build rules were deleted back in 2021, so it hasn't been buildable as an image since — yet the build still compiles a 2017-vintage Go GOBGP `.deb` that nothing installs.
+**Remove:** `platform/nephos/`; the `nephos` job in `.azure-pipelines/azure-pipelines-build.yml`.
 
-Remove the container, `src/gobgp`, the `rules/gobgp.*` recipes, and the dead `DOCKER_FPM_GOBGP` and `DOCKER_FPM_QUAGGA` references in `rules/docker-fpm.*`. Nothing is lost — FRR does all of this.
+##### 7.1.4 GoBGP FPM container
 
-##### Python 2 packages
+SONiC standardized on FRR, which is set by `SONIC_ROUTING_STACK = frr`. The GoBGP image build rules were deleted back in 2021, so it has not been buildable as an image since then. Even so, every build still compiles a 2017 era Go GOBGP package that nothing installs. Removing it loses nothing, because FRR already provides all of this.
 
-`swsssdk-py2` and `redis-dump-load-py2`. Both are gated behind `ENABLE_PY2_MODULES`, which is off for bullseye, bookworm, and trixie — so neither is built on any current release. Pure dead weight. (The py3 version of swsssdk is a different case — it's still in use, so it's out of scope here and noted under Additional findings.)
+**Remove:** `dockers/docker-fpm-gobgp/`, `src/gobgp/`, `rules/gobgp.mk`, and `rules/gobgp.dep`; the dead `DOCKER_FPM_GOBGP` and `DOCKER_FPM_QUAGGA` references in `rules/docker-fpm.mk` and `rules/docker-fpm.dep`; the gobgp dependency in the non-frr branch of `platform/vs/docker-sonic-vs.mk`.
 
-##### Kubernetes master
+##### 7.1.5 Python 2 packages
 
-`INCLUDE_KUBERNETES_MASTER`. This runs a full Kubernetes control plane on the switch — apiserver, controller, scheduler, proxy, etcd 3.5.0, coredns 1.8.4, and the dashboard 2.7.0 web UI — plus cloud credential libraries for backups. Every one of those is years past end of life, so this is the single biggest CVE-surface win in the list. It's off by default and has no real CI.
+Both packages are gated behind `ENABLE_PY2_MODULES`, which is off for bullseye, bookworm, and trixie. As a result, neither is built on any current release, so both are dead weight. The py3 version of swsssdk is a separate matter, because it is still in use. It is out of scope here and is noted under Additional findings.
 
-This is master only. The worker feature (`INCLUDE_KUBERNETES`) is separate and stays — someone hardened its cluster-join security before this WG existed, which points to a real user. Removing master also drops `sonic-kubernetes_master.yang`. Leave the `ctrmgrd` container wrapper alone; it runs for ordinary feature start/stop, not just k8s.
+**Remove:** `rules/swsssdk-py2.mk`, `rules/swsssdk-py2.dep`, `rules/redis-dump-load-py2.mk`, and `rules/redis-dump-load-py2.dep`; the `SWSSSDK_PY2` dependency lines in `rules/sonic-py-common.mk` and `rules/swsssdk-py3.mk`.
 
-##### docker-basic_router
+##### 7.1.6 Kubernetes master
 
-A SAI demo/reference container. It's wired into no build rule, never ships in an image, and isn't in CI. Its last real change was 2020. Nothing uses it — straight delete.
+This runs a full Kubernetes control plane on the switch. That includes the apiserver, controller, scheduler, proxy, etcd 3.5.0, coredns 1.8.4, and the dashboard 2.7.0 web UI, along with cloud credential libraries used for backups. Every one of those versions is years past end of life, which makes this the single biggest reduction in CVE surface in this list. It is off by default and has no real CI coverage.
 
-##### System Telemetry container
+This applies to the master only. The worker feature (`INCLUDE_KUBERNETES`) is a separate feature and should stay. Someone hardened its cluster-join security before this working group existed, which points to a real user.
 
-`docker-sonic-telemetry`, off by default. It's redundant: this container and the gnmi container run the exact same binary, `/usr/sbin/telemetry` (started by `telemetry.sh` and `gnmi-native.sh` respectively). There is no separate gNMI server — the `telemetry` binary *is* the server; the name is just historical. Both read the same `TELEMETRY|gnmi` config, and the gnmi start script only adds ZMQ and VRF options on top. So there is no functional gap: Get/Set/Subscribe and dial-out are identical.
+**Remove:** `files/image_config/kubernetes/` (`kubernetes_master_entrance.sh`, `kubernetes_master_entrance.service`, `kubernetes.list`); the `INCLUDE_KUBERNETES_MASTER` flag and the master version pins in `rules/config`; the master-only blocks in `files/build_templates/sonic_debian_extension.j2`; `sonic-kubernetes_master.yang`; the master build in `.azure-pipelines/azure-pipelines-build.yml`.
+**Keep:** `INCLUDE_KUBERNETES` (the worker), `src/sonic-ctrmgrd*`, and the `ctrmgrd` wrapper, which runs for ordinary feature start and stop rather than only for k8s.
 
-Remove the container and the `INCLUDE_SYSTEM_TELEMETRY` flag. Keep the `telemetry` binary — the gnmi container runs it.
+##### 7.1.7 docker-basic_router
 
-##### Broken FRR config modes
+This is a SAI demo and reference container. It is not wired into any build rule, it never ships in an image, and it is not in CI. Its last real change was in 2020, and nothing uses it.
 
-`docker_routing_config_mode` has four values. `separated` and `split` write per-daemon config files (`bgpd.conf`, `zebra.conf`, and so on). FRR 10.5.4, which SONiC ships, dropped support for per-daemon config files — so both of these modes are broken today. This is really dead-code removal.
+**Remove:** `dockers/docker-basic_router/`.
 
-The supported path is `unified`, where config comes from bgpcfgd and `config_db.json`; make that the default. Right now `minigraph.py` hardcodes the default as `separated` (and init_cfg doesn't set it, so it resolves to `separated`), so this change must flip that default to `unified`. The fourth mode, `split-unified`, still works and is handled under Deprecate.
+##### 7.1.8 System Telemetry container
 
-##### Old Debian build leftovers
+This container is off by default, and it is redundant. Both this container and the gnmi container run the same binary, `/usr/sbin/telemetry`, started by `telemetry.sh` and `gnmi-native.sh` respectively. There is no separate gNMI server. The `telemetry` binary is the server, and the name is only historical. Both containers read the same `TELEMETRY|gnmi` config, and the gnmi start script simply adds ZMQ and VRF options on top. There is therefore no functional gap, because Get, Set, Subscribe, and dial-out are identical in both.
 
-Debian 8 (jessie), 9 (stretch), and 10 (buster) are all long past end of life. The risk is someone building a new container on a 6+-year-old base.
+**Remove:** `dockers/docker-sonic-telemetry/`, `rules/docker-telemetry.mk`, and `rules/docker-telemetry.dep`; the `INCLUDE_SYSTEM_TELEMETRY` flag in `rules/config`.
+**Keep:** the `telemetry` binary, which is built by sonic-gnmi and run by the gnmi container.
 
-stretch and buster each have real `docker-base-*`, `docker-config-engine-*`, and `docker-swss-layer-*` containers to delete. jessie is different — there's no `docker-base-jessie`. What's left of jessie is the `sonic-slave-jessie` build slave and its `make jessie` target, plus jessie strings in the generic `docker-base` (armhf/arm64 sources and `FROM ...:jessie`); drop the slave and its wiring, and check the generic `docker-base` before touching it.
+##### 7.1.9 Broken FRR config modes
 
-Before deleting any base, confirm nothing still bases a container on it. Bullseye (Debian 11) is newer and handled under Deprecate.
+`docker_routing_config_mode` has four values. Both `separated` and `split` write per-daemon config files such as `bgpd.conf` and `zebra.conf`. FRR 10.5.4, which SONiC ships, dropped support for per-daemon config files, so both of these modes are broken today. Removing them is really just deleting dead code.
+
+The supported path is `unified`, where the config comes from bgpcfgd and `config_db.json`, and that should become the default. Today `minigraph.py` hardcodes the default as `separated`, and init_cfg does not set it, so it resolves to `separated`. This change must flip that default to `unified`. The fourth mode, `split-unified`, still works and is handled under Deprecate.
+
+**Change:** remove the `separated` and `split` branches in `dockers/docker-fpm-frr/docker_init.sh` and the per-daemon templates under `dockers/docker-fpm-frr/frr/{bgpd,zebra,staticd,sharpd}/`; flip the default in `src/sonic-config-engine/minigraph.py` from `separated` to `unified`.
+
+##### 7.1.10 Old Debian build leftovers
+
+Debian 8 (jessie), Debian 9 (stretch), and Debian 10 (buster) are all long past end of life. The risk is that someone builds a new container on a base that is more than six years old. Before deleting any base, confirm that nothing still builds a container on it. Bullseye is Debian 11, which is newer, and it is handled under Deprecate.
+
+**Remove (stretch):** `dockers/docker-base-stretch/`, `rules/docker-base-stretch.{mk,dep}`, `dockers/docker-config-engine-stretch/`, `rules/docker-config-engine-stretch.{mk,dep}`.
+**Remove (buster):** `dockers/docker-base-buster/`, `rules/docker-base-buster.{mk,dep}`, `dockers/docker-config-engine-buster/`, `rules/docker-config-engine-buster.{mk,dep}`, `dockers/docker-swss-layer-buster/`, `rules/docker-swss-layer-buster.{mk,dep}`.
+**Remove (jessie):** `sonic-slave-jessie/`, the `jessie` target in `Makefile`, and the jessie `SLAVE_DIR` branch in `Makefile.work`. jessie has no `docker-base-jessie`, so also check the jessie strings in the generic `dockers/docker-base/` (its armhf and arm64 sources and its `FROM ...:jessie` lines) before touching that container.
 
 #### 7.2 Deprecate now, remove later
 
-##### Bullseye base containers — remove in 202705
+##### 7.2.1 Bullseye base containers
 
-`docker-base-bullseye`, `docker-config-engine-bullseye`, `docker-swss-layer-bullseye` (Debian 11). Newer than the bases above, and may still be a live base for some containers, so give it a cycle: move those containers to bookworm/trixie, then remove the bullseye bases in 202705.
+This should be removed in 202705. Bullseye is Debian 11, which is newer than the bases above and may still be a live base for some containers. It deserves a cycle of notice. Move those containers to bookworm or trixie first, and then remove it.
 
-##### FRR split-unified config mode — remove in 202705
+**Remove (202705):** `dockers/docker-base-bullseye/`, `rules/docker-base-bullseye.{mk,dep}`, `dockers/docker-config-engine-bullseye/`, `rules/docker-config-engine-bullseye.{mk,dep}`, `dockers/docker-swss-layer-bullseye/`, `rules/docker-swss-layer-bullseye.{mk,dep}`.
 
-The manual routing mode, where the operator writes `frr.conf` by hand. It has a real problem: the bgp container runs supervisord, not systemd, so FRR can't hot-reload — any `frr.conf` change forces a full FRR restart, which drops BGP sessions. That makes it impractical for production, so it's doubtful anyone serious runs it.
+##### 7.2.2 FRR split-unified config mode
 
-Deprecate now and consolidate on `unified` (bgpcfgd + `config_db.json`). Before removing, confirm bgpcfgd and `config_db.json` cover the FRR features operators actually need.
+This should be removed in 202705. It is the manual routing mode, where the operator writes `frr.conf` by hand. It has a real problem. The bgp container runs supervisord rather than systemd, so FRR cannot hot-reload, and any change to `frr.conf` forces a full FRR restart that drops BGP sessions. That makes it impractical for production, so it is doubtful anyone serious runs it. The plan is to consolidate on `unified`, which uses bgpcfgd and `config_db.json`. Before removing it, confirm that bgpcfgd and `config_db.json` cover the FRR features operators actually need.
 
-##### REST API — remove in 202711
+**Change (202705):** remove the `split-unified` branch in `dockers/docker-fpm-frr/docker_init.sh`.
 
-`docker-sonic-restapi`, off by default. Its own spec calls it the "SONiC REST API for Baremetal Scenarios" — an imperative agent for baremetal VNET/VXLAN/VLAN config over HTTPS, not a general REST interface. gNMI is the go-forward, but two things gNMI doesn't cover: bulk route programming with per-route partial success (HTTP 207), and route expiry (timed route aging).
+##### 7.2.3 REST API
 
-Because of that gap, give it the longest runway. Before removing, confirm no control plane still drives it. The mgmt-framework REST server is a different thing and stays.
+This should be removed in 202711. It is off by default. Its own spec calls it the "SONiC REST API for Baremetal Scenarios." It is an imperative agent for baremetal VNET, VXLAN, and VLAN config over HTTPS, not a general REST interface. gNMI is the intended replacement, but it does not cover two things. The first is bulk route programming with per-route partial success (HTTP 207). The second is route expiry, which is timed route aging. Because of that gap, this candidate gets the longest runway. Before removing it, confirm that no control plane still drives it. The mgmt-framework REST server is a different thing and stays.
+
+**Remove (202711):** `dockers/docker-sonic-restapi/`, `src/sonic-restapi/` and its `.gitmodules` entry, `rules/docker-restapi.{mk,dep}`, and `rules/restapi.{mk,dep}`; the `INCLUDE_RESTAPI` flag in `rules/config`; the `restapi` feature in `files/build_templates/init_cfg.json.j2`.
 
 ### 8. Config and management impact
 
-Removing a feature drops its `FEATURE` table entries, build flags, and any YANG models tied to it (for example `sonic-kubernetes_master.yang`). Users who never enabled these see no CLI change.
+Removing a feature drops its `FEATURE` table entries, its build flags, and any YANG models tied to it, such as `sonic-kubernetes_master.yang`. Users who never enabled these features see no CLI change.
 
-The FRR change removes `separated` and `split` from `docker_routing_config_mode` and makes `unified` the default. Platform removals don't affect other platforms.
+The FRR change removes `separated` and `split` from `docker_routing_config_mode` and makes `unified` the default. The platform removals do not affect other platforms.
 
 ### 9. Warmboot/Fastboot impact
 
-None. Every candidate is off by default, dead, or specific to hardware being removed. Nothing here touches the warmboot/fastboot path on supported platforms.
+There is no warmboot or fastboot impact. Every candidate is off by default, already dead, or specific to hardware that is being removed. None of this touches the warmboot or fastboot path on supported platforms.
 
 ### 10. Testing
 
 - Each supported CI platform still builds after the removals.
-- Removed packages are gone from the SBOM and CVE scan (image diff).
+- The removed packages no longer appear in the SBOM or the CVE scan, confirmed by an image diff.
 - The default FRR path (`unified`) comes up and programs routes.
-- All remaining containers build with nothing pointing at a deleted base.
+- Every remaining container builds with nothing pointing at a deleted base.
 
 ### 11. Additional findings
 
-Real, but out of scope here — removing them needs code porting, which this HLD doesn't cover. Noted so they're tracked.
+These are real, but they are out of scope here, because removing them needs code porting that this HLD does not cover. They are listed so they are tracked.
 
-- **swsssdk-py3.** The old Python Redis SDK. `swsscommon` replaces it, but code still imports `swsssdk` at runtime (`sonic-utilities/scripts/dualtor_neighbor_check.py`, `sonic-py-common`, the vpp container). It can't be deprecated until those are ported to `swsscommon`.
+- **swsssdk-py3.** This is the old Python Redis SDK. `swsscommon` replaces it, but code still imports `swsssdk` at runtime, including `sonic-utilities/scripts/dualtor_neighbor_check.py`, `sonic-py-common`, and the vpp container. It cannot be deprecated until those are ported to `swsscommon`.

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -101,7 +101,7 @@ Rules of thumb:
 |---|-----------|-----------|----------|
 | B1 | Kubernetes worker (`INCLUDE_KUBERNETES`) | 202711 | Off by default, but still patched upstream, so users may exist. Deprecate and see. **Keep the ctrmgrd wrapper — it is not k8s-only.** |
 | B2 | Bullseye base containers (`docker-base-bullseye`, `docker-config-engine-bullseye`, `docker-swss-layer-bullseye`) | 202705 | Debian 11. May still be a live base for some containers. Move them to bookworm/trixie, then remove. |
-| B3 | FRR `split-unified` config mode (operator writes `frr.conf`) | 202711 | The manual mode. No hot reload — the bgp container runs supervisord, not systemd, so any `frr.conf` change forces a full FRR restart. Consolidate on `unified` (bgpcfgd + `config_db.json`). Confirm bgpcfgd/config_db covers the needed FRR features before removal. |
+| B3 | FRR `split-unified` config mode (operator writes `frr.conf`) | 202705 | The manual mode. No hot reload — the bgp container runs supervisord, not systemd, so any `frr.conf` change forces a full FRR restart. Consolidate on `unified` (bgpcfgd + `config_db.json`). Confirm bgpcfgd/config_db covers the needed FRR features before removal. |
 
 ### 8. Per-candidate detail
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -14,15 +14,15 @@
     - [7.1.2 DTEL (data-plane telemetry)](#712-dtel-data-plane-telemetry)
     - [7.1.3 Standalone P4 platform](#713-standalone-p4-platform)
     - [7.1.4 Nephos platform](#714-nephos-platform)
-    - [7.1.5 GoBGP FPM container](#715-gobgp-fpm-container)
+    - [7.1.5 GoBGP and Quagga routing stacks](#715-gobgp-and-quagga-routing-stacks)
     - [7.1.6 Python 2 packages](#716-python-2-packages)
     - [7.1.7 Kubernetes master](#717-kubernetes-master)
     - [7.1.8 docker-basic_router](#718-docker-basic_router)
     - [7.1.9 System Telemetry container](#719-system-telemetry-container)
     - [7.1.10 Broken FRR config modes](#7110-broken-frr-config-modes)
-    - [7.1.11 Old Debian build leftovers](#7111-old-debian-build-leftovers)
+    - [7.1.11 End-of-life Debian bases](#7111-end-of-life-debian-bases)
   - [7.2 Deprecate now, remove later](#72-deprecate-now-remove-later)
-    - [7.2.1 Bullseye base containers](#721-bullseye-base-containers)
+    - [7.2.1 Bookworm base containers](#721-bookworm-base-containers)
     - [7.2.2 FRR split-unified config mode](#722-frr-split-unified-config-mode)
     - [7.2.3 REST API](#723-rest-api)
 - [8. Config and management impact](#8-config-and-management-impact)
@@ -35,6 +35,7 @@
 | Rev | Date | Author | Change |
 |-----|------|--------|--------|
 | 0.1 | 2026-07-19 | Brad House (Nexthop) | First draft. Security WG. |
+| 0.2 | 2026-07-24 | Brad House (Nexthop) | Added the Keep verdict. Moved bullseye to immediate removal and deprecated bookworm in its place. Folded Quagga into the GoBGP removal. |
 
 ### 2. Scope
 
@@ -77,10 +78,11 @@ This HLD proposes a standing process to retire those features, along with the fi
 For each release:
 
 1. **Propose.** File or update this HLD with candidates. Each candidate states what it is, what replaces it, the gap in what you lose, and a verdict.
-2. **Pick a verdict.** There are two:
+2. **Pick a verdict.** There are three:
    - **Remove now:** dead, broken, or EOL with no real users. Delete it this cycle.
    - **Deprecate now, remove later:** still has possible users or needs migration work. Name a removal release.
-3. **Review.** The community reviews it, and this HLD is scheduled at the weekly HLD review on Tuesdays. Component owners sign off. A feature is not removed without owner sign-off.
+   - **Keep:** the feature stays. Review turned up real usage, a dependency another feature relies on, or a gap that the proposed replacement does not cover.
+3. **Review.** The community reviews it, and this HLD is scheduled at the weekly HLD review on Tuesdays. Component owners sign off. A feature is not removed without owner sign-off. Review can change a verdict in either direction, and moving a candidate to **Keep** is a normal outcome rather than a failure of the process. When that happens, record what the review turned up and why the feature stays, so that a later cycle does not have to rediscover it.
 4. **Announce.** Deprecations go in the release notes.
 5. **Remove** in the named release.
 
@@ -121,11 +123,19 @@ The Nephos and MediaTek switch silicon vendor left the market around 2019. The p
 
 **Remove:** `platform/nephos/`; the `nephos` job in `.azure-pipelines/azure-pipelines-build.yml`.
 
-##### 7.1.5 GoBGP FPM container
+##### 7.1.5 GoBGP and Quagga routing stacks
 
-SONiC standardized on FRR, which is set by `SONIC_ROUTING_STACK = frr`. The GoBGP image build rules were deleted back in 2021, so it has not been buildable as an image since then. Even so, every build still compiles a 2017 era Go GOBGP package that nothing installs. Removing it loses nothing, because FRR already provides all of this.
+SONiC standardized on FRR, which is set by `SONIC_ROUTING_STACK = frr`. The GoBGP image build rules were deleted back in 2021, so it has not been buildable as an image since then. Even so, every build still compiles a 2017 era Go GOBGP package that nothing installs.
 
-**Remove:** `dockers/docker-fpm-gobgp/`, `src/gobgp/`, `rules/gobgp.mk`, and `rules/gobgp.dep`; the dead `DOCKER_FPM_GOBGP` and `DOCKER_FPM_QUAGGA` references in `rules/docker-fpm.mk` and `rules/docker-fpm.dep`; the gobgp dependency in the non-frr branch of `platform/vs/docker-sonic-vs.mk`.
+Quagga left even earlier, and it should go in the same change. Its container and build rules are already gone, but the CLI branches, the build glue, and the sudoers policy that referenced it were never cleaned up. Removing both loses nothing, because FRR already provides all of this. Once they are gone, `get_routing_stack()` has only one possible answer, so the routing-stack conditionals collapse to a single path.
+
+One Quagga-named file needs care rather than deletion. `clear/bgp_quagga_v4.py` is the live implementation of `clear ip bgp` under FRR, because the `frr` branch of `clear/main.py` imports it and there is no `clear/bgp_frr_v4.py`. Rename that file instead of removing it.
+
+**Remove (GoBGP):** `dockers/docker-fpm-gobgp/`, `src/gobgp/`, `rules/gobgp.mk`, and `rules/gobgp.dep`; the gobgp dependency in the non-frr branch of `platform/vs/docker-sonic-vs.mk`.
+**Remove (Quagga):** in sonic-utilities, `show/bgp_quagga_v4.py`, `show/bgp_quagga_v6.py`, and `clear/bgp_quagga_v6.py`, the `routing_stack == "quagga"` branches in `show/main.py` and `clear/main.py`, the non-frr `else` branches that carry the Quagga `bgp` and `zebra` groups in `debug/main.py` and `undebug/main.py`, the `/etc/quagga/bgpd.conf` branch of `show startupconfiguration bgp`, and the matching cases in `tests/show_test.py`, `tests/clear_test.py`, and `tests/debug_test.py`; the `docker exec bgp cat /etc/quagga/bgpd.conf` entry in `files/image_config/sudoers/sudoers`.
+**Remove (both):** the dead `DOCKER_FPM_GOBGP` and `DOCKER_FPM_QUAGGA` references in `rules/docker-fpm.mk` and `rules/docker-fpm.dep`, which leaves the routing-stack conditional with a single branch.
+**Rename:** `src/sonic-utilities/clear/bgp_quagga_v4.py` to `clear/bgp_frr_v4.py`, and update the import in `clear/main.py`.
+**Fix:** the stale `## Quagga rules` header in `files/image_config/rsyslog/rsyslog.d/00-sonic.conf.j2`, the `docker-fpm.gz` line in `README.md` that still describes the image as Quagga, and the "For quagga build" comments in `sonic-slave-bookworm/Dockerfile.j2` and `sonic-slave-trixie/Dockerfile.j2`. The packages under those comments, such as `libreadline-dev`, `libpam-dev`, and the texlive set, are FRR build dependencies now, so confirm what FRR needs before removing any of them.
 
 ##### 7.1.6 Python 2 packages
 
@@ -163,21 +173,25 @@ The supported path is `unified`, where the config comes from bgpcfgd and `config
 
 **Change:** remove the `separated` and `split` branches in `dockers/docker-fpm-frr/docker_init.sh` and the per-daemon templates under `dockers/docker-fpm-frr/frr/{bgpd,zebra,staticd,sharpd}/`; flip the default in `src/sonic-config-engine/minigraph.py` from `separated` to `unified`.
 
-##### 7.1.11 Old Debian build leftovers
+##### 7.1.11 End-of-life Debian bases
 
-Debian 8 (jessie), Debian 9 (stretch), and Debian 10 (buster) are all long past end of life. The risk is that someone builds a new container on a base that is more than six years old. Before deleting any base, confirm that nothing still builds a container on it. Bullseye is Debian 11, which is newer, and it is handled under Deprecate.
+Debian 8 (jessie), Debian 9 (stretch), Debian 10 (buster), and Debian 11 (bullseye) are all out of support. Bullseye leaves Debian LTS in August 2026, which is before 202611 ships, so it belongs with the rest rather than in a later cycle. The risk in every case is the same, which is that someone builds a new container on a base that no longer gets security updates.
+
+jessie, stretch, and buster are pure leftovers, because nothing builds on them. Bullseye is different, because containers still build on it today, so those have to move first. Before deleting any base, confirm that nothing still builds a container on it. Debian 12 (bookworm) is still a live base and is handled under Deprecate.
 
 **Remove (stretch):** `dockers/docker-base-stretch/`, `rules/docker-base-stretch.{mk,dep}`, `dockers/docker-config-engine-stretch/`, `rules/docker-config-engine-stretch.{mk,dep}`.
 **Remove (buster):** `dockers/docker-base-buster/`, `rules/docker-base-buster.{mk,dep}`, `dockers/docker-config-engine-buster/`, `rules/docker-config-engine-buster.{mk,dep}`, `dockers/docker-swss-layer-buster/`, `rules/docker-swss-layer-buster.{mk,dep}`.
 **Remove (jessie):** `sonic-slave-jessie/`, the `jessie` target in `Makefile`, and the jessie `SLAVE_DIR` branch in `Makefile.work`. jessie has no `docker-base-jessie`, so also check the jessie strings in the generic `dockers/docker-base/` (its armhf and arm64 sources and its `FROM ...:jessie` lines) before touching that container.
+**Move first (bullseye):** seven containers still build on a bullseye base. Two of them, `docker-syncd-bfn` and `docker-saiserver-bfn`, go away with Barefoot in 7.1.1. The other five have to move to bookworm or trixie before bullseye can go, and they are `docker-syncd-centec` and `docker-saiserver-centec` under both `platform/centec/` and `platform/centec-arm64/`, plus `dockers/docker-sonic-sdk/`. The centec containers reach bullseye through `platform/template/docker-syncd-bullseye.mk`, so pointing their `docker-syncd-centec.mk` at the bookworm or trixie template covers four of the five.
+**Remove (bullseye):** `dockers/docker-base-bullseye/`, `rules/docker-base-bullseye.{mk,dep}`, `dockers/docker-config-engine-bullseye/`, `rules/docker-config-engine-bullseye.{mk,dep}`, `dockers/docker-swss-layer-bullseye/`, `rules/docker-swss-layer-bullseye.{mk,dep}`, `platform/template/docker-syncd-bullseye.mk`, and `sonic-slave-bullseye/`; the `bullseye` target and the `NOBULLSEYE` and `BUILD_BULLSEYE` handling in `Makefile`, the bullseye `SLAVE_DIR` branch in `Makefile.work`, the `sonic-slave-bullseye` entry in `Makefile.cache`, and in `slave.mk` the `BULLSEYE_DEBS_PATH` and `BULLSEYE_FILES_PATH` variables, the `bullseye` target, and the `BLDENV` tests that name it; the `BLDENV == bullseye` conditionals in `rules/grpc.mk`, `rules/protobuf.mk`, `rules/sonic-dash-api.mk`, and `rules/sonic-fips.mk`.
 
 #### 7.2 Deprecate now, remove later
 
-##### 7.2.1 Bullseye base containers
+##### 7.2.1 Bookworm base containers
 
-This should be removed in 202705. Bullseye is Debian 11, which is newer than the bases above and may still be a live base for some containers. It deserves a cycle of notice. Move those containers to bookworm or trixie first, and then remove it.
+This should be removed in 202705. Bookworm is Debian 12. Its regular security support ends in 2026, which leaves LTS only, and trixie is the current base. It is still a live base, so it deserves a cycle of notice rather than immediate removal. Three syncd containers build on it, which are `docker-syncd-pensando`, `docker-syncd-vs` under `platform/alpinevs/`, and `docker-syncd-vs` under `platform/nokia-vs/`, and the last two reach it through `platform/template/docker-syncd-bookworm.mk`. Move those to trixie first, and then remove the base.
 
-**Remove (202705):** `dockers/docker-base-bullseye/`, `rules/docker-base-bullseye.{mk,dep}`, `dockers/docker-config-engine-bullseye/`, `rules/docker-config-engine-bullseye.{mk,dep}`, `dockers/docker-swss-layer-bullseye/`, `rules/docker-swss-layer-bullseye.{mk,dep}`.
+**Remove (202705):** `dockers/docker-base-bookworm/`, `rules/docker-base-bookworm.{mk,dep}`, `dockers/docker-config-engine-bookworm/`, `rules/docker-config-engine-bookworm.{mk,dep}`, `dockers/docker-swss-layer-bookworm/`, `rules/docker-swss-layer-bookworm.{mk,dep}`, `platform/template/docker-syncd-bookworm.mk`, and `sonic-slave-bookworm/`; the `bookworm` target and the `NOBOOKWORM` and `BUILD_BOOKWORM` handling in `Makefile`, and the bookworm `SLAVE_DIR` branch in `Makefile.work`.
 
 ##### 7.2.2 FRR split-unified config mode
 
@@ -197,6 +211,8 @@ Removing a feature drops its `FEATURE` table entries, its build flags, and any Y
 
 The FRR change removes `separated` and `split` from `docker_routing_config_mode` and makes `unified` the default. The platform removals do not affect other platforms.
 
+The Quagga cleanup does not change any command an operator runs, because the FRR branch of every affected command already provides the same CLI. `clear ip bgp` keeps working through the renamed `clear/bgp_frr_v4.py`. The one visible difference is `show startupconfiguration bgp`, which loses its `/etc/quagga/bgpd.conf` branch and reads only `/etc/frr/bgpd.conf`.
+
 ### 9. Warmboot/Fastboot impact
 
 There is no warmboot or fastboot impact. Every candidate is off by default, already dead, or specific to hardware that is being removed. None of this touches the warmboot or fastboot path on supported platforms.
@@ -206,7 +222,8 @@ There is no warmboot or fastboot impact. Every candidate is off by default, alre
 - Each supported CI platform still builds after the removals.
 - The removed packages no longer appear in the SBOM or the CVE scan, confirmed by an image diff.
 - The default FRR path (`unified`) comes up and programs routes.
-- Every remaining container builds with nothing pointing at a deleted base.
+- Every remaining container builds with nothing pointing at a deleted base, and the centec and sonic-sdk containers build on their new base.
+- `show ip bgp` and `clear ip bgp` still work after the Quagga cleanup and the `clear/bgp_frr_v4.py` rename.
 
 ### 11. Additional findings
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -99,7 +99,7 @@ Rules of thumb:
 
 | # | Candidate | Remove in | Why wait |
 |---|-----------|-----------|----------|
-| B1 | Kubernetes worker (`INCLUDE_KUBERNETES`) | 202711 | Off by default, but still patched upstream, so users may exist. Deprecate and see. **Keep the ctrmgrd wrapper — it is not k8s-only.** |
+| B1 | Kubernetes worker (`INCLUDE_KUBERNETES`) | 202711 | Off by default, not in CI, ancient pins. Recent commits are security fixes, not feature work — no real sign the worker feature is used. We just can't prove zero users, so deprecate with notice instead of removing now. Confirm with Microsoft. **Keep the ctrmgrd wrapper — it is not k8s-only.** |
 | B2 | Bullseye base containers (`docker-base-bullseye`, `docker-config-engine-bullseye`, `docker-swss-layer-bullseye`) | 202705 | Debian 11. May still be a live base for some containers. Move them to bookworm/trixie, then remove. |
 | B3 | FRR `split-unified` config mode (operator writes `frr.conf`) | 202705 | The manual mode. No hot reload — the bgp container runs supervisord, not systemd, so any `frr.conf` change forces a full FRR restart. Consolidate on `unified` (bgpcfgd + `config_db.json`). Confirm bgpcfgd/config_db covers the needed FRR features before removal. |
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -101,6 +101,7 @@ Rules of thumb:
 |---|-----------|-----------|----------|
 | B1 | Bullseye base containers (`docker-base-bullseye`, `docker-config-engine-bullseye`, `docker-swss-layer-bullseye`) | 202705 | Debian 11. May still be a live base for some containers. Move them to bookworm/trixie, then remove. |
 | B2 | FRR `split-unified` config mode (operator writes `frr.conf`) | 202705 | The manual mode. No hot reload — the bgp container runs supervisord, not systemd, so any `frr.conf` change forces a full FRR restart. Consolidate on `unified` (bgpcfgd + `config_db.json`). Confirm bgpcfgd/config_db covers the needed FRR features before removal. |
+| B3 | REST API (`docker-sonic-restapi`) | 202711 | Baremetal VNET config API. Off by default, superseded by gNMI. Gap: gNMI has no equal for its bulk-route (207 partial) or route-expiry semantics — see B3 note. Confirm no live consumer (Microsoft) before removal. |
 
 ### 8. Per-candidate detail
 
@@ -121,6 +122,8 @@ Short notes on the ones with real gaps or tricky scope.
 Catch: `minigraph.py` still hardcodes the default as `separated` (init_cfg doesn't set it, so it resolves to `separated` today). This change must flip the default to `unified`.
 
 **A10 — old Debian bases.** Two shapes. **stretch** and **buster** each have real `docker-base-*` / `docker-config-engine-*` / `docker-swss-layer-*` containers to delete. **jessie** does not — there is no `docker-base-jessie`. What's left of jessie is the `sonic-slave-jessie` build slave and its `make jessie` target (Debian 8), plus jessie strings in the generic `docker-base` (armhf/arm64 sources, `FROM ...:jessie`). Drop the jessie slave and its wiring; check the generic `docker-base` before touching it. Many other jessie strings sit in code we already remove (p4, nephos). Bullseye is not here — it's deprecated for later removal (B1).
+
+**B3 — REST API.** Not a general REST interface — its spec calls it the "SONiC REST API for Baremetal Scenarios." An imperative agent for Azure baremetal VNET/VXLAN/VLAN config over HTTPS. Off by default; gNMI is the go-forward. Two things gNMI does not replace: bulk route programming with per-route partial success (HTTP `207`), and route expiry (timed route aging). Deprecate now; before removal, confirm with Microsoft that no baremetal control plane still drives it. Note: the mgmt-framework REST server is a different thing and stays.
 
 ### 9. Config and management impact
 
@@ -145,7 +148,6 @@ None. Every candidate is off by default, dead, or platform-specific to hardware 
 
 Held back until an owner confirms. Not proposed here.
 
-- **REST API** (`docker-sonic-restapi`): baremetal VNET config API. gNMI does not cover its bulk-route (207 partial) and route-expiry semantics. Needs Microsoft to confirm no live consumer.
 - **PDE** (`docker-pde`): Broadcom bring-up tool. Confirm with Broadcom.
 - **clounix platform:** nearly inert but added under a year ago. Confirm intent with the vendor.
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -89,7 +89,7 @@ Rules of thumb:
 | A3 | Nephos platform (`platform/nephos`) | Vendor gone (~2019). No real commits in years. No device tree. | Cleanup is mostly the pipeline YAML. |
 | A4 | GoBGP FPM (`docker-fpm-gobgp`, `src/gobgp`, `rules/gobgp.*`) | Not buildable as an image since 2021, yet still compiles a 2017-era Go deb every build. FRR replaced it. | Drop the dead `DOCKER_FPM_GOBGP` / `DOCKER_FPM_QUAGGA` refs in `docker-fpm.*` too. |
 | A5 | Python 2 packages (`swsssdk-py2`, `redis-dump-load-py2`) | Gated off on bullseye/bookworm/trixie. Never built on any current release. | None. The py3 version is a separate case — see [13](#13-additional-findings). |
-| A6 | Kubernetes master (`INCLUDE_KUBERNETES_MASTER`) | Runs a full k8s control plane on a switch. All pins are years EOL (k8s 1.22, etcd 3.5.0, coredns 1.8.4, dashboard 2.7.0) plus Azure creds. Off, no real CI. | Biggest CVE win. Master only. The worker (`INCLUDE_KUBERNETES`) is a separate feature and **stays** — pre-WG security hardening on it points to a real (likely Microsoft) user. |
+| A6 | Kubernetes master (`INCLUDE_KUBERNETES_MASTER`) | Runs a full k8s control plane on a switch. All pins are years EOL (k8s 1.22, etcd 3.5.0, coredns 1.8.4, dashboard 2.7.0) plus cloud credential deps. Off, no real CI. | Biggest CVE win. Master only. The worker (`INCLUDE_KUBERNETES`) is a separate feature and **stays** — pre-WG security hardening on it points to a real user. |
 | A7 | `docker-basic_router` | Dead SAI demo container. Wired into no build. Never shipped. | Nothing uses it. |
 | A8 | System Telemetry (`docker-sonic-telemetry`) | Off by default. Redundant — the gnmi container runs the **same binary**. | Keep the `telemetry` binary (gnmi needs it). Remove the container + `INCLUDE_SYSTEM_TELEMETRY` flag. See A8 note. |
 | A9 | Broken FRR modes (`separated`, `split`) | Both write per-daemon FRR config files. FRR 10.5.4 (shipped) dropped support for those. They no longer work. | Default becomes `unified`. `minigraph.py` still hardcodes `separated` — flip it. See A9 note. |
@@ -101,7 +101,7 @@ Rules of thumb:
 |---|-----------|-----------|----------|
 | B1 | Bullseye base containers (`docker-base-bullseye`, `docker-config-engine-bullseye`, `docker-swss-layer-bullseye`) | 202705 | Debian 11. May still be a live base for some containers. Move them to bookworm/trixie, then remove. |
 | B2 | FRR `split-unified` config mode (operator writes `frr.conf`) | 202705 | The manual mode. No hot reload — the bgp container runs supervisord, not systemd, so any `frr.conf` change forces a full FRR restart. Consolidate on `unified` (bgpcfgd + `config_db.json`). Confirm bgpcfgd/config_db covers the needed FRR features before removal. |
-| B3 | REST API (`docker-sonic-restapi`) | 202711 | Baremetal VNET config API. Off by default, superseded by gNMI. Gap: gNMI has no equal for its bulk-route (207 partial) or route-expiry semantics — see B3 note. Confirm no live consumer (Microsoft) before removal. |
+| B3 | REST API (`docker-sonic-restapi`) | 202711 | Baremetal VNET config API. Off by default, superseded by gNMI. Gap: gNMI has no equal for its bulk-route (207 partial) or route-expiry semantics — see B3 note. Confirm no live consumer before removal. |
 
 ### 8. Per-candidate detail
 
@@ -123,7 +123,7 @@ Catch: `minigraph.py` still hardcodes the default as `separated` (init_cfg doesn
 
 **A10 — old Debian bases.** Two shapes. **stretch** and **buster** each have real `docker-base-*` / `docker-config-engine-*` / `docker-swss-layer-*` containers to delete. **jessie** does not — there is no `docker-base-jessie`. What's left of jessie is the `sonic-slave-jessie` build slave and its `make jessie` target (Debian 8), plus jessie strings in the generic `docker-base` (armhf/arm64 sources, `FROM ...:jessie`). Drop the jessie slave and its wiring; check the generic `docker-base` before touching it. Many other jessie strings sit in code we already remove (p4, nephos). Bullseye is not here — it's deprecated for later removal (B1).
 
-**B3 — REST API.** Not a general REST interface — its spec calls it the "SONiC REST API for Baremetal Scenarios." An imperative agent for Azure baremetal VNET/VXLAN/VLAN config over HTTPS. Off by default; gNMI is the go-forward. Two things gNMI does not replace: bulk route programming with per-route partial success (HTTP `207`), and route expiry (timed route aging). Deprecate now; before removal, confirm with Microsoft that no baremetal control plane still drives it. Note: the mgmt-framework REST server is a different thing and stays.
+**B3 — REST API.** Not a general REST interface — its spec calls it the "SONiC REST API for Baremetal Scenarios." An imperative agent for baremetal VNET/VXLAN/VLAN config over HTTPS. Off by default; gNMI is the go-forward. Two things gNMI does not replace: bulk route programming with per-route partial success (HTTP `207`), and route expiry (timed route aging). Deprecate now; before removal, confirm no baremetal control plane still drives it. Note: the mgmt-framework REST server is a different thing and stays.
 
 ### 9. Config and management impact
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -36,6 +36,7 @@
 |-----|------|--------|--------|
 | 0.1 | 2026-07-19 | Brad House (Nexthop) | First draft. Security WG. |
 | 0.2 | 2026-07-24 | Brad House (Nexthop) | Added the Keep verdict. Moved bullseye to immediate removal and deprecated bookworm in its place. Folded Quagga into the GoBGP removal. |
+| 0.3 | 2026-07-24 | Brad House (Nexthop) | Filled in the notification steps of the process, which are the mailing list, the working groups, the TSC for platform removals, and a second round before the branch date. |
 
 ### 2. Scope
 
@@ -59,6 +60,8 @@ Releases ship twice a year, in November (`YYYY11`) and in May (`YYYY05`). The cy
 | TAM | Telemetry and Monitoring (added in 202605). |
 | EOL | End of life. |
 | CI | The community build/test gate. |
+| TSC | Technical Steering Committee. |
+| WG | Working group. |
 
 ### 4. Overview
 
@@ -75,6 +78,8 @@ This HLD proposes a standing process to retire those features, along with the fi
 
 ### 6. Process
 
+This section is the boilerplate for the deprecation cycle itself. It is meant to carry forward unchanged into the plan for each following release, so that only the candidate list in section 7 changes from one cycle to the next.
+
 For each release:
 
 1. **Propose.** File or update this HLD with candidates. Each candidate states what it is, what replaces it, the gap in what you lose, and a verdict.
@@ -83,18 +88,27 @@ For each release:
    - **Deprecate now, remove later:** still has possible users or needs migration work. Name a removal release.
    - **Keep:** the feature stays. Review turned up real usage, a dependency another feature relies on, or a gap that the proposed replacement does not cover.
 3. **Review.** The community reviews it, and this HLD is scheduled at the weekly HLD review on Tuesdays. Component owners sign off. A feature is not removed without owner sign-off. Review can change a verdict in either direction, and moving a candidate to **Keep** is a normal outcome rather than a failure of the process. When that happens, record what the review turned up and why the feature stays, so that a later cycle does not have to rediscover it.
-4. **Announce.** Deprecations go in the release notes.
-5. **Remove** in the named release.
+4. **Take platform removals to the TSC.** Platforms are special, because a platform is somebody's hardware and the people who own it are not always the people who read HLDs. Every platform removal is proposed to the TSC in addition to the steps above, and the TSC can reject it. Owner sign-off does not substitute for that, and the TSC decision is what settles a platform removal.
+5. **Notify the mailing list.** After HLD review, send the proposal to `sonic-dev@lists.sonicfoundation.dev`. Not everyone with a stake attends HLD review, and the mailing list is how the rest of them find out while there is still time to object. Include the full candidate list, the verdict for each one, the named removal release, and a date by which responses are wanted.
+6. **Notify the interested working groups.** Send each candidate to the working group that owns the area it touches, where one exists. A working group knows its own users, so it is the fastest way to turn "we think nobody runs this" into a real answer. Reach the routing group for routing stack and FRR changes, the telemetry group for telemetry changes, the management group for management interface changes, and the platform and hardware groups for platform removals. Sending the same item to more than one group is fine and is better than missing one.
+7. **Notify again before the branch date.** Every notification above goes out a second time, no later than two months before the release branch is cut, and revised for whatever the first round turned up. Anyone who has since changed a verdict says so in that second round. This gives a user who missed the first notice a last chance to speak up while there is still time to revert a removal.
+8. **Announce.** Deprecations go in the release notes.
+9. **Remove** in the named release.
+
+The goal of steps 4 through 7 is to over-communicate. It costs little to send the same proposal to one more list or one more group, and it costs a great deal to remove something that a user turns out to depend on. Nobody should learn that a feature is gone from the release notes, or from their build breaking.
 
 A few rules of thumb guide the calls above:
 
 - "Not built by default" and "not in CI" are hints, not proof. We check real use before calling anything dead.
 - A forced bump, such as a libyang, base image, submodule pointer, or mass format change, does not count as maintenance.
 - If a replacement has a gap, we name it so users can speak up.
+- Silence is not consent on its own. It counts only after the notifications above have gone out twice and the second round has had time to draw a response.
 
 ### 7. Candidates for 202611
 
 Each candidate below stands on its own. It states what the feature is, why it should go, the paths to remove, and anything to watch out for.
+
+Three of these are platform removals, which are 7.1.1 Barefoot, 7.1.3 standalone P4, and 7.1.4 Nephos. Those go to the TSC under step 4 of the process, separately from the rest of this list.
 
 #### 7.1 Remove now
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -11,7 +11,6 @@
 - [7. Candidates for 202611](#7-candidates-for-202611)
   - [7.1 Remove now](#71-remove-now)
   - [7.2 Deprecate now, remove later](#72-deprecate-now-remove-later)
-  - [7.3 Looked at, keeping](#73-looked-at-keeping)
 - [8. Per-candidate detail](#8-per-candidate-detail)
 - [9. Config and management impact](#9-config-and-management-impact)
 - [10. Warmboot/Fastboot impact](#10-warmbootfastboot-impact)
@@ -102,15 +101,6 @@ Rules of thumb:
 | B1 | `swsssdk-py3` | 202705 | Still imported at runtime (`dualtor_neighbor_check.py`), and by `sonic-py-common` and the vpp container. Move them to `swsscommon` first. |
 | B2 | Kubernetes worker (`INCLUDE_KUBERNETES`) | 202711 | Off by default, but still patched upstream, so users may exist. Deprecate and see. **Keep the ctrmgrd wrapper — it is not k8s-only.** |
 | B3 | Bullseye base containers (`docker-base-bullseye`, `docker-config-engine-bullseye`, `docker-swss-layer-bullseye`) | 202705 | Debian 11. May still be a live base for some containers. Move them to bookworm/trixie, then remove. |
-
-#### 7.3 Looked at, keeping
-
-We checked these and are **not** proposing removal. Listed so reviewers know we looked.
-
-- **Live silicon vendors:** centec, centec-arm64, marvell-teralynx, pensando, nokia-vs. Out of CI does not mean unused — these have real HWSKUs or recent feature work.
-- **Real (if niche) users:** `docker-sonic-p4rt` (Google PINS), `docker-iccpd` (MCLAG), `docker-sonic-redfish` (new in 2026, aspeed BMC, in CI).
-- **Test-only, not image surface:** `docker-ptf`, `docker-ptf-sai`.
-- **p4lang toolchain** (`rules/p4lang.mk`): kept — DASH SAI and PTF depend on it.
 
 ### 8. Per-candidate detail
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -68,7 +68,7 @@ Per release:
 2. **Two verdicts:**
    - **Remove now** — dead, broken, or EOL with no real users. Delete this cycle.
    - **Deprecate now, remove later** — still has possible users or needs migration work. Name a removal release.
-3. **Review.** Component owners and the TSC sign off. A feature is not removed without owner sign-off.
+3. **Review.** The community reviews it. This HLD gets scheduled at the weekly HLD review (Tuesdays). Component owners sign off. A feature is not removed without owner sign-off.
 4. **Announce.** Deprecations go in the release notes.
 5. **Remove** in the named release.
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -10,12 +10,24 @@
 - [6. Process](#6-process)
 - [7. Candidates for 202611](#7-candidates-for-202611)
   - [7.1 Remove now](#71-remove-now)
+    - [Barefoot / Tofino platform (with DTEL)](#barefoot--tofino-platform-with-dtel)
+    - [Standalone P4 platform](#standalone-p4-platform)
+    - [Nephos platform](#nephos-platform)
+    - [GoBGP FPM container](#gobgp-fpm-container)
+    - [Python 2 packages](#python-2-packages)
+    - [Kubernetes master](#kubernetes-master)
+    - [docker-basic_router](#docker-basic_router)
+    - [System Telemetry container](#system-telemetry-container)
+    - [Broken FRR config modes](#broken-frr-config-modes)
+    - [Old Debian build leftovers](#old-debian-build-leftovers)
   - [7.2 Deprecate now, remove later](#72-deprecate-now-remove-later)
-- [8. Per-candidate detail](#8-per-candidate-detail)
-- [9. Config and management impact](#9-config-and-management-impact)
-- [10. Warmboot/Fastboot impact](#10-warmbootfastboot-impact)
-- [11. Testing](#11-testing)
-- [12. Additional findings](#12-additional-findings)
+    - [Bullseye base containers — remove in 202705](#bullseye-base-containers--remove-in-202705)
+    - [FRR split-unified config mode — remove in 202705](#frr-split-unified-config-mode--remove-in-202705)
+    - [REST API — remove in 202711](#rest-api--remove-in-202711)
+- [8. Config and management impact](#8-config-and-management-impact)
+- [9. Warmboot/Fastboot impact](#9-warmbootfastboot-impact)
+- [10. Testing](#10-testing)
+- [11. Additional findings](#11-additional-findings)
 
 ### 1. Revision
 
@@ -79,72 +91,103 @@ Rules of thumb:
 
 ### 7. Candidates for 202611
 
+Each candidate below stands on its own: what it is, why it goes, and anything to watch out for.
+
 #### 7.1 Remove now
 
-| # | Candidate | Why | Watch out for |
-|---|-----------|-----|---------------|
-| A1 | Barefoot / Tofino platform (`platform/barefoot`) + DTEL | Intel EOL'd Tofino. Not in CI. Untested. | DTEL rides along (only Tofino ran it). Also drop the stale `barefoot` job in the pipeline YAML. |
-| A2 | Standalone P4 platform (`platform/p4`) | Dead reference model since ~2022. In no CI. 12 MB, 923 files, 4 stale submodules. | Keep `rules/p4lang.mk` (bmv2/p4c/PI). DASH SAI and PTF still use it. |
-| A3 | Nephos platform (`platform/nephos`) | Vendor gone (~2019). No real commits in years. No device tree. | Cleanup is mostly the pipeline YAML. |
-| A4 | GoBGP FPM (`docker-fpm-gobgp`, `src/gobgp`, `rules/gobgp.*`) | Not buildable as an image since 2021, yet still compiles a 2017-era Go deb every build. FRR replaced it. | Drop the dead `DOCKER_FPM_GOBGP` / `DOCKER_FPM_QUAGGA` refs in `docker-fpm.*` too. |
-| A5 | Python 2 packages (`swsssdk-py2`, `redis-dump-load-py2`) | Gated off on bullseye/bookworm/trixie. Never built on any current release. | None. The py3 version is a separate case — see [12](#12-additional-findings). |
-| A6 | Kubernetes master (`INCLUDE_KUBERNETES_MASTER`) | Runs a full k8s control plane on a switch. All pins are years EOL (k8s 1.22, etcd 3.5.0, coredns 1.8.4, dashboard 2.7.0) plus cloud credential deps. Off, no real CI. | Biggest CVE win. Master only. The worker (`INCLUDE_KUBERNETES`) is a separate feature and **stays** — pre-WG security hardening on it points to a real user. |
-| A7 | `docker-basic_router` | Dead SAI demo container. Wired into no build. Never shipped. | Nothing uses it. |
-| A8 | System Telemetry (`docker-sonic-telemetry`) | Off by default. Redundant — the gnmi container runs the **same binary**. | Keep the `telemetry` binary (gnmi needs it). Remove the container + `INCLUDE_SYSTEM_TELEMETRY` flag. See A8 note. |
-| A9 | Broken FRR modes (`separated`, `split`) | Both write per-daemon FRR config files. FRR 10.5.4 (shipped) dropped support for those. They no longer work. | Default becomes `unified`. `minigraph.py` still hardcodes `separated` — flip it. See A9 note. |
-| A10 | Old Debian build leftovers (jessie, stretch, buster) | Debian 8, 9, and 10. All long EOL. Risk: someone builds on a 6+ year old base. | jessie and stretch/buster are different — see A10 note. Check nothing still `FROM`s a base before deleting. Bullseye is a separate case (B1). |
+##### Barefoot / Tofino platform (with DTEL)
+
+`platform/barefoot`. Intel ended the Tofino line, and the platform is absent from the CI build matrix (aspeed_arm64, broadcom, marvell-prestera, mellanox, nvidia_bluefield, vs, alpinevs, vpp) — so it is unbuilt and untested. It's about 7.7 MB / 880 files and pulls in the Barefoot SAI, saithrift, `docker-syncd-bfn`, `docker-saiserver-bfn`, and the ODM sub-platforms built on Tofino (Accton Wedge100BF, Arista 7170, Ingrasys, Netberg, WNC).
+
+Data-plane telemetry (DTEL, `dtelorch`) only ran on Tofino in practice, so it goes with the platform. TAM, added in 202605, covers the same need. Also delete the stale `barefoot` job still sitting in `azure-pipelines-build.yml`.
+
+##### Standalone P4 platform
+
+`platform/p4` — the old bmv2 software behavioral model (`docker-sonic-p4`, `sai-p4-bm`, `p4c-bm`, `tenjin`, `p4-hlir`). It's a reference target, not real hardware. Dead since around 2022, in no CI, about 12 MB / 920 files with 4 stale external submodules. The only thing referencing it outside `platform/p4/` is a Debian-8-era TODO in `rules/redis.mk`.
+
+Remove `platform/p4/*`, its submodules, and that TODO. Leave `rules/p4lang.mk` alone — the p4lang toolchain (bmv2/p4c/PI) it builds is a live dependency of DASH SAI, which ships in `sonic-vs.img.gz`, and of the PTF test containers.
+
+##### Nephos platform
+
+`platform/nephos`. The Nephos/MediaTek silicon vendor left the market around 2019. About 2.3 MB / 160 files (`docker-syncd-nephos`, SAI, saithrift, ODM modules). There's no `device/nephos` tree, no genuine commit in years, and it isn't in CI. Cleanup is mostly its `azure-pipelines-build.yml` entry.
+
+##### GoBGP FPM container
+
+`docker-fpm-gobgp`, `src/gobgp`, `rules/gobgp.*`. SONiC standardized on FRR (`SONIC_ROUTING_STACK = frr`). The gobgp image-build rules were deleted back in 2021, so it hasn't been buildable as an image since — yet the build still compiles a 2017-vintage Go GOBGP `.deb` that nothing installs.
+
+Remove the container, `src/gobgp`, the `rules/gobgp.*` recipes, and the dead `DOCKER_FPM_GOBGP` and `DOCKER_FPM_QUAGGA` references in `rules/docker-fpm.*`. Nothing is lost — FRR does all of this.
+
+##### Python 2 packages
+
+`swsssdk-py2` and `redis-dump-load-py2`. Both are gated behind `ENABLE_PY2_MODULES`, which is off for bullseye, bookworm, and trixie — so neither is built on any current release. Pure dead weight. (The py3 version of swsssdk is a different case — it's still in use, so it's out of scope here and noted under Additional findings.)
+
+##### Kubernetes master
+
+`INCLUDE_KUBERNETES_MASTER`. This runs a full Kubernetes control plane on the switch — apiserver, controller, scheduler, proxy, etcd 3.5.0, coredns 1.8.4, and the dashboard 2.7.0 web UI — plus cloud credential libraries for backups. Every one of those is years past end of life, so this is the single biggest CVE-surface win in the list. It's off by default and has no real CI.
+
+This is master only. The worker feature (`INCLUDE_KUBERNETES`) is separate and stays — someone hardened its cluster-join security before this WG existed, which points to a real user. Removing master also drops `sonic-kubernetes_master.yang`. Leave the `ctrmgrd` container wrapper alone; it runs for ordinary feature start/stop, not just k8s.
+
+##### docker-basic_router
+
+A SAI demo/reference container. It's wired into no build rule, never ships in an image, and isn't in CI. Its last real change was 2020. Nothing uses it — straight delete.
+
+##### System Telemetry container
+
+`docker-sonic-telemetry`, off by default. It's redundant: this container and the gnmi container run the exact same binary, `/usr/sbin/telemetry` (started by `telemetry.sh` and `gnmi-native.sh` respectively). There is no separate gNMI server — the `telemetry` binary *is* the server; the name is just historical. Both read the same `TELEMETRY|gnmi` config, and the gnmi start script only adds ZMQ and VRF options on top. So there is no functional gap: Get/Set/Subscribe and dial-out are identical.
+
+Remove the container and the `INCLUDE_SYSTEM_TELEMETRY` flag. Keep the `telemetry` binary — the gnmi container runs it.
+
+##### Broken FRR config modes
+
+`docker_routing_config_mode` has four values. `separated` and `split` write per-daemon config files (`bgpd.conf`, `zebra.conf`, and so on). FRR 10.5.4, which SONiC ships, dropped support for per-daemon config files — so both of these modes are broken today. This is really dead-code removal.
+
+The supported path is `unified`, where config comes from bgpcfgd and `config_db.json`; make that the default. Right now `minigraph.py` hardcodes the default as `separated` (and init_cfg doesn't set it, so it resolves to `separated`), so this change must flip that default to `unified`. The fourth mode, `split-unified`, still works and is handled under Deprecate.
+
+##### Old Debian build leftovers
+
+Debian 8 (jessie), 9 (stretch), and 10 (buster) are all long past end of life. The risk is someone building a new container on a 6+-year-old base.
+
+stretch and buster each have real `docker-base-*`, `docker-config-engine-*`, and `docker-swss-layer-*` containers to delete. jessie is different — there's no `docker-base-jessie`. What's left of jessie is the `sonic-slave-jessie` build slave and its `make jessie` target, plus jessie strings in the generic `docker-base` (armhf/arm64 sources and `FROM ...:jessie`); drop the slave and its wiring, and check the generic `docker-base` before touching it.
+
+Before deleting any base, confirm nothing still bases a container on it. Bullseye (Debian 11) is newer and handled under Deprecate.
 
 #### 7.2 Deprecate now, remove later
 
-| # | Candidate | Remove in | Why wait |
-|---|-----------|-----------|----------|
-| B1 | Bullseye base containers (`docker-base-bullseye`, `docker-config-engine-bullseye`, `docker-swss-layer-bullseye`) | 202705 | Debian 11. May still be a live base for some containers. Move them to bookworm/trixie, then remove. |
-| B2 | FRR `split-unified` config mode (operator writes `frr.conf`) | 202705 | The manual mode. No hot reload — the bgp container runs supervisord, not systemd, so any `frr.conf` change forces a full FRR restart. Consolidate on `unified` (bgpcfgd + `config_db.json`). Confirm bgpcfgd/config_db covers the needed FRR features before removal. |
-| B3 | REST API (`docker-sonic-restapi`) | 202711 | Baremetal VNET config API. Off by default, superseded by gNMI. Gap: gNMI has no equal for its bulk-route (207 partial) or route-expiry semantics — see B3 note. Confirm no live consumer before removal. |
+##### Bullseye base containers — remove in 202705
 
-### 8. Per-candidate detail
+`docker-base-bullseye`, `docker-config-engine-bullseye`, `docker-swss-layer-bullseye` (Debian 11). Newer than the bases above, and may still be a live base for some containers, so give it a cycle: move those containers to bookworm/trixie, then remove the bullseye bases in 202705.
 
-Short notes on the ones with real gaps or tricky scope.
+##### FRR split-unified config mode — remove in 202705
 
-**A1 — Barefoot / DTEL.** Tofino is EOL. The platform is absent from the CI build matrix (aspeed_arm64, broadcom, marvell-prestera, mellanox, nvidia_bluefield, vs, alpinevs, vpp) — so it is unbuilt and untested. A stale `barefoot` job still sits in `azure-pipelines-build.yml` and should go too. DTEL (`dtelorch`) only ran on Tofino in practice, and TAM (202605) covers the same use case, so DTEL goes with it.
+The manual routing mode, where the operator writes `frr.conf` by hand. It has a real problem: the bgp container runs supervisord, not systemd, so FRR can't hot-reload — any `frr.conf` change forces a full FRR restart, which drops BGP sessions. That makes it impractical for production, so it's doubtful anyone serious runs it.
 
-**A2 — P4 platform.** This is the old bmv2 software switch (`docker-sonic-p4`, `sai-p4-bm`, `p4c-bm`, `tenjin`, `p4-hlir`), not the p4lang toolchain. The only reference outside `platform/p4/` is a stale Debian-8 TODO in `rules/redis.mk`. Remove `platform/p4/*`, its 4 submodules, and that TODO. **Do not touch `rules/p4lang.mk`** — DASH SAI (in `sonic-vs.img.gz` via `INCLUDE_VS_DASH_SAI`) and the PTF containers still need bmv2/p4c/PI.
+Deprecate now and consolidate on `unified` (bgpcfgd + `config_db.json`). Before removing, confirm bgpcfgd and `config_db.json` cover the FRR features operators actually need.
 
-**A8 — System Telemetry.** Confirmed: both containers exec the **same binary**, `/usr/sbin/telemetry` (telemetry `telemetry.sh:168`, gnmi `gnmi-native.sh:155`). There is no separate gNMI server — the `telemetry` binary *is* the server; the name is legacy. Both read the same `TELEMETRY|gnmi` config; the gnmi start script just adds ZMQ and VRF args. So parity is exact, not approximate — full Get/Set/Subscribe and dial-out. No gap. The `telemetry` binary stays (gnmi runs it); we drop the redundant container and the `INCLUDE_SYSTEM_TELEMETRY` flag.
+##### REST API — remove in 202711
 
-**A9 — FRR modes.** `docker_routing_config_mode` has four values:
+`docker-sonic-restapi`, off by default. Its own spec calls it the "SONiC REST API for Baremetal Scenarios" — an imperative agent for baremetal VNET/VXLAN/VLAN config over HTTPS, not a general REST interface. gNMI is the go-forward, but two things gNMI doesn't cover: bulk route programming with per-route partial success (HTTP 207), and route expiry (timed route aging).
 
-- `separated`, `split` — write per-daemon config files (`bgpd.conf`, `zebra.conf`, ...). FRR 10.5 dropped per-daemon config files, so both are broken. **Remove.**
-- `unified` — config comes from bgpcfgd and `config_db.json`. The supported path. **Keep, make it the default.**
-- `split-unified` — the operator writes `frr.conf` by hand. **Deprecate (B2).** No hot reload (supervisord, not systemd), so any change forces a full FRR restart — impractical for production.
+Because of that gap, give it the longest runway. Before removing, confirm no control plane still drives it. The mgmt-framework REST server is a different thing and stays.
 
-Catch: `minigraph.py` still hardcodes the default as `separated` (init_cfg doesn't set it, so it resolves to `separated` today). This change must flip the default to `unified`.
+### 8. Config and management impact
 
-**A10 — old Debian bases.** Two cases here. **stretch** and **buster** each have real `docker-base-*` / `docker-config-engine-*` / `docker-swss-layer-*` containers to delete. **jessie** does not — there is no `docker-base-jessie`. What's left of jessie is the `sonic-slave-jessie` build slave and its `make jessie` target (Debian 8), plus jessie strings in the generic `docker-base` (armhf/arm64 sources, `FROM ...:jessie`). Drop the jessie slave and its wiring; check the generic `docker-base` before touching it. Many other jessie strings sit in code we already remove (p4, nephos). Bullseye is not here — it's deprecated for later removal (B1).
+Removing a feature drops its `FEATURE` table entries, build flags, and any YANG models tied to it (for example `sonic-kubernetes_master.yang`). Users who never enabled these see no CLI change.
 
-**B3 — REST API.** Not a general REST interface — its spec calls it the "SONiC REST API for Baremetal Scenarios." An imperative agent for baremetal VNET/VXLAN/VLAN config over HTTPS. Off by default; gNMI is the go-forward. Two things gNMI does not replace: bulk route programming with per-route partial success (HTTP `207`), and route expiry (timed route aging). Deprecate now; before removal, confirm no baremetal control plane still drives it. Note: the mgmt-framework REST server is a different thing and stays.
+The FRR change removes `separated` and `split` from `docker_routing_config_mode` and makes `unified` the default. Platform removals don't affect other platforms.
 
-### 9. Config and management impact
+### 9. Warmboot/Fastboot impact
 
-- **A6 / A8:** these are feature containers. Removing them drops their `FEATURE` table entries and build flags. No CLI change for users who never turned them on.
-- **A9 / B2:** drops the two broken modes (`separated`, `split`) and makes `unified` (bgpcfgd + `config_db.json`) the default (also flip the `minigraph.py` default). `split-unified` (the manual, hand-written `frr.conf` mode) is deprecated and removed later, leaving `unified` as the only mode.
-- **A2 / A3 / A1:** platform removals. No effect on other platforms.
-- No YANG changes beyond dropping models for removed features (e.g. `sonic-kubernetes_master.yang` with A6).
+None. Every candidate is off by default, dead, or specific to hardware being removed. Nothing here touches the warmboot/fastboot path on supported platforms.
 
-### 10. Warmboot/Fastboot impact
+### 10. Testing
 
-None. Every candidate is off by default, dead, or platform-specific to hardware being removed. Removing them does not touch the warmboot/fastboot path for supported platforms.
+- Each supported CI platform still builds after the removals.
+- Removed packages are gone from the SBOM and CVE scan (image diff).
+- The default FRR path (`unified`) comes up and programs routes.
+- All remaining containers build with nothing pointing at a deleted base.
 
-### 11. Testing
+### 11. Additional findings
 
-- **Build:** each supported CI platform still builds after removal.
-- **Image diff:** confirm removed packages are gone from the SBOM and CVE scan.
-- **A8:** gnmi container still serves Get/Set/Subscribe and dial-out.
-- **A9:** default FRR path still comes up and programs routes.
-- **A10:** all remaining containers build with nothing pointing at the deleted bases.
+Real, but out of scope here — removing them needs code porting, which this HLD doesn't cover. Noted so they're tracked.
 
-### 12. Additional findings
-
-Real, but out of scope here. Removing them needs code porting, which this HLD does not cover. Noted so they are tracked.
-
-- **`swsssdk-py3`.** The old Python Redis SDK. `swsscommon` replaces it, but code still imports `swsssdk` at runtime (`sonic-utilities/scripts/dualtor_neighbor_check.py`, `sonic-py-common`, the vpp container). Can't deprecate until those are ported to `swsscommon`. (Its py2 twin is a clean remove — A5.)
+- **swsssdk-py3.** The old Python Redis SDK. `swsscommon` replaces it, but code still imports `swsssdk` at runtime (`sonic-utilities/scripts/dualtor_neighbor_check.py`, `sonic-py-common`, the vpp container). It can't be deprecated until those are ported to `swsscommon`.

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -16,6 +16,7 @@
 - [10. Warmboot/Fastboot impact](#10-warmbootfastboot-impact)
 - [11. Testing](#11-testing)
 - [12. Open items](#12-open-items)
+- [13. Additional findings](#13-additional-findings)
 
 ### 1. Revision
 
@@ -87,20 +88,20 @@ Rules of thumb:
 | A2 | Standalone P4 platform (`platform/p4`) | Dead reference model since ~2022. In no CI. 12 MB, 923 files, 4 stale submodules. | Keep `rules/p4lang.mk` (bmv2/p4c/PI). DASH SAI and PTF still use it. |
 | A3 | Nephos platform (`platform/nephos`) | Vendor gone (~2019). No real commits in years. No device tree. | Cleanup is mostly the pipeline YAML. |
 | A4 | GoBGP FPM (`docker-fpm-gobgp`, `src/gobgp`, `rules/gobgp.*`) | Not buildable as an image since 2021, yet still compiles a 2017-era Go deb every build. FRR replaced it. | Drop the dead `DOCKER_FPM_GOBGP` / `DOCKER_FPM_QUAGGA` refs in `docker-fpm.*` too. |
-| A5 | Python 2 packages (`swsssdk-py2`, `redis-dump-load-py2`) | Gated off on bullseye/bookworm/trixie. Never built on any current release. | None. Py3 versions stay (see B1). |
-| A6 | Kubernetes master (`INCLUDE_KUBERNETES_MASTER`) | Runs a full k8s control plane on a switch. All pins are years EOL (k8s 1.22, etcd 3.5.0, coredns 1.8.4, dashboard 2.7.0) plus Azure creds. Off, no real CI. | Biggest CVE win. Master only — worker is separate (see B2). |
+| A5 | Python 2 packages (`swsssdk-py2`, `redis-dump-load-py2`) | Gated off on bullseye/bookworm/trixie. Never built on any current release. | None. The py3 version is a separate case — see [13](#13-additional-findings). |
+| A6 | Kubernetes master (`INCLUDE_KUBERNETES_MASTER`) | Runs a full k8s control plane on a switch. All pins are years EOL (k8s 1.22, etcd 3.5.0, coredns 1.8.4, dashboard 2.7.0) plus Azure creds. Off, no real CI. | Biggest CVE win. Master only — worker is separate (see B1). |
 | A7 | `docker-basic_router` | Dead SAI demo container. Wired into no build. Never shipped. | Nothing uses it. |
 | A8 | System Telemetry (`docker-sonic-telemetry`) | Off by default. Redundant — the gnmi container runs the **same binary**. | Keep the `telemetry` binary (gnmi needs it). Remove the container + `INCLUDE_SYSTEM_TELEMETRY` flag. See A8 note. |
 | A9 | Broken FRR modes (`separated`, `split`) | Both write per-daemon FRR config files. FRR 10.5.4 (shipped) dropped support for those. They no longer work. | Default becomes `unified`. `minigraph.py` still hardcodes `separated` — flip it. See A9 note. |
-| A10 | Old Debian build leftovers (jessie, stretch, buster) | Debian 8, 9, and 10. All long EOL. Risk: someone builds on a 6+ year old base. | jessie and stretch/buster are different shapes — see A10 note. Check nothing still `FROM`s a base before deleting. Bullseye is a separate case (B3). |
+| A10 | Old Debian build leftovers (jessie, stretch, buster) | Debian 8, 9, and 10. All long EOL. Risk: someone builds on a 6+ year old base. | jessie and stretch/buster are different shapes — see A10 note. Check nothing still `FROM`s a base before deleting. Bullseye is a separate case (B2). |
 
 #### 7.2 Deprecate now, remove later
 
 | # | Candidate | Remove in | Why wait |
 |---|-----------|-----------|----------|
-| B1 | `swsssdk-py3` | 202705 | Still imported at runtime (`dualtor_neighbor_check.py`), and by `sonic-py-common` and the vpp container. Move them to `swsscommon` first. |
-| B2 | Kubernetes worker (`INCLUDE_KUBERNETES`) | 202711 | Off by default, but still patched upstream, so users may exist. Deprecate and see. **Keep the ctrmgrd wrapper — it is not k8s-only.** |
-| B3 | Bullseye base containers (`docker-base-bullseye`, `docker-config-engine-bullseye`, `docker-swss-layer-bullseye`) | 202705 | Debian 11. May still be a live base for some containers. Move them to bookworm/trixie, then remove. |
+| B1 | Kubernetes worker (`INCLUDE_KUBERNETES`) | 202711 | Off by default, but still patched upstream, so users may exist. Deprecate and see. **Keep the ctrmgrd wrapper — it is not k8s-only.** |
+| B2 | Bullseye base containers (`docker-base-bullseye`, `docker-config-engine-bullseye`, `docker-swss-layer-bullseye`) | 202705 | Debian 11. May still be a live base for some containers. Move them to bookworm/trixie, then remove. |
+| B3 | FRR `split-unified` config mode (operator writes `frr.conf`) | 202711 | The manual mode. No hot reload — the bgp container runs supervisord, not systemd, so any `frr.conf` change forces a full FRR restart. Consolidate on `unified` (bgpcfgd + `config_db.json`). Confirm bgpcfgd/config_db covers the needed FRR features before removal. |
 
 ### 8. Per-candidate detail
 
@@ -112,16 +113,20 @@ Short notes on the ones with real gaps or tricky scope.
 
 **A8 — System Telemetry.** Confirmed: both containers exec the **same binary**, `/usr/sbin/telemetry` (telemetry `telemetry.sh:168`, gnmi `gnmi-native.sh:155`). There is no separate gNMI server — the `telemetry` binary *is* the server; the name is legacy. Both read the same `TELEMETRY|gnmi` config; the gnmi start script just adds ZMQ and VRF args. So parity is exact, not approximate — full Get/Set/Subscribe and dial-out. No gap. The `telemetry` binary stays (gnmi runs it); we drop the redundant container and the `INCLUDE_SYSTEM_TELEMETRY` flag.
 
-**A9 — FRR modes.** `docker_init.sh` has four modes. `separated` and `split` write per-daemon files (`bgpd.conf`, `zebra.conf`, ...). FRR 10.5 no longer reads those, so both are broken. Keep the unified path — one `frr.conf`, `service integrated-vtysh-config`. The default becomes `unified`. Catch: `minigraph.py` still hardcodes the default as `separated`, and init_cfg doesn't set it, so today it resolves to `separated`. This change must flip that default to `unified`. So: drop two dead modes, plus a default flip.
+**A9 — FRR modes.** `docker_routing_config_mode` has four values:
 
-**A10 — old Debian bases.** Two shapes. **stretch** and **buster** each have real `docker-base-*` / `docker-config-engine-*` / `docker-swss-layer-*` containers to delete. **jessie** does not — there is no `docker-base-jessie`. What's left of jessie is the `sonic-slave-jessie` build slave and its `make jessie` target (Debian 8), plus jessie strings in the generic `docker-base` (armhf/arm64 sources, `FROM ...:jessie`). Drop the jessie slave and its wiring; check the generic `docker-base` before touching it. Many other jessie strings sit in code we already remove (p4, nephos). Bullseye is not here — it's deprecated for later removal (B3).
+- `separated`, `split` — write per-daemon config files (`bgpd.conf`, `zebra.conf`, ...). FRR 10.5 dropped per-daemon config files, so both are broken. **Remove.**
+- `unified` — config comes from bgpcfgd and `config_db.json`. The supported path. **Keep, make it the default.**
+- `split-unified` — the operator writes `frr.conf` by hand. **Deprecate (B3).** No hot reload (supervisord, not systemd), so any change forces a full FRR restart — impractical for production.
 
-**B1 — swsssdk-py3.** Looks dead but isn't. `swsscommon` replaces it, but real code still imports `swsssdk` at runtime. Migrate those, then drop the wheel.
+Catch: `minigraph.py` still hardcodes the default as `separated` (init_cfg doesn't set it, so it resolves to `separated` today). This change must flip the default to `unified`.
+
+**A10 — old Debian bases.** Two shapes. **stretch** and **buster** each have real `docker-base-*` / `docker-config-engine-*` / `docker-swss-layer-*` containers to delete. **jessie** does not — there is no `docker-base-jessie`. What's left of jessie is the `sonic-slave-jessie` build slave and its `make jessie` target (Debian 8), plus jessie strings in the generic `docker-base` (armhf/arm64 sources, `FROM ...:jessie`). Drop the jessie slave and its wiring; check the generic `docker-base` before touching it. Many other jessie strings sit in code we already remove (p4, nephos). Bullseye is not here — it's deprecated for later removal (B2).
 
 ### 9. Config and management impact
 
-- **A6 / A8 / B2:** these are feature containers. Removing them drops their `FEATURE` table entries and build flags. No CLI change for users who never turned them on.
-- **A9:** drops `separated` and `split` from `docker_routing_config_mode`. Default becomes `unified` (also flip the `minigraph.py` default).
+- **A6 / A8 / B1:** these are feature containers. Removing them drops their `FEATURE` table entries and build flags. No CLI change for users who never turned them on.
+- **A9 / B3:** drops the two broken modes (`separated`, `split`) and makes `unified` (bgpcfgd + `config_db.json`) the default (also flip the `minigraph.py` default). `split-unified` (the manual, hand-written `frr.conf` mode) is deprecated and removed later, leaving `unified` as the only mode.
 - **A2 / A3 / A1:** platform removals. No effect on other platforms.
 - No YANG changes beyond dropping models for removed features (e.g. `sonic-kubernetes_master.yang` with A6).
 
@@ -135,7 +140,6 @@ None. Every candidate is off by default, dead, or platform-specific to hardware 
 - **Image diff:** confirm removed packages are gone from the SBOM and CVE scan.
 - **A8:** gnmi container still serves Get/Set/Subscribe and dial-out.
 - **A9:** default FRR path still comes up and programs routes.
-- **B1:** `dualtor_neighbor_check` and `sonic-py-common` work on `swsscommon`.
 - **A10:** all remaining containers build with nothing pointing at the deleted bases.
 
 ### 12. Open items
@@ -146,3 +150,9 @@ Held back until an owner confirms. Not proposed here.
 - **Kubernetes worker owner check:** confirm the user base before setting a firm removal date.
 - **PDE** (`docker-pde`): Broadcom bring-up tool. Confirm with Broadcom.
 - **clounix platform:** nearly inert but added under a year ago. Confirm intent with the vendor.
+
+### 13. Additional findings
+
+Real, but out of scope here. Removing them needs code porting, which this HLD does not cover. Noted so they are tracked.
+
+- **`swsssdk-py3`.** The old Python Redis SDK. `swsscommon` replaces it, but code still imports `swsssdk` at runtime (`sonic-utilities/scripts/dualtor_neighbor_check.py`, `sonic-py-common`, the vpp container). Can't deprecate until those are ported to `swsscommon`. (Its py2 twin is a clean remove — A5.)

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -1,0 +1,158 @@
+# SONiC EOL & Deprecation Plan — 202611
+
+## Table of Content
+
+- [1. Revision](#1-revision)
+- [2. Scope](#2-scope)
+- [3. Definitions/Abbreviations](#3-definitionsabbreviations)
+- [4. Overview](#4-overview)
+- [5. Why remove code](#5-why-remove-code)
+- [6. Process](#6-process)
+- [7. Candidates for 202611](#7-candidates-for-202611)
+  - [7.1 Remove now](#71-remove-now)
+  - [7.2 Deprecate now, remove later](#72-deprecate-now-remove-later)
+  - [7.3 Looked at, keeping](#73-looked-at-keeping)
+- [8. Per-candidate detail](#8-per-candidate-detail)
+- [9. Config and management impact](#9-config-and-management-impact)
+- [10. Warmboot/Fastboot impact](#10-warmbootfastboot-impact)
+- [11. Testing](#11-testing)
+- [12. Open items](#12-open-items)
+
+### 1. Revision
+
+| Rev | Date | Author | Change |
+|-----|------|--------|--------|
+| 0.1 | 2026-07-19 | Brad House (Nexthop) | First draft. Security WG. |
+
+### 2. Scope
+
+This HLD does two things:
+
+1. Sets up a repeatable, per-release process to deprecate and remove SONiC features.
+2. Lists the features we propose to act on in **202611**.
+
+It comes out of the SONiC Security Working Group. Goal: shrink the attack surface. Less code means fewer packages, fewer CVEs, less to build and test.
+
+Releases ship twice a year: **November (`YYYY11`)** and **May (`YYYY05`)**. So the cycles here are 202611 (Nov 2026), 202705 (May 2027), 202711 (Nov 2027).
+
+### 3. Definitions/Abbreviations
+
+| Term | Meaning |
+|------|---------|
+| Deprecate | Mark a feature as going away. Still ships, but warns of removal. |
+| Remove | Delete the code and its build wiring. |
+| SBOM | Software Bill of Materials. |
+| DTEL | Data-plane telemetry (in-band / INT). |
+| TAM | Telemetry and Monitoring (added in 202605). |
+| EOL | End of life. |
+| CI | The community build/test gate. |
+
+### 4. Overview
+
+SONiC still ships features that few or no one runs. Some are dead. Some broke when a dependency moved on. Some were tied to hardware that no longer exists. Each one still adds packages to the image, findings to every CVE scan, and jobs to CI.
+
+This HLD proposes a standing process to retire such features, plus the first batch to act on.
+
+### 5. Why remove code
+
+- The best fix for a CVE is to delete the code that carries it.
+- Unmaintained code is a standing risk. It rarely gets patched.
+- Dead build wiring hides real problems and slows builds.
+- Fewer features = smaller image, fewer scans to triage, less CI.
+
+### 6. Process
+
+Per release:
+
+1. **Propose.** File (or update) this HLD with candidates. Each candidate says what it is, what replaces it, the gap (what you lose), and a verdict.
+2. **Two verdicts:**
+   - **Remove now** — dead, broken, or EOL with no real users. Delete this cycle.
+   - **Deprecate now, remove later** — still has possible users or needs migration work. Name a removal release.
+3. **Review.** Component owners and the TSC sign off. A feature is not removed without owner sign-off.
+4. **Announce.** Deprecations go in the release notes.
+5. **Remove** in the named release.
+
+Rules of thumb:
+
+- "Not built by default" and "not in CI" are **hints**, not proof. We check real use before we call anything dead.
+- A forced bump (libyang, base image, submodule pointer, mass format) does **not** count as maintenance.
+- If a replacement has a gap, we name it so users can speak up.
+
+### 7. Candidates for 202611
+
+#### 7.1 Remove now
+
+| # | Candidate | Why | Watch out for |
+|---|-----------|-----|---------------|
+| A1 | Barefoot / Tofino platform (`platform/barefoot`) + DTEL | Intel EOL'd Tofino. Not in CI. Untested. | DTEL rides along (only Tofino ran it). Also drop the stale `barefoot` job in the pipeline YAML. |
+| A2 | Standalone P4 platform (`platform/p4`) | Dead reference model since ~2022. In no CI. 12 MB, 923 files, 4 stale submodules. | Keep `rules/p4lang.mk` (bmv2/p4c/PI). DASH SAI and PTF still use it. |
+| A3 | Nephos platform (`platform/nephos`) | Vendor gone (~2019). No real commits in years. No device tree. | Cleanup is mostly the pipeline YAML. |
+| A4 | GoBGP FPM (`docker-fpm-gobgp`, `src/gobgp`, `rules/gobgp.*`) | Not buildable as an image since 2021, yet still compiles a 2017-era Go deb every build. FRR replaced it. | Drop the dead `DOCKER_FPM_GOBGP` / `DOCKER_FPM_QUAGGA` refs in `docker-fpm.*` too. |
+| A5 | Python 2 packages (`swsssdk-py2`, `redis-dump-load-py2`) | Gated off on bullseye/bookworm/trixie. Never built on any current release. | None. Py3 versions stay (see B1). |
+| A6 | Kubernetes master (`INCLUDE_KUBERNETES_MASTER`) | Runs a full k8s control plane on a switch. All pins are years EOL (k8s 1.22, etcd 3.5.0, coredns 1.8.4, dashboard 2.7.0) plus Azure creds. Off, no real CI. | Biggest CVE win. Master only — worker is separate (see B2). |
+| A7 | `docker-basic_router` | Dead SAI demo container. Wired into no build. Never shipped. | Nothing uses it. |
+| A8 | System Telemetry (`docker-sonic-telemetry`) | Off by default. The gnmi container reads the **same** config and does more. Already the default. | Confirm `gnmi_server` matches on Get/Set/Subscribe. Stop building the old `telemetry` binary too. |
+| A9 | Broken FRR modes (`separated`, `split`) | Both write per-daemon FRR config files. FRR 10.5.4 (shipped) dropped support for those. They no longer work. | Which mode becomes the default is an open item — see [12](#12-open-items). |
+| A10 | Old Debian build leftovers (jessie, stretch, buster) | jessie = Debian 8, stretch/buster = Debian 9/10. All long EOL. Risk: someone builds on a 6+ year old base. | jessie and stretch/buster are different shapes — see A10 note. Check nothing still `FROM`s a base before deleting. Bullseye stays for now. |
+
+#### 7.2 Deprecate now, remove later
+
+| # | Candidate | Remove in | Why wait |
+|---|-----------|-----------|----------|
+| B1 | `swsssdk-py3` | 202705 | Still imported at runtime (`dualtor_neighbor_check.py`), and by `sonic-py-common` and the vpp container. Move them to `swsscommon` first. |
+| B2 | Kubernetes worker (`INCLUDE_KUBERNETES`) | 202711 | Off by default, but still patched upstream, so users may exist. Deprecate and see. **Keep the ctrmgrd wrapper — it is not k8s-only.** |
+
+#### 7.3 Looked at, keeping
+
+We checked these and are **not** proposing removal. Listed so reviewers know we looked.
+
+- **Live silicon vendors:** centec, centec-arm64, marvell-teralynx, pensando, nokia-vs. Out of CI does not mean unused — these have real HWSKUs or recent feature work.
+- **Real (if niche) users:** `docker-sonic-p4rt` (Google PINS), `docker-iccpd` (MCLAG), `docker-sonic-redfish` (new in 2026, aspeed BMC, in CI).
+- **Test-only, not image surface:** `docker-ptf`, `docker-ptf-sai`.
+- **p4lang toolchain** (`rules/p4lang.mk`): kept — DASH SAI and PTF depend on it.
+
+### 8. Per-candidate detail
+
+Short notes on the ones with real gaps or tricky scope.
+
+**A1 — Barefoot / DTEL.** Tofino is EOL. The platform is absent from the CI build matrix (aspeed_arm64, broadcom, marvell-prestera, mellanox, nvidia_bluefield, vs, alpinevs, vpp) — so it is unbuilt and untested. A stale `barefoot` job still sits in `azure-pipelines-build.yml` and should go too. DTEL (`dtelorch`) only ran on Tofino in practice, and TAM (202605) covers the same use case, so DTEL goes with it.
+
+**A2 — P4 platform.** This is the old bmv2 software switch (`docker-sonic-p4`, `sai-p4-bm`, `p4c-bm`, `tenjin`, `p4-hlir`), not the p4lang toolchain. The only reference outside `platform/p4/` is a stale Debian-8 TODO in `rules/redis.mk`. Remove `platform/p4/*`, its 4 submodules, and that TODO. **Do not touch `rules/p4lang.mk`** — DASH SAI (in `sonic-vs.img.gz` via `INCLUDE_VS_DASH_SAI`) and the PTF containers still need bmv2/p4c/PI.
+
+**A8 — System Telemetry.** The telemetry and gnmi containers both come from `sonic-gnmi`. `telemetry.sh` and `gnmi-native.sh` read the same `TELEMETRY|gnmi` config table; the gnmi one just adds more (ZMQ, VRF binding). Dial-out exists in both. So there is near-zero config migration. Gap: confirm `gnmi_server` fully matches the old `telemetry` binary before deleting.
+
+**A9 — FRR modes.** `docker_init.sh` has four modes. `separated` and `split` write per-daemon files (`bgpd.conf`, `zebra.conf`, ...). FRR 10.5 no longer reads those, so these two modes are broken. The working path uses one unified `frr.conf` (`service integrated-vtysh-config`). This is really a dead-code fix. Open question: what the default should become — see [12](#12-open-items).
+
+**A10 — old Debian bases.** Two shapes. **stretch** and **buster** each have real `docker-base-*` / `docker-config-engine-*` / `docker-swss-layer-*` containers to delete. **jessie** does not — there is no `docker-base-jessie`. What's left of jessie is the `sonic-slave-jessie` build slave and its `make jessie` target (Debian 8), plus jessie strings in the generic `docker-base` (armhf/arm64 sources, `FROM ...:jessie`). Drop the jessie slave and its wiring; check the generic `docker-base` before touching it. Many other jessie strings sit in code we already remove (p4, nephos). Keep bullseye — it may still be a live base.
+
+**B1 — swsssdk-py3.** Looks dead but isn't. `swsscommon` replaces it, but real code still imports `swsssdk` at runtime. Migrate those, then drop the wheel.
+
+### 9. Config and management impact
+
+- **A6 / A8 / B2:** these are feature containers. Removing them drops their `FEATURE` table entries and build flags. No CLI change for users who never turned them on.
+- **A9:** removes two values from `docker_routing_config_mode`. The surviving default is an open item.
+- **A2 / A3 / A1:** platform removals. No effect on other platforms.
+- No YANG changes beyond dropping models for removed features (e.g. `sonic-kubernetes_master.yang` with A6).
+
+### 10. Warmboot/Fastboot impact
+
+None. Every candidate is off by default, dead, or platform-specific to hardware being removed. Removing them does not touch the warmboot/fastboot path for supported platforms.
+
+### 11. Testing
+
+- **Build:** each supported CI platform still builds after removal.
+- **Image diff:** confirm removed packages are gone from the SBOM and CVE scan.
+- **A8:** gnmi container still serves Get/Set/Subscribe and dial-out.
+- **A9:** default FRR path still comes up and programs routes.
+- **B1:** `dualtor_neighbor_check` and `sonic-py-common` work on `swsscommon`.
+- **A10:** all remaining containers build with nothing pointing at the deleted bases.
+
+### 12. Open items
+
+Held back until an owner confirms. Not proposed here.
+
+- **FRR default mode (A9):** which single mode survives, and whether the FRR 10.5 upgrade already moved the default. Needs routing maintainers.
+- **REST API** (`docker-sonic-restapi`): baremetal VNET config API. gNMI does not cover its bulk-route (207 partial) and route-expiry semantics. Needs Microsoft to confirm no live consumer.
+- **Kubernetes worker owner check:** confirm the user base before setting a firm removal date.
+- **PDE** (`docker-pde`): Broadcom bring-up tool. Confirm with Broadcom.
+- **clounix platform:** nearly inert but added under a year ago. Confirm intent with the vendor.

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -91,9 +91,9 @@ Rules of thumb:
 | A5 | Python 2 packages (`swsssdk-py2`, `redis-dump-load-py2`) | Gated off on bullseye/bookworm/trixie. Never built on any current release. | None. Py3 versions stay (see B1). |
 | A6 | Kubernetes master (`INCLUDE_KUBERNETES_MASTER`) | Runs a full k8s control plane on a switch. All pins are years EOL (k8s 1.22, etcd 3.5.0, coredns 1.8.4, dashboard 2.7.0) plus Azure creds. Off, no real CI. | Biggest CVE win. Master only — worker is separate (see B2). |
 | A7 | `docker-basic_router` | Dead SAI demo container. Wired into no build. Never shipped. | Nothing uses it. |
-| A8 | System Telemetry (`docker-sonic-telemetry`) | Off by default. The gnmi container reads the **same** config and does more. Already the default. | Confirm `gnmi_server` matches on Get/Set/Subscribe. Stop building the old `telemetry` binary too. |
-| A9 | Broken FRR modes (`separated`, `split`) | Both write per-daemon FRR config files. FRR 10.5.4 (shipped) dropped support for those. They no longer work. | Which mode becomes the default is an open item — see [12](#12-open-items). |
-| A10 | Old Debian build leftovers (jessie, stretch, buster) | jessie = Debian 8, stretch/buster = Debian 9/10. All long EOL. Risk: someone builds on a 6+ year old base. | jessie and stretch/buster are different shapes — see A10 note. Check nothing still `FROM`s a base before deleting. Bullseye stays for now. |
+| A8 | System Telemetry (`docker-sonic-telemetry`) | Off by default. Redundant — the gnmi container runs the **same binary**. | Keep the `telemetry` binary (gnmi needs it). Remove the container + `INCLUDE_SYSTEM_TELEMETRY` flag. See A8 note. |
+| A9 | Broken FRR modes (`separated`, `split`) | Both write per-daemon FRR config files. FRR 10.5.4 (shipped) dropped support for those. They no longer work. | Default becomes `unified`. `minigraph.py` still hardcodes `separated` — flip it. See A9 note. |
+| A10 | Old Debian build leftovers (jessie, stretch, buster) | Debian 8, 9, and 10. All long EOL. Risk: someone builds on a 6+ year old base. | jessie and stretch/buster are different shapes — see A10 note. Check nothing still `FROM`s a base before deleting. Bullseye is a separate case (B3). |
 
 #### 7.2 Deprecate now, remove later
 
@@ -101,6 +101,7 @@ Rules of thumb:
 |---|-----------|-----------|----------|
 | B1 | `swsssdk-py3` | 202705 | Still imported at runtime (`dualtor_neighbor_check.py`), and by `sonic-py-common` and the vpp container. Move them to `swsscommon` first. |
 | B2 | Kubernetes worker (`INCLUDE_KUBERNETES`) | 202711 | Off by default, but still patched upstream, so users may exist. Deprecate and see. **Keep the ctrmgrd wrapper — it is not k8s-only.** |
+| B3 | Bullseye base containers (`docker-base-bullseye`, `docker-config-engine-bullseye`, `docker-swss-layer-bullseye`) | 202705 | Debian 11. May still be a live base for some containers. Move them to bookworm/trixie, then remove. |
 
 #### 7.3 Looked at, keeping
 
@@ -119,18 +120,18 @@ Short notes on the ones with real gaps or tricky scope.
 
 **A2 — P4 platform.** This is the old bmv2 software switch (`docker-sonic-p4`, `sai-p4-bm`, `p4c-bm`, `tenjin`, `p4-hlir`), not the p4lang toolchain. The only reference outside `platform/p4/` is a stale Debian-8 TODO in `rules/redis.mk`. Remove `platform/p4/*`, its 4 submodules, and that TODO. **Do not touch `rules/p4lang.mk`** — DASH SAI (in `sonic-vs.img.gz` via `INCLUDE_VS_DASH_SAI`) and the PTF containers still need bmv2/p4c/PI.
 
-**A8 — System Telemetry.** The telemetry and gnmi containers both come from `sonic-gnmi`. `telemetry.sh` and `gnmi-native.sh` read the same `TELEMETRY|gnmi` config table; the gnmi one just adds more (ZMQ, VRF binding). Dial-out exists in both. So there is near-zero config migration. Gap: confirm `gnmi_server` fully matches the old `telemetry` binary before deleting.
+**A8 — System Telemetry.** Confirmed: both containers exec the **same binary**, `/usr/sbin/telemetry` (telemetry `telemetry.sh:168`, gnmi `gnmi-native.sh:155`). There is no separate gNMI server — the `telemetry` binary *is* the server; the name is legacy. Both read the same `TELEMETRY|gnmi` config; the gnmi start script just adds ZMQ and VRF args. So parity is exact, not approximate — full Get/Set/Subscribe and dial-out. No gap. The `telemetry` binary stays (gnmi runs it); we drop the redundant container and the `INCLUDE_SYSTEM_TELEMETRY` flag.
 
-**A9 — FRR modes.** `docker_init.sh` has four modes. `separated` and `split` write per-daemon files (`bgpd.conf`, `zebra.conf`, ...). FRR 10.5 no longer reads those, so these two modes are broken. The working path uses one unified `frr.conf` (`service integrated-vtysh-config`). This is really a dead-code fix. Open question: what the default should become — see [12](#12-open-items).
+**A9 — FRR modes.** `docker_init.sh` has four modes. `separated` and `split` write per-daemon files (`bgpd.conf`, `zebra.conf`, ...). FRR 10.5 no longer reads those, so both are broken. Keep the unified path — one `frr.conf`, `service integrated-vtysh-config`. The default becomes `unified`. Catch: `minigraph.py` still hardcodes the default as `separated`, and init_cfg doesn't set it, so today it resolves to `separated`. This change must flip that default to `unified`. So: drop two dead modes, plus a default flip.
 
-**A10 — old Debian bases.** Two shapes. **stretch** and **buster** each have real `docker-base-*` / `docker-config-engine-*` / `docker-swss-layer-*` containers to delete. **jessie** does not — there is no `docker-base-jessie`. What's left of jessie is the `sonic-slave-jessie` build slave and its `make jessie` target (Debian 8), plus jessie strings in the generic `docker-base` (armhf/arm64 sources, `FROM ...:jessie`). Drop the jessie slave and its wiring; check the generic `docker-base` before touching it. Many other jessie strings sit in code we already remove (p4, nephos). Keep bullseye — it may still be a live base.
+**A10 — old Debian bases.** Two shapes. **stretch** and **buster** each have real `docker-base-*` / `docker-config-engine-*` / `docker-swss-layer-*` containers to delete. **jessie** does not — there is no `docker-base-jessie`. What's left of jessie is the `sonic-slave-jessie` build slave and its `make jessie` target (Debian 8), plus jessie strings in the generic `docker-base` (armhf/arm64 sources, `FROM ...:jessie`). Drop the jessie slave and its wiring; check the generic `docker-base` before touching it. Many other jessie strings sit in code we already remove (p4, nephos). Bullseye is not here — it's deprecated for later removal (B3).
 
 **B1 — swsssdk-py3.** Looks dead but isn't. `swsscommon` replaces it, but real code still imports `swsssdk` at runtime. Migrate those, then drop the wheel.
 
 ### 9. Config and management impact
 
 - **A6 / A8 / B2:** these are feature containers. Removing them drops their `FEATURE` table entries and build flags. No CLI change for users who never turned them on.
-- **A9:** removes two values from `docker_routing_config_mode`. The surviving default is an open item.
+- **A9:** drops `separated` and `split` from `docker_routing_config_mode`. Default becomes `unified` (also flip the `minigraph.py` default).
 - **A2 / A3 / A1:** platform removals. No effect on other platforms.
 - No YANG changes beyond dropping models for removed features (e.g. `sonic-kubernetes_master.yang` with A6).
 
@@ -151,7 +152,6 @@ None. Every candidate is off by default, dead, or platform-specific to hardware 
 
 Held back until an owner confirms. Not proposed here.
 
-- **FRR default mode (A9):** which single mode survives, and whether the FRR 10.5 upgrade already moved the default. Needs routing maintainers.
 - **REST API** (`docker-sonic-restapi`): baremetal VNET config API. gNMI does not cover its bulk-route (207 partial) and route-expiry semantics. Needs Microsoft to confirm no live consumer.
 - **Kubernetes worker owner check:** confirm the user base before setting a firm removal date.
 - **PDE** (`docker-pde`): Broadcom bring-up tool. Confirm with Broadcom.

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -10,16 +10,17 @@
 - [6. Process](#6-process)
 - [7. Candidates for 202611](#7-candidates-for-202611)
   - [7.1 Remove now](#71-remove-now)
-    - [7.1.1 Barefoot / Tofino platform (with DTEL)](#711-barefoot--tofino-platform-with-dtel)
-    - [7.1.2 Standalone P4 platform](#712-standalone-p4-platform)
-    - [7.1.3 Nephos platform](#713-nephos-platform)
-    - [7.1.4 GoBGP FPM container](#714-gobgp-fpm-container)
-    - [7.1.5 Python 2 packages](#715-python-2-packages)
-    - [7.1.6 Kubernetes master](#716-kubernetes-master)
-    - [7.1.7 docker-basic_router](#717-docker-basic_router)
-    - [7.1.8 System Telemetry container](#718-system-telemetry-container)
-    - [7.1.9 Broken FRR config modes](#719-broken-frr-config-modes)
-    - [7.1.10 Old Debian build leftovers](#7110-old-debian-build-leftovers)
+    - [7.1.1 Barefoot / Tofino platform](#711-barefoot--tofino-platform)
+    - [7.1.2 DTEL (data-plane telemetry)](#712-dtel-data-plane-telemetry)
+    - [7.1.3 Standalone P4 platform](#713-standalone-p4-platform)
+    - [7.1.4 Nephos platform](#714-nephos-platform)
+    - [7.1.5 GoBGP FPM container](#715-gobgp-fpm-container)
+    - [7.1.6 Python 2 packages](#716-python-2-packages)
+    - [7.1.7 Kubernetes master](#717-kubernetes-master)
+    - [7.1.8 docker-basic_router](#718-docker-basic_router)
+    - [7.1.9 System Telemetry container](#719-system-telemetry-container)
+    - [7.1.10 Broken FRR config modes](#7110-broken-frr-config-modes)
+    - [7.1.11 Old Debian build leftovers](#7111-old-debian-build-leftovers)
   - [7.2 Deprecate now, remove later](#72-deprecate-now-remove-later)
     - [7.2.1 Bullseye base containers](#721-bullseye-base-containers)
     - [7.2.2 FRR split-unified config mode](#722-frr-split-unified-config-mode)
@@ -95,40 +96,44 @@ Each candidate below stands on its own. It states what the feature is, why it sh
 
 #### 7.1 Remove now
 
-##### 7.1.1 Barefoot / Tofino platform (with DTEL)
+##### 7.1.1 Barefoot / Tofino platform
 
 Intel has ended the Tofino line, and the platform is not in the CI build matrix (aspeed_arm64, broadcom, marvell-prestera, mellanox, nvidia_bluefield, vs, alpinevs, and vpp). Because nothing builds it, nothing tests it. The platform is roughly 7.7 MB across about 880 files, and it pulls in the Barefoot SAI, saithrift, the `docker-syncd-bfn` and `docker-saiserver-bfn` containers, and the ODM sub-platforms built on Tofino (Accton Wedge100BF, Arista 7170, Ingrasys, Netberg, and WNC).
 
-Data-plane telemetry (DTEL, `dtelorch`) only ever ran on Tofino in practice, so it should be removed with the platform. TAM, which was added in 202605, already covers the same need.
+**Remove:** `platform/barefoot/`; the Tofino `device/` folders (Accton Wedge100BF, Arista 7170, Ingrasys, Netberg, WNC); the `barefoot` job in `.azure-pipelines/azure-pipelines-build.yml`; the `barefoot` filter in `rules/docker-platform-monitor.mk`.
 
-**Remove:** `platform/barefoot/`; the Tofino `device/` folders (Accton Wedge100BF, Arista 7170, Ingrasys, Netberg, WNC); `src/sonic-swss/orchagent/dtelorch.{cpp,h}` and its wiring in `orchagent/orchdaemon.cpp`; the `barefoot` job in `.azure-pipelines/azure-pipelines-build.yml`; the `barefoot` filter in `rules/docker-platform-monitor.mk`.
+##### 7.1.2 DTEL (data-plane telemetry)
 
-##### 7.1.2 Standalone P4 platform
+DTEL is SONiC's in-band data-plane telemetry. In practice it only ever ran on Barefoot Tofino, and that platform is EOL and is being removed in 7.1.1. With the only hardware that ran it gone, the DTEL code in the orchestration agent is dead. TAM, which was added in 202605, already covers the same need on current hardware.
+
+**Remove:** `src/sonic-swss/orchagent/dtelorch.{cpp,h}`, the DTEL table set and initialization in `orchagent/orchdaemon.cpp`, and the DTEL handling in `orchagent/aclorch.{cpp,h}`; the DTEL CONFIG_DB tables and any `sonic-dtel` YANG model; `src/sonic-swss/tests/test_dtel.py`.
+
+##### 7.1.3 Standalone P4 platform
 
 This is the old bmv2 software behavioral model. It is a reference target rather than real hardware, and it has been dead since roughly 2022. Nothing in CI builds it. It is about 12 MB across 920 files, and it pulls in four stale external submodules. The only thing that references it outside `platform/p4/` is a Debian 8 era TODO in `rules/redis.mk`.
 
 **Remove:** `platform/p4/` (which includes `docker-sonic-p4`, `sai-p4-bm`, `p4c-bm`, `tenjin`, and `p4-hlir`); the four P4 submodule entries in `.gitmodules` (`platform/p4/p4c-bm/p4c-bm`, `platform/p4/p4-hlir/p4-hlir`, `platform/p4/p4-hlir/p4-hlir-v1.1`, `platform/p4/SAI-P4-BM`); the stale TODO in `rules/redis.mk`.
 **Keep:** `rules/p4lang.mk`. The p4lang toolchain it builds (bmv2, p4c, and PI) is a live dependency of DASH SAI, which ships in `sonic-vs.img.gz`, and of the PTF test containers.
 
-##### 7.1.3 Nephos platform
+##### 7.1.4 Nephos platform
 
 The Nephos and MediaTek switch silicon vendor left the market around 2019. The platform is about 2.3 MB across 160 files. There is no `device/nephos` tree, there has been no genuine commit in years, and it is not in CI.
 
 **Remove:** `platform/nephos/`; the `nephos` job in `.azure-pipelines/azure-pipelines-build.yml`.
 
-##### 7.1.4 GoBGP FPM container
+##### 7.1.5 GoBGP FPM container
 
 SONiC standardized on FRR, which is set by `SONIC_ROUTING_STACK = frr`. The GoBGP image build rules were deleted back in 2021, so it has not been buildable as an image since then. Even so, every build still compiles a 2017 era Go GOBGP package that nothing installs. Removing it loses nothing, because FRR already provides all of this.
 
 **Remove:** `dockers/docker-fpm-gobgp/`, `src/gobgp/`, `rules/gobgp.mk`, and `rules/gobgp.dep`; the dead `DOCKER_FPM_GOBGP` and `DOCKER_FPM_QUAGGA` references in `rules/docker-fpm.mk` and `rules/docker-fpm.dep`; the gobgp dependency in the non-frr branch of `platform/vs/docker-sonic-vs.mk`.
 
-##### 7.1.5 Python 2 packages
+##### 7.1.6 Python 2 packages
 
 Both packages are gated behind `ENABLE_PY2_MODULES`, which is off for bullseye, bookworm, and trixie. As a result, neither is built on any current release, so both are dead weight. The py3 version of swsssdk is a separate matter, because it is still in use. It is out of scope here and is noted under Additional findings.
 
 **Remove:** `rules/swsssdk-py2.mk`, `rules/swsssdk-py2.dep`, `rules/redis-dump-load-py2.mk`, and `rules/redis-dump-load-py2.dep`; the `SWSSSDK_PY2` dependency lines in `rules/sonic-py-common.mk` and `rules/swsssdk-py3.mk`.
 
-##### 7.1.6 Kubernetes master
+##### 7.1.7 Kubernetes master
 
 This runs a full Kubernetes control plane on the switch. That includes the apiserver, controller, scheduler, proxy, etcd 3.5.0, coredns 1.8.4, and the dashboard 2.7.0 web UI, along with cloud credential libraries used for backups. Every one of those versions is years past end of life, which makes this the single biggest reduction in CVE surface in this list. It is off by default and has no real CI coverage.
 
@@ -137,20 +142,20 @@ This applies to the master only. The worker feature (`INCLUDE_KUBERNETES`) is a 
 **Remove:** `files/image_config/kubernetes/` (`kubernetes_master_entrance.sh`, `kubernetes_master_entrance.service`, `kubernetes.list`); the `INCLUDE_KUBERNETES_MASTER` flag and the master version pins in `rules/config`; the master-only blocks in `files/build_templates/sonic_debian_extension.j2`; `sonic-kubernetes_master.yang`; the master build in `.azure-pipelines/azure-pipelines-build.yml`.
 **Keep:** `INCLUDE_KUBERNETES` (the worker), `src/sonic-ctrmgrd*`, and the `ctrmgrd` wrapper, which runs for ordinary feature start and stop rather than only for k8s.
 
-##### 7.1.7 docker-basic_router
+##### 7.1.8 docker-basic_router
 
 This is a SAI demo and reference container. It is not wired into any build rule, it never ships in an image, and it is not in CI. Its last real change was in 2020, and nothing uses it.
 
 **Remove:** `dockers/docker-basic_router/`.
 
-##### 7.1.8 System Telemetry container
+##### 7.1.9 System Telemetry container
 
 This container is off by default, and it is redundant. Both this container and the gnmi container run the same binary, `/usr/sbin/telemetry`, started by `telemetry.sh` and `gnmi-native.sh` respectively. There is no separate gNMI server. The `telemetry` binary is the server, and the name is only historical. Both containers read the same `TELEMETRY|gnmi` config, and the gnmi start script simply adds ZMQ and VRF options on top. There is therefore no functional gap, because Get, Set, Subscribe, and dial-out are identical in both.
 
 **Remove:** `dockers/docker-sonic-telemetry/`, `rules/docker-telemetry.mk`, and `rules/docker-telemetry.dep`; the `INCLUDE_SYSTEM_TELEMETRY` flag in `rules/config`.
 **Keep:** the `telemetry` binary, which is built by sonic-gnmi and run by the gnmi container.
 
-##### 7.1.9 Broken FRR config modes
+##### 7.1.10 Broken FRR config modes
 
 `docker_routing_config_mode` has four values. Both `separated` and `split` write per-daemon config files such as `bgpd.conf` and `zebra.conf`. FRR 10.5.4, which SONiC ships, dropped support for per-daemon config files, so both of these modes are broken today. Removing them is really just deleting dead code.
 
@@ -158,7 +163,7 @@ The supported path is `unified`, where the config comes from bgpcfgd and `config
 
 **Change:** remove the `separated` and `split` branches in `dockers/docker-fpm-frr/docker_init.sh` and the per-daemon templates under `dockers/docker-fpm-frr/frr/{bgpd,zebra,staticd,sharpd}/`; flip the default in `src/sonic-config-engine/minigraph.py` from `separated` to `unified`.
 
-##### 7.1.10 Old Debian build leftovers
+##### 7.1.11 Old Debian build leftovers
 
 Debian 8 (jessie), Debian 9 (stretch), and Debian 10 (buster) are all long past end of life. The risk is that someone builds a new container on a base that is more than six years old. Before deleting any base, confirm that nothing still builds a container on it. Bullseye is Debian 11, which is newer, and it is handled under Deprecate.
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -15,8 +15,7 @@
 - [9. Config and management impact](#9-config-and-management-impact)
 - [10. Warmboot/Fastboot impact](#10-warmbootfastboot-impact)
 - [11. Testing](#11-testing)
-- [12. Open items](#12-open-items)
-- [13. Additional findings](#13-additional-findings)
+- [12. Additional findings](#12-additional-findings)
 
 ### 1. Revision
 
@@ -88,7 +87,7 @@ Rules of thumb:
 | A2 | Standalone P4 platform (`platform/p4`) | Dead reference model since ~2022. In no CI. 12 MB, 923 files, 4 stale submodules. | Keep `rules/p4lang.mk` (bmv2/p4c/PI). DASH SAI and PTF still use it. |
 | A3 | Nephos platform (`platform/nephos`) | Vendor gone (~2019). No real commits in years. No device tree. | Cleanup is mostly the pipeline YAML. |
 | A4 | GoBGP FPM (`docker-fpm-gobgp`, `src/gobgp`, `rules/gobgp.*`) | Not buildable as an image since 2021, yet still compiles a 2017-era Go deb every build. FRR replaced it. | Drop the dead `DOCKER_FPM_GOBGP` / `DOCKER_FPM_QUAGGA` refs in `docker-fpm.*` too. |
-| A5 | Python 2 packages (`swsssdk-py2`, `redis-dump-load-py2`) | Gated off on bullseye/bookworm/trixie. Never built on any current release. | None. The py3 version is a separate case — see [13](#13-additional-findings). |
+| A5 | Python 2 packages (`swsssdk-py2`, `redis-dump-load-py2`) | Gated off on bullseye/bookworm/trixie. Never built on any current release. | None. The py3 version is a separate case — see [12](#12-additional-findings). |
 | A6 | Kubernetes master (`INCLUDE_KUBERNETES_MASTER`) | Runs a full k8s control plane on a switch. All pins are years EOL (k8s 1.22, etcd 3.5.0, coredns 1.8.4, dashboard 2.7.0) plus cloud credential deps. Off, no real CI. | Biggest CVE win. Master only. The worker (`INCLUDE_KUBERNETES`) is a separate feature and **stays** — pre-WG security hardening on it points to a real user. |
 | A7 | `docker-basic_router` | Dead SAI demo container. Wired into no build. Never shipped. | Nothing uses it. |
 | A8 | System Telemetry (`docker-sonic-telemetry`) | Off by default. Redundant — the gnmi container runs the **same binary**. | Keep the `telemetry` binary (gnmi needs it). Remove the container + `INCLUDE_SYSTEM_TELEMETRY` flag. See A8 note. |
@@ -144,14 +143,7 @@ None. Every candidate is off by default, dead, or platform-specific to hardware 
 - **A9:** default FRR path still comes up and programs routes.
 - **A10:** all remaining containers build with nothing pointing at the deleted bases.
 
-### 12. Open items
-
-Held back until an owner confirms. Not proposed here.
-
-- **PDE** (`docker-pde`): Broadcom bring-up tool. Confirm with Broadcom.
-- **clounix platform:** nearly inert but added under a year ago. Confirm intent with the vendor.
-
-### 13. Additional findings
+### 12. Additional findings
 
 Real, but out of scope here. Removing them needs code porting, which this HLD does not cover. Noted so they are tracked.
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -103,6 +103,7 @@ A few rules of thumb guide the calls above:
 - A forced bump, such as a libyang, base image, submodule pointer, or mass format change, does not count as maintenance.
 - If a replacement has a gap, we name it so users can speak up.
 - Silence is not consent on its own. It counts only after the notifications above have gone out twice and the second round has had time to draw a response.
+- A removal that touches configuration is not finished until `db_migrator.py` cleans up what it leaves behind in CONFIG_DB. See section 8.
 
 ### 7. Candidates for 202611
 
@@ -226,6 +227,16 @@ This should be removed in 202711. It is off by default. Its own spec calls it th
 
 Removing a feature drops its `FEATURE` table entries, its build flags, and any YANG models tied to it, such as `sonic-kubernetes_master.yang`. Users who never enabled these features see no CLI change.
 
+Removing the code is only half of it, because a device that upgrades keeps whatever it already had in CONFIG_DB. Every removal that touches configuration therefore has to update `sonic-utilities/scripts/db_migrator.py`, and that update is part of the removal rather than a follow-up. Without it, an upgraded device carries dead `FEATURE` rows and orphaned tables forever, a table that outlives its YANG model can fail config validation, and a setting whose supported values have narrowed can leave the device pointing at a value that no longer exists.
+
+The shape of the change is the same each time. Add a new `version_<branch>_<build>` method chained onto the current tail of the version chain, bump `CURRENT_VERSION` to it, which is `version_202605_01` today, and drop the state that is going away with `delete_table` or with entry deletion. What this batch needs:
+
+- `DEVICE_METADATA|localhost|docker_routing_config_mode`. A device holding `separated` or `split` has to be migrated to `unified`, because 7.1.10 deletes the code behind both. This is the case that matters most, since skipping it leaves a device configured for a routing mode that no longer exists rather than merely carrying dead config.
+- The `KUBERNETES_MASTER` table, which goes with 7.1.7, along with its YANG model.
+- The DTEL tables, which go with 7.1.2.
+- `FEATURE|telemetry`, which goes with 7.1.9. `FEATURE|gnmi` stays, and the two must not be confused, because the surviving container is the gnmi one.
+- `FEATURE|restapi`, when the REST API is removed in 202711 under 7.2.3, which lands in that release's migrator rather than this one.
+
 The FRR change removes `separated` and `split` from `docker_routing_config_mode` and makes `unified` the default. The platform removals do not affect other platforms.
 
 Collapsing the routing stack to FRR alone does not change any command an operator runs, because the FRR branch of every affected command already provides the same CLI. `clear ip bgp` keeps working through the renamed `clear/bgp_frr_v4.py`. The one visible difference is `show startupconfiguration bgp`, which loses its `/etc/quagga/bgpd.conf` branch and reads only `/etc/frr/bgpd.conf`.
@@ -239,6 +250,8 @@ There is no warmboot or fastboot impact. Every candidate is off by default, alre
 - Each supported CI platform still builds after the removals.
 - The removed packages no longer appear in the SBOM or the CVE scan, confirmed by an image diff.
 - The default FRR path (`unified`) comes up and programs routes.
+- A `config_db.json` from the previous release migrates cleanly, with no leftover tables for removed features and no config validation errors against the reduced YANG model set.
+- A device configured for `separated` or `split` comes up in `unified` after upgrade, rather than pointing at a mode whose code is gone.
 - Every remaining container builds with nothing pointing at a deleted base, and the centec and sonic-sdk containers build on their new base.
 - `show ip bgp` and `clear ip bgp` still work after the routing-stack collapse and the `clear/bgp_frr_v4.py` rename.
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -125,17 +125,20 @@ The Nephos and MediaTek switch silicon vendor left the market around 2019. The p
 
 ##### 7.1.5 GoBGP and Quagga routing stacks
 
-SONiC standardized on FRR, which is set by `SONIC_ROUTING_STACK = frr`. The GoBGP image build rules were deleted back in 2021, so it has not been buildable as an image since then. Even so, every build still compiles a 2017 era Go GOBGP package that nothing installs.
+FRR is the only routing stack SONiC supports. `rules/config` already documents `frr` as the sole supported value of `SONIC_ROUTING_STACK`. Even so, both the build and the CLI still carry the machinery to elect GoBGP or Quagga instead, and that selectable-stack machinery is what this candidate removes.
 
-Quagga left even earlier, and it should go in the same change. Its container and build rules are already gone, but the CLI branches, the build glue, and the sudoers policy that referenced it were never cleaned up. Removing both loses nothing, because FRR already provides all of this. Once they are gone, `get_routing_stack()` has only one possible answer, so the routing-stack conditionals collapse to a single path.
+GoBGP had its image build rules deleted back in 2021, so it has not been buildable as an image since then. Even so, every build still compiles a 2017 era Go GOBGP package that nothing installs. Quagga left even earlier. Its container and build rules are long gone, but the branches that would select it were never cleaned up, so the build glue, the CLI, and the sudoers policy still carry a Quagga path that cannot be reached. Removing both loses nothing, because FRR provides all of it. Once they are gone, every routing-stack conditional collapses to a single path, and `get_routing_stack()` has only one possible answer, so the runtime detection that shells out to `docker ps` can go with it.
 
-One Quagga-named file needs care rather than deletion. `clear/bgp_quagga_v4.py` is the live implementation of `clear ip bgp` under FRR, because the `frr` branch of `clear/main.py` imports it and there is no `clear/bgp_frr_v4.py`. Rename that file instead of removing it.
+The target here is stack selection rather than the word Quagga. FRR is itself a fork of Quagga, so Quagga-derived names legitimately survive in FRR-sourced code, including the whole of `src/sonic-frr/`, its `_QUAGGA_*` header guards, and the `fpm.h` that fpmsyncd carries. Those are upstream names and they stay.
 
-**Remove (GoBGP):** `dockers/docker-fpm-gobgp/`, `src/gobgp/`, `rules/gobgp.mk`, and `rules/gobgp.dep`; the gobgp dependency in the non-frr branch of `platform/vs/docker-sonic-vs.mk`.
-**Remove (Quagga):** in sonic-utilities, `show/bgp_quagga_v4.py`, `show/bgp_quagga_v6.py`, and `clear/bgp_quagga_v6.py`, the `routing_stack == "quagga"` branches in `show/main.py` and `clear/main.py`, the non-frr `else` branches that carry the Quagga `bgp` and `zebra` groups in `debug/main.py` and `undebug/main.py`, the `/etc/quagga/bgpd.conf` branch of `show startupconfiguration bgp`, and the matching cases in `tests/show_test.py`, `tests/clear_test.py`, and `tests/debug_test.py`; the `docker exec bgp cat /etc/quagga/bgpd.conf` entry in `files/image_config/sudoers/sudoers`.
-**Remove (both):** the dead `DOCKER_FPM_GOBGP` and `DOCKER_FPM_QUAGGA` references in `rules/docker-fpm.mk` and `rules/docker-fpm.dep`, which leaves the routing-stack conditional with a single branch.
+Where a Quagga-named file turns out to be the live FRR implementation, rename it rather than delete it. `clear/bgp_quagga_v4.py` is the clear case, because the `frr` branch of `clear/main.py` imports it and there is no `clear/bgp_frr_v4.py`, which makes it the working implementation of `clear ip bgp` today.
+
+**Remove (GoBGP):** `dockers/docker-fpm-gobgp/`, `src/gobgp/`, `rules/gobgp.mk`, and `rules/gobgp.dep`.
+**Remove (stack selection in the build):** `rules/docker-fpm.mk` and `rules/docker-fpm.dep`, which exist only to elect a stack, so `DOCKER_FPM_FRR` can be referenced directly and the dead `DOCKER_FPM_GOBGP` and `DOCKER_FPM_QUAGGA` names go with them; the `else` branch that adds `$(GOBGP)` in `platform/vs/docker-sonic-vs.mk`; the `SONIC_ROUTING_STACK` conditionals in `slave.mk` and `files/build_templates/sonic_debian_extension.j2`, whose FRR blocks become unconditional; the commented-out `ROUTING_STACK` selection in `platform/p4/docker-sonic-p4.mk`, which goes with 7.1.3 in any case. Keep `SONIC_ROUTING_STACK = frr` in `rules/config` as a single-value knob, because downstream `rules/config.user` files may still set it.
+**Remove (stack selection in the CLI):** in sonic-utilities, the `routing_stack == "quagga"` branches of `show/main.py` and `clear/main.py` along with `show/bgp_quagga_v4.py`, `show/bgp_quagga_v6.py`, and `clear/bgp_quagga_v6.py`; the non-frr `else` branches that carry the Quagga `bgp` and `zebra` groups in `debug/main.py` and `undebug/main.py`; the `/etc/quagga/bgpd.conf` branch of `show startupconfiguration bgp` and the matching `docker exec bgp cat /etc/quagga/bgpd.conf` entry in `files/image_config/sudoers/sudoers`; the cases that exercise the removed branches in `tests/show_test.py`, `tests/clear_test.py`, and `tests/debug_test.py`.
 **Rename:** `src/sonic-utilities/clear/bgp_quagga_v4.py` to `clear/bgp_frr_v4.py`, and update the import in `clear/main.py`.
-**Fix:** the stale `## Quagga rules` header in `files/image_config/rsyslog/rsyslog.d/00-sonic.conf.j2`, the `docker-fpm.gz` line in `README.md` that still describes the image as Quagga, and the "For quagga build" comments in `sonic-slave-bookworm/Dockerfile.j2` and `sonic-slave-trixie/Dockerfile.j2`. The packages under those comments, such as `libreadline-dev`, `libpam-dev`, and the texlive set, are FRR build dependencies now, so confirm what FRR needs before removing any of them.
+
+Comments that only mention Quagga in passing, such as the `docker-fpm.gz` line in `README.md`, the `## Quagga rules` header in `files/image_config/rsyslog/rsyslog.d/00-sonic.conf.j2`, and the "For quagga build" comments in the sonic-slave Dockerfiles, are worth correcting when the code around them is touched, but they are not the point of this candidate. The packages under that build comment, such as `libreadline-dev`, `libpam-dev`, and the texlive set, are FRR build dependencies now, so leave them alone.
 
 ##### 7.1.6 Python 2 packages
 
@@ -211,7 +214,7 @@ Removing a feature drops its `FEATURE` table entries, its build flags, and any Y
 
 The FRR change removes `separated` and `split` from `docker_routing_config_mode` and makes `unified` the default. The platform removals do not affect other platforms.
 
-The Quagga cleanup does not change any command an operator runs, because the FRR branch of every affected command already provides the same CLI. `clear ip bgp` keeps working through the renamed `clear/bgp_frr_v4.py`. The one visible difference is `show startupconfiguration bgp`, which loses its `/etc/quagga/bgpd.conf` branch and reads only `/etc/frr/bgpd.conf`.
+Collapsing the routing stack to FRR alone does not change any command an operator runs, because the FRR branch of every affected command already provides the same CLI. `clear ip bgp` keeps working through the renamed `clear/bgp_frr_v4.py`. The one visible difference is `show startupconfiguration bgp`, which loses its `/etc/quagga/bgpd.conf` branch and reads only `/etc/frr/bgpd.conf`.
 
 ### 9. Warmboot/Fastboot impact
 
@@ -223,7 +226,7 @@ There is no warmboot or fastboot impact. Every candidate is off by default, alre
 - The removed packages no longer appear in the SBOM or the CVE scan, confirmed by an image diff.
 - The default FRR path (`unified`) comes up and programs routes.
 - Every remaining container builds with nothing pointing at a deleted base, and the centec and sonic-sdk containers build on their new base.
-- `show ip bgp` and `clear ip bgp` still work after the Quagga cleanup and the `clear/bgp_frr_v4.py` rename.
+- `show ip bgp` and `clear ip bgp` still work after the routing-stack collapse and the `clear/bgp_frr_v4.py` rename.
 
 ### 11. Additional findings
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -19,11 +19,10 @@
     - [7.1.7 Kubernetes master](#717-kubernetes-master)
     - [7.1.8 docker-basic_router](#718-docker-basic_router)
     - [7.1.9 System Telemetry container](#719-system-telemetry-container)
-    - [7.1.10 Broken FRR config modes](#7110-broken-frr-config-modes)
-    - [7.1.11 End-of-life Debian bases](#7111-end-of-life-debian-bases)
+    - [7.1.10 End-of-life Debian bases](#7110-end-of-life-debian-bases)
   - [7.2 Deprecate now, remove later](#72-deprecate-now-remove-later)
     - [7.2.1 Bookworm base containers](#721-bookworm-base-containers)
-    - [7.2.2 FRR split-unified config mode](#722-frr-split-unified-config-mode)
+    - [7.2.2 FRR split and split-unified config modes](#722-frr-split-and-split-unified-config-modes)
     - [7.2.3 REST API](#723-rest-api)
 - [8. SAI API](#8-sai-api)
 - [9. Configuration and management](#9-configuration-and-management)
@@ -45,8 +44,7 @@
 | 0.1 | 2026-07-19 | Brad House (Nexthop) | First draft. Security WG. |
 | 0.2 | 2026-07-24 | Brad House (Nexthop) | Added the Keep verdict. Moved bullseye to immediate removal and deprecated bookworm in its place. Folded Quagga into the GoBGP removal. |
 | 0.3 | 2026-07-24 | Brad House (Nexthop) | Filled in the notification steps of the process, which are the mailing list, the working groups, the TSC for platform removals, and a second round before the branch date. |
-| 0.4 | 2026-08-24 | Brad House (Nexthop) | Moved the standing process, the verdicts, and the rules of thumb into the TSC policy document, so that this HLD covers only the 202611 candidates. Restructured to the HLD template. |
-| 0.5 | 2026-08-24 | Brad House (Nexthop) | Moved Nephos to the head of the remove-now list, so that the platform removals read together. 7.1.1 through 7.1.4 are renumbered, and the rest of the list is unchanged. |
+| 0.4 | 2026-08-24 | Brad House (Nexthop) | Moved the standing process, the verdicts, and the rules of thumb into the TSC policy document, and restructured this plan to the HLD template. Led the remove-now list with Nephos so that the platform removals read together. Dropped the FRR config mode candidate, whose premise did not survive a check against the FRR source, and widened 7.2.2 to cover `split` as well as `split-unified` in its place. Spelled out in 7.2.3 that RESTCONF is not affected, and compared both candidate replacements against what the REST API actually writes. Re-derived every candidate against the tree: corrected the Barefoot device folders, the bookworm container list, the DTEL replacement and YANG claims, and the CI statements for Barefoot and Nephos. Turned the file enumerations into lists. |
 
 ### 2. Scope
 
@@ -80,7 +78,7 @@ The verdicts used below, which are **Remove now**, **Deprecate now, remove later
 
 SONiC still ships features that few or no one runs. Some of them are dead. Some broke when a dependency moved on. Some were tied to hardware that no longer exists. Each one still adds packages to the image, findings to every CVE scan, and jobs to CI.
 
-This HLD proposes the first batch to act on. Fourteen candidates are listed. Eleven are proposed for removal in 202611, and three are proposed for deprecation now with a named removal release, which is 202705 for two of them and 202711 for the REST API.
+This HLD proposes the first batch to act on. Thirteen candidates are listed. Ten are proposed for removal in 202611, and three are proposed for deprecation now with a named removal release, which is 202705 for two of them and 202711 for the REST API.
 
 ### 5. Requirements
 
@@ -101,9 +99,8 @@ Out of scope for this plan:
 
 There is no change to the SONiC architecture. Every candidate below removes a component, a build rule, or a platform, and nothing is added. None of these features is a SONiC Application Extension, so the Application Extension infrastructure is not involved.
 
-Two candidates narrow an existing choice rather than deleting a leaf:
+One candidate narrows an existing choice rather than deleting a leaf:
 
-- 7.1.10 collapses `docker_routing_config_mode` from four values to `unified` and `split-unified`, and makes `unified` the default. The supported path is unchanged, because `unified` already works today and the two removed modes are broken with the FRR version SONiC ships.
 - 7.1.5 collapses the routing stack to FRR alone. `rules/config` already documents `frr` as the sole supported value of `SONIC_ROUTING_STACK`, and neither alternative has been buildable for years, so this deletes unreachable branches rather than changing which stack runs.
 
 ### 7. High-Level Design
@@ -118,27 +115,66 @@ Three of these are platform removals, which are 7.1.1 Nephos, 7.1.2 Barefoot, an
 
 ##### 7.1.1 Nephos platform
 
-The Nephos and MediaTek switch silicon vendor left the market around 2019. The platform is about 2.3 MB across 160 files. There is no `device/nephos` tree, there has been no genuine commit in years, and it is not in CI.
+The Nephos and MediaTek switch silicon vendor left the market around 2019. The platform is about 2.3 MB across 166 files, and there is no `device/nephos` tree at all, so no shipping device selects it.
 
-**Remove:** `platform/nephos/`; the `nephos` job in `.azure-pipelines/azure-pipelines-build.yml`.
+Nothing builds it, so nothing tests it. There is a `nephos` entry in the default `jobGroups` of `.azure-pipelines/azure-pipelines-build.yml`, but no pipeline instantiates it, so the entry is itself dead wiring. See 7.1.2 for how that is determined, since Barefoot is in the same position.
+
+Every commit touching `platform/nephos/` for years has been a tree-wide sweep rather than work on the platform, the most recent being build-cache dependency tracking in August 2026, and before that the supervisor exit listener, per-ASIC warmboot, and mirror URL changes.
+
+**Remove:**
+
+- `platform/nephos/`
+- the `nephos` job group in `.azure-pipelines/azure-pipelines-build.yml`
 
 ##### 7.1.2 Barefoot / Tofino platform
 
-Intel has ended the Tofino line, and the platform is not in the CI build matrix (aspeed_arm64, broadcom, marvell-prestera, mellanox, nvidia_bluefield, vs, alpinevs, and vpp). Because nothing builds it, nothing tests it. The platform is roughly 7.7 MB across about 880 files, and it pulls in the Barefoot SAI, saithrift, the `docker-syncd-bfn` and `docker-saiserver-bfn` containers, and the ODM sub-platforms built on Tofino (Accton Wedge100BF, Arista 7170, Ingrasys, Netberg, and WNC).
+Intel has ended the Tofino line. The platform is roughly 7.8 MB across 880 files, and it pulls in the Barefoot SAI, saithrift, the `docker-syncd-bfn` and `docker-saiserver-bfn` containers, and the ODM sub-platforms built on Tofino.
 
-**Remove:** `platform/barefoot/`; the Tofino `device/` folders (Accton Wedge100BF, Arista 7170, Ingrasys, Netberg, WNC); the `barefoot` job in `.azure-pipelines/azure-pipelines-build.yml`; the `barefoot` filter in `rules/docker-platform-monitor.mk`.
+Nothing builds it, so nothing tests it, and this is worth stating precisely because there is a `barefoot` entry in the default `jobGroups` of `.azure-pipelines/azure-pipelines-build.yml` that makes it look otherwise. Nothing instantiates that entry. The pull request gate in `azure-pipelines.yml` passes its own job groups, which are vs, vpp, alpinevs, broadcom, mellanox, marvell-prestera on arm64 and armhf, nvidia-bluefield, and aspeed-arm64. Official builds go through `.azure-pipelines/official-build.yml`, which passes `jobFilters: none`, and `azure-pipelines-job-groups.yml` then emits a group only when the pipeline definition name ends with that group's name. The definitions that exist are the ones the badges in `README.md` point at, which are broadcom, mellanox, marvell-teralynx, and marvell-prestera on armhf and arm64. There is no `Azure.sonic-buildimage.official.barefoot`, and none of the release branches has one either.
+
+The same reasoning covers `nephos` in 7.1.1, and the dead job group entries go with each platform.
+
+The device folders are listed individually below rather than by vendor, because most of these vendors also ship non-Tofino platforms. The list is every folder whose `platform_asic` file reads `barefoot`, which is fourteen of them today, and it is worth re-deriving that way at removal time rather than trusting this list.
+
+**Remove:**
+
+- `platform/barefoot/`
+- the whole `device/barefoot/` tree, which is `x86_64-accton_as9516_32d-r0`, `x86_64-accton_as9516bf_32d-r0`, `x86_64-accton_wedge100bf_32x-r0`, and `x86_64-accton_wedge100bf_65x-r0`
+- `device/accton/x86_64-accton_wedge100bf_32qs-r0`
+- `device/arista/x86_64-arista_7170_32c`, `x86_64-arista_7170_32cd`, `x86_64-arista_7170_64c`, and `x86_64-arista_7170b_64c`
+- `device/ingrasys/x86_64-ingrasys_s9280_64x-r0`, which is the only Tofino platform Ingrasys ships. The rest of `device/ingrasys/` stays.
+- `device/netberg/x86_64-netberg_aurora_610-r0`, `x86_64-netberg_aurora_710-r0`, and `x86_64-netberg_aurora_750-r0`
+- `device/wnc/x86_64-wnc_osw1800-r0`
+- the `barefoot` job group in `.azure-pipelines/azure-pipelines-build.yml`
+- the `barefoot` filter in `rules/docker-platform-monitor.mk`
 
 ##### 7.1.3 DTEL (data-plane telemetry)
 
-DTEL is SONiC's in-band data-plane telemetry. In practice it only ever ran on Barefoot Tofino, and that platform is EOL and is being removed in 7.1.2. With the only hardware that ran it gone, the DTEL code in the orchestration agent is dead. TAM, which was added in 202605, already covers the same need on current hardware.
+DTEL is SONiC's in-band data-plane telemetry. In practice it only ever ran on Barefoot Tofino, and that platform is EOL and is being removed in 7.1.2. With the only hardware that ran it gone, the DTEL code in the orchestration agent is dead, and that is the whole of the argument for removing it.
 
-**Remove:** `src/sonic-swss/orchagent/dtelorch.{cpp,h}`, the DTEL table set and initialization in `orchagent/orchdaemon.cpp`, and the DTEL handling in `orchagent/aclorch.{cpp,h}`; the DTEL CONFIG_DB tables and any `sonic-dtel` YANG model; `src/sonic-swss/tests/test_dtel.py`.
+TAM is the intended successor for in-band telemetry and drop monitoring, and its HLD is in review as sonic-net/SONiC#2094, alongside #2344 and #2379 in the same area. None of it has merged, so nothing in the tree covers DTEL's function today. This candidate does not wait on TAM, because the case here is that the hardware is gone rather than that a replacement has arrived.
+
+**Remove:**
+
+- `src/sonic-swss/orchagent/dtelorch.{cpp,h}`
+- the DTEL table set and its initialization in `src/sonic-swss/orchagent/orchdaemon.cpp`
+- the DTEL handling in `src/sonic-swss/orchagent/aclorch.{cpp,h}`
+- the DTEL CONFIG_DB tables. There is no `sonic-dtel` YANG model in the tree, so nothing to remove there.
+- `src/sonic-swss/tests/test_dtel.py`
 
 ##### 7.1.4 Standalone P4 platform
 
 This is the old bmv2 software behavioral model. It is a reference target rather than real hardware, and it has been dead since roughly 2022. Nothing in CI builds it. It is about 12 MB across 920 files, and it pulls in four stale external submodules. The only thing that references it outside `platform/p4/` is a Debian 8 era TODO in `rules/redis.mk`.
 
-**Remove:** `platform/p4/` (which includes `docker-sonic-p4`, `sai-p4-bm`, `p4c-bm`, `tenjin`, and `p4-hlir`); the four P4 submodule entries in `.gitmodules` (`platform/p4/p4c-bm/p4c-bm`, `platform/p4/p4-hlir/p4-hlir`, `platform/p4/p4-hlir/p4-hlir-v1.1`, `platform/p4/SAI-P4-BM`); the stale TODO in `rules/redis.mk`. **Keep:** `rules/p4lang.mk`. The p4lang toolchain it builds (bmv2, p4c, and PI) is a live dependency of DASH SAI, which ships in `sonic-vs.img.gz`, and of the PTF test containers.
+**Remove:**
+
+- `platform/p4/`, which includes `docker-sonic-p4`, `sai-p4-bm`, `p4c-bm`, `tenjin`, and `p4-hlir`
+- the four P4 submodule entries in `.gitmodules`, which are `platform/p4/p4c-bm/p4c-bm`, `platform/p4/p4-hlir/p4-hlir`, `platform/p4/p4-hlir/p4-hlir-v1.1`, and `platform/p4/SAI-P4-BM`
+- the jessie-era TODO in `rules/redis.mk`, which is the only reference to this platform outside `platform/p4/`
+
+**Keep:**
+
+- `rules/p4lang.mk`. The p4lang toolchain it builds, which is bmv2, p4c, and PI, is a live dependency of DASH SAI through `rules/dash-sai.mk`, and of `platform/vs/docker-ptf.mk` and `platform/vs/docker-ptf-sai.mk`.
 
 ##### 7.1.5 GoBGP and Quagga routing stacks
 
@@ -150,7 +186,32 @@ The target here is stack selection rather than the word Quagga. FRR is itself a 
 
 Where a Quagga-named file turns out to be the live FRR implementation, rename it rather than delete it. `clear/bgp_quagga_v4.py` is the clear case, because the `frr` branch of `clear/main.py` imports it and there is no `clear/bgp_frr_v4.py`, which makes it the working implementation of `clear ip bgp` today.
 
-**Remove (GoBGP):** `dockers/docker-fpm-gobgp/`, `src/gobgp/`, `rules/gobgp.mk`, and `rules/gobgp.dep`. **Remove (stack selection in the build):** `rules/docker-fpm.mk` and `rules/docker-fpm.dep`, which exist only to elect a stack, so `DOCKER_FPM_FRR` can be referenced directly and the dead `DOCKER_FPM_GOBGP` and `DOCKER_FPM_QUAGGA` names go with them; the `else` branch that adds `$(GOBGP)` in `platform/vs/docker-sonic-vs.mk`; the `SONIC_ROUTING_STACK` conditionals in `slave.mk` and `files/build_templates/sonic_debian_extension.j2`, whose FRR blocks become unconditional; the commented-out `ROUTING_STACK` selection in `platform/p4/docker-sonic-p4.mk`, which goes with 7.1.4 in any case. Keep `SONIC_ROUTING_STACK = frr` in `rules/config` as a single-value knob, because downstream `rules/config.user` files may still set it. **Remove (stack selection in the CLI):** in sonic-utilities, the `routing_stack == "quagga"` branches of `show/main.py` and `clear/main.py` along with `show/bgp_quagga_v4.py`, `show/bgp_quagga_v6.py`, and `clear/bgp_quagga_v6.py`; the non-frr `else` branches that carry the Quagga `bgp` and `zebra` groups in `debug/main.py` and `undebug/main.py`; the `/etc/quagga/bgpd.conf` branch of `show startupconfiguration bgp` and the matching `docker exec bgp cat /etc/quagga/bgpd.conf` entry in `files/image_config/sudoers/sudoers`; the cases that exercise the removed branches in `tests/show_test.py`, `tests/clear_test.py`, and `tests/debug_test.py`. **Rename:** `src/sonic-utilities/clear/bgp_quagga_v4.py` to `clear/bgp_frr_v4.py`, and update the import in `clear/main.py`.
+**Remove (GoBGP):**
+
+- `dockers/docker-fpm-gobgp/`, `src/gobgp/`, `rules/gobgp.mk`, and `rules/gobgp.dep`
+
+**Remove (stack selection in the build):**
+
+- `rules/docker-fpm.mk` and `rules/docker-fpm.dep`, which exist only to elect a stack. `DOCKER_FPM_FRR` can be referenced directly, and the dead `DOCKER_FPM_GOBGP` and `DOCKER_FPM_QUAGGA` names go with them.
+- the `else` branch that adds `$(GOBGP)` in `platform/vs/docker-sonic-vs.mk`
+- the `SONIC_ROUTING_STACK` conditionals in `slave.mk` and `files/build_templates/sonic_debian_extension.j2`, whose FRR blocks become unconditional
+- the commented-out `ROUTING_STACK` selection in `platform/p4/docker-sonic-p4.mk`, which goes with 7.1.4 in any case
+
+**Remove (stack selection in the CLI), all in sonic-utilities:**
+
+- the `routing_stack == "quagga"` branches of `show/main.py` and `clear/main.py`
+- `show/bgp_quagga_v4.py`, `show/bgp_quagga_v6.py`, and `clear/bgp_quagga_v6.py`
+- the non-frr `else` branches carrying the Quagga `bgp` and `zebra` groups in `debug/main.py` and `undebug/main.py`
+- the `/etc/quagga/bgpd.conf` branch of `show startupconfiguration bgp`, and the matching `docker exec bgp cat /etc/quagga/bgpd.conf` entry in `files/image_config/sudoers/sudoers`
+- the cases exercising the removed branches in `tests/show_test.py`, `tests/clear_test.py`, and `tests/debug_test.py`
+
+**Rename:**
+
+- `src/sonic-utilities/clear/bgp_quagga_v4.py` to `clear/bgp_frr_v4.py`, updating the import in `clear/main.py`
+
+**Keep:**
+
+- `SONIC_ROUTING_STACK = frr` in `rules/config` as a single-value knob, because downstream `rules/config.user` files may still set it
 
 Comments that only mention Quagga in passing, such as the `docker-fpm.gz` line in `README.md`, the `## Quagga rules` header in `files/image_config/rsyslog/rsyslog.d/00-sonic.conf.j2`, and the "For quagga build" comments in the sonic-slave Dockerfiles, are worth correcting when the code around them is touched, but they are not the point of this candidate. The packages under that build comment, such as `libreadline-dev`, `libpam-dev`, and the texlive set, are FRR build dependencies now, so leave them alone.
 
@@ -158,7 +219,11 @@ Comments that only mention Quagga in passing, such as the `docker-fpm.gz` line i
 
 Both packages are gated behind `ENABLE_PY2_MODULES`, which is off for bullseye, bookworm, and trixie. As a result, neither is built on any current release, so both are dead weight. The py3 version of swsssdk is a separate matter, because it is still in use. It is out of scope here and is noted under Additional findings.
 
-**Remove:** `rules/swsssdk-py2.mk`, `rules/swsssdk-py2.dep`, `rules/redis-dump-load-py2.mk`, and `rules/redis-dump-load-py2.dep`; the `SWSSSDK_PY2` dependency lines in `rules/sonic-py-common.mk` and `rules/swsssdk-py3.mk`.
+**Remove:**
+
+- `rules/swsssdk-py2.mk` and `rules/swsssdk-py2.dep`
+- `rules/redis-dump-load-py2.mk` and `rules/redis-dump-load-py2.dep`
+- the `SWSSSDK_PY2` dependency lines in `rules/sonic-py-common.mk` and `rules/swsssdk-py3.mk`
 
 ##### 7.1.7 Kubernetes master
 
@@ -166,55 +231,155 @@ This runs a full Kubernetes control plane on the switch. That includes the apise
 
 This applies to the master only. The worker feature (`INCLUDE_KUBERNETES`) is a separate feature and should stay. Someone hardened its cluster-join security before this working group existed, which points to a real user.
 
-**Remove:** `files/image_config/kubernetes/` (`kubernetes_master_entrance.sh`, `kubernetes_master_entrance.service`, `kubernetes.list`); the `INCLUDE_KUBERNETES_MASTER` flag and the master version pins in `rules/config`; the master-only blocks in `files/build_templates/sonic_debian_extension.j2`; `sonic-kubernetes_master.yang`; the master build in `.azure-pipelines/azure-pipelines-build.yml`. **Keep:** `INCLUDE_KUBERNETES` (the worker), `src/sonic-ctrmgrd*`, and the `ctrmgrd` wrapper, which runs for ordinary feature start and stop rather than only for k8s.
+**Remove:**
+
+- `files/image_config/kubernetes/`, which is `kubernetes_master_entrance.sh`, `kubernetes_master_entrance.service`, and `kubernetes.list`
+- the `INCLUDE_KUBERNETES_MASTER` flag in `rules/config`, and the `MASTER_*` version pins beside it, which are `MASTER_KUBERNETES_VERSION`, `MASTER_KUBERNETES_CONTAINER_IMAGE_VERSION`, `MASTER_PAUSE_VERSION`, `MASTER_COREDNS_VERSION`, `MASTER_ETCD_VERSION`, `MASTER_CRI_DOCKERD`, `MASTER_UI_METRIC_VERSION`, and `MASTER_UI_DASH_VERSION`
+- the `include_kubernetes_master` blocks in `files/build_templates/sonic_debian_extension.j2`
+- `src/sonic-yang-models/yang-models/sonic-kubernetes_master.yang`
+- the `K8S_MASTER_CHANGED` master image build in `.azure-pipelines/azure-pipelines-build.yml`
+
+**Keep:**
+
+- `INCLUDE_KUBERNETES`, which is the worker and a separate feature
+- `src/sonic-ctrmgrd*` and the `ctrmgrd` wrapper, which runs for ordinary feature start and stop rather than only for k8s
 
 ##### 7.1.8 docker-basic_router
 
 This is a SAI demo and reference container. It is not wired into any build rule, it never ships in an image, and it is not in CI. Its last real change was in 2020, and nothing uses it.
 
-**Remove:** `dockers/docker-basic_router/`.
+**Remove:**
+
+- `dockers/docker-basic_router/`
 
 ##### 7.1.9 System Telemetry container
 
 This container is off by default, and it is redundant. Both this container and the gnmi container run the same binary, `/usr/sbin/telemetry`, started by `telemetry.sh` and `gnmi-native.sh` respectively. There is no separate gNMI server. The `telemetry` binary is the server, and the name is only historical. Both containers read the same `TELEMETRY|gnmi` config, and the gnmi start script simply adds ZMQ and VRF options on top. There is therefore no functional gap, because Get, Set, Subscribe, and dial-out are identical in both.
 
-**Remove:** `dockers/docker-sonic-telemetry/`, `rules/docker-telemetry.mk`, and `rules/docker-telemetry.dep`; the `INCLUDE_SYSTEM_TELEMETRY` flag in `rules/config`. **Keep:** the `telemetry` binary, which is built by sonic-gnmi and run by the gnmi container.
+**Remove:**
 
-##### 7.1.10 Broken FRR config modes
+- `dockers/docker-sonic-telemetry/`
+- `rules/docker-telemetry.mk` and `rules/docker-telemetry.dep`
+- the `INCLUDE_SYSTEM_TELEMETRY` flag in `rules/config`
 
-`docker_routing_config_mode` has four values. Both `separated` and `split` write per-daemon config files such as `bgpd.conf` and `zebra.conf`. FRR 10.5.4, which SONiC ships, dropped support for per-daemon config files, so both of these modes are broken today. Removing them is really just deleting dead code.
+**Keep:**
 
-The supported path is `unified`, where the config comes from bgpcfgd and `config_db.json`, and that should become the default. Today `minigraph.py` hardcodes the default as `separated`, and init_cfg does not set it, so it resolves to `separated`. This change must flip that default to `unified`. The fourth mode, `split-unified`, still works and is handled under Deprecate.
+- the `telemetry` binary, which is built by sonic-gnmi and run by the gnmi container through `gnmi-native.sh`
 
-**Change:** remove the `separated` and `split` branches in `dockers/docker-fpm-frr/docker_init.sh` and the per-daemon templates under `dockers/docker-fpm-frr/frr/{bgpd,zebra,staticd,sharpd}/`; flip the default in `src/sonic-config-engine/minigraph.py` from `separated` to `unified`.
-
-##### 7.1.11 End-of-life Debian bases
+##### 7.1.10 End-of-life Debian bases
 
 Debian 8 (jessie), Debian 9 (stretch), Debian 10 (buster), and Debian 11 (bullseye) are all out of support. Bullseye leaves Debian LTS in August 2026, which is before 202611 ships, so it belongs with the rest rather than in a later cycle. The risk in every case is the same, which is that someone builds a new container on a base that no longer gets security updates.
 
 jessie, stretch, and buster are pure leftovers, because nothing builds on them. Bullseye is different, because containers still build on it today, so those have to move first. Before deleting any base, confirm that nothing still builds a container on it. Debian 12 (bookworm) is still a live base and is handled under Deprecate.
 
-**Remove (stretch):** `dockers/docker-base-stretch/`, `rules/docker-base-stretch.{mk,dep}`, `dockers/docker-config-engine-stretch/`, `rules/docker-config-engine-stretch.{mk,dep}`. **Remove (buster):** `dockers/docker-base-buster/`, `rules/docker-base-buster.{mk,dep}`, `dockers/docker-config-engine-buster/`, `rules/docker-config-engine-buster.{mk,dep}`, `dockers/docker-swss-layer-buster/`, `rules/docker-swss-layer-buster.{mk,dep}`. **Remove (jessie):** `sonic-slave-jessie/`, the `jessie` target in `Makefile`, and the jessie `SLAVE_DIR` branch in `Makefile.work`. jessie has no `docker-base-jessie`, so also check the jessie strings in the generic `dockers/docker-base/` (its armhf and arm64 sources and its `FROM ...:jessie` lines) before touching that container. **Move first (bullseye):** seven containers still build on a bullseye base. Two of them, `docker-syncd-bfn` and `docker-saiserver-bfn`, go away with Barefoot in 7.1.2. The other five have to move to bookworm or trixie before bullseye can go, and they are `docker-syncd-centec` and `docker-saiserver-centec` under both `platform/centec/` and `platform/centec-arm64/`, plus `dockers/docker-sonic-sdk/`. The centec containers reach bullseye through `platform/template/docker-syncd-bullseye.mk`, so pointing their `docker-syncd-centec.mk` at the bookworm or trixie template covers four of the five. **Remove (bullseye):** `dockers/docker-base-bullseye/`, `rules/docker-base-bullseye.{mk,dep}`, `dockers/docker-config-engine-bullseye/`, `rules/docker-config-engine-bullseye.{mk,dep}`, `dockers/docker-swss-layer-bullseye/`, `rules/docker-swss-layer-bullseye.{mk,dep}`, `platform/template/docker-syncd-bullseye.mk`, and `sonic-slave-bullseye/`; the `bullseye` target and the `NOBULLSEYE` and `BUILD_BULLSEYE` handling in `Makefile`, the bullseye `SLAVE_DIR` branch in `Makefile.work`, the `sonic-slave-bullseye` entry in `Makefile.cache`, and in `slave.mk` the `BULLSEYE_DEBS_PATH` and `BULLSEYE_FILES_PATH` variables, the `bullseye` target, and the `BLDENV` tests that name it; the `BLDENV == bullseye` conditionals in `rules/grpc.mk`, `rules/protobuf.mk`, `rules/sonic-dash-api.mk`, and `rules/sonic-fips.mk`.
+**Remove (stretch):**
+
+- `dockers/docker-base-stretch/` and `rules/docker-base-stretch.{mk,dep}`
+- `dockers/docker-config-engine-stretch/` and `rules/docker-config-engine-stretch.{mk,dep}`
+
+**Remove (buster):**
+
+- `dockers/docker-base-buster/` and `rules/docker-base-buster.{mk,dep}`
+- `dockers/docker-config-engine-buster/` and `rules/docker-config-engine-buster.{mk,dep}`
+- `dockers/docker-swss-layer-buster/` and `rules/docker-swss-layer-buster.{mk,dep}`
+
+**Remove (jessie):**
+
+- `sonic-slave-jessie/`
+- the `jessie` target in `Makefile`, and the jessie `SLAVE_DIR` branch in `Makefile.work`
+- jessie has no `docker-base-jessie`, so check the jessie strings in the generic `dockers/docker-base/` first, meaning its armhf and arm64 sources and its `FROM ...:jessie` lines, before touching that container
+
+**Move first (bullseye).** Seven containers still build on a bullseye base. Two of them, `docker-syncd-bfn` and `docker-saiserver-bfn`, go away with Barefoot in 7.1.2. The other five have to move to bookworm or trixie before bullseye can go:
+
+- `docker-syncd-centec` and `docker-saiserver-centec` under `platform/centec/`
+- `docker-syncd-centec` and `docker-saiserver-centec` under `platform/centec-arm64/`
+- `dockers/docker-sonic-sdk/`
+
+The centec containers reach bullseye through `platform/template/docker-syncd-bullseye.mk`, so pointing their `docker-syncd-centec.mk` at the bookworm or trixie template covers four of the five.
+
+**Remove (bullseye):**
+
+- `dockers/docker-base-bullseye/` and `rules/docker-base-bullseye.{mk,dep}`
+- `dockers/docker-config-engine-bullseye/` and `rules/docker-config-engine-bullseye.{mk,dep}`
+- `dockers/docker-swss-layer-bullseye/` and `rules/docker-swss-layer-bullseye.{mk,dep}`
+- `platform/template/docker-syncd-bullseye.mk` and `sonic-slave-bullseye/`
+- in `Makefile`, the `bullseye` target and the `NOBULLSEYE` and `BUILD_BULLSEYE` handling
+- the bullseye `SLAVE_DIR` branch in `Makefile.work`, and the `sonic-slave-bullseye` entry in `Makefile.cache`
+- in `slave.mk`, the `BULLSEYE_DEBS_PATH` and `BULLSEYE_FILES_PATH` variables, the `bullseye` target, and the `BLDENV` tests that name it
+- the `BLDENV == bullseye` conditionals in `rules/grpc.mk`, `rules/protobuf.mk`, `rules/sonic-dash-api.mk`, and `rules/sonic-fips.mk`
 
 #### 7.2 Deprecate now, remove later
 
 ##### 7.2.1 Bookworm base containers
 
-This should be removed in 202705. Bookworm is Debian 12. Its regular security support ends in 2026, which leaves LTS only, and trixie is the current base. It is still a live base, so it deserves a cycle of notice rather than immediate removal. Three syncd containers build on it, which are `docker-syncd-pensando`, `docker-syncd-vs` under `platform/alpinevs/`, and `docker-syncd-vs` under `platform/nokia-vs/`, and the last two reach it through `platform/template/docker-syncd-bookworm.mk`. Move those to trixie first, and then remove the base.
+This should be removed in 202705. Bookworm is Debian 12. Its regular security support ends in 2026, which leaves LTS only, and trixie is the current base. It is a live base with more on it than bullseye has, so it deserves a cycle of notice rather than immediate removal.
 
-**Remove (202705):** `dockers/docker-base-bookworm/`, `rules/docker-base-bookworm.{mk,dep}`, `dockers/docker-config-engine-bookworm/`, `rules/docker-config-engine-bookworm.{mk,dep}`, `dockers/docker-swss-layer-bookworm/`, `rules/docker-swss-layer-bookworm.{mk,dep}`, `platform/template/docker-syncd-bookworm.mk`, and `sonic-slave-bookworm/`; the `bookworm` target and the `NOBOOKWORM` and `BUILD_BOOKWORM` handling in `Makefile`, and the bookworm `SLAVE_DIR` branch in `Makefile.work`.
+Five containers build on bookworm today, and all five move to trixie before the base can go:
 
-##### 7.2.2 FRR split-unified config mode
+- `platform/vs/docker-sonic-vs`, which takes `docker-swss-layer-bookworm` directly. This is the virtual switch image the community tests with, so it is the one to move first and the one most likely to surface problems.
+- `platform/cisco/docker-syncd-cisco` and `platform/cisco/docker-gbsyncd-cisco`, both `FROM docker-config-engine-bookworm`
+- `platform/alpinevs/docker-syncd-vs` and `platform/nokia-vs/docker-syncd-vs`, which reach it through `platform/template/docker-syncd-bookworm.mk`
 
-This should be removed in 202705. It is the manual routing mode, where the operator writes `frr.conf` by hand. It has a real problem. The bgp container runs supervisord rather than systemd, so FRR cannot hot-reload, and any change to `frr.conf` forces a full FRR restart that drops BGP sessions. That makes it impractical for production, so it is doubtful anyone serious runs it. The plan is to consolidate on `unified`, which uses bgpcfgd and `config_db.json`. Before removing it, confirm that bgpcfgd and `config_db.json` cover the FRR features operators actually need.
+`docker-syncd-pensando` is not among them, despite what an earlier draft of this plan said. It is already on trixie, through `platform/template/docker-syncd-trixie.mk`.
 
-**Change (202705):** remove the `split-unified` branch in `dockers/docker-fpm-frr/docker_init.sh`.
+**Remove (202705):**
+
+- `dockers/docker-base-bookworm/` and `rules/docker-base-bookworm.{mk,dep}`
+- `dockers/docker-config-engine-bookworm/` and `rules/docker-config-engine-bookworm.{mk,dep}`
+- `dockers/docker-swss-layer-bookworm/` and `rules/docker-swss-layer-bookworm.{mk,dep}`
+- `platform/template/docker-syncd-bookworm.mk` and `sonic-slave-bookworm/`
+- in `Makefile`, the `bookworm` target and the `NOBOOKWORM` and `BUILD_BOOKWORM` handling
+- the bookworm `SLAVE_DIR` branch in `Makefile.work`
+
+##### 7.2.2 FRR split and split-unified config modes
+
+Both should be removed in 202705. These are the two manual routing modes, where SONiC renders no FRR config at all and the operator writes it by hand, as per-daemon files under `split` and as a single `frr.conf` under `split-unified`. The other two values of `docker_routing_config_mode`, which are `separated` and `unified`, generate the config from CONFIG_DB and are not touched by this candidate.
+
+They share a real problem. The bgp container runs supervisord rather than systemd, so FRR cannot hot-reload, and any change to the hand-written config forces a full FRR restart that drops BGP sessions. That makes both impractical for production, so it is doubtful anyone serious runs either. `split` has a second problem of its own, which is that FRR no longer writes per-daemon files. Since the move to `mgmtd`, `write memory` updates only the integrated config, and FRR's own documentation calls per-daemon files a transition mechanism to be removed once a user has moved off them. An operator running `split` therefore cannot save the running config back to the files they manage.
+
+Neither mode is as separate from CONFIG_DB as its description suggests. supervisord starts bgpcfgd in every mode, because nothing in the container consults `docker_routing_config_mode` to decide, so a box in a split mode still has bgpcfgd pushing whatever BGP state CONFIG_DB holds. It is a no-op in practice only because such a box has no BGP tables filled in.
+
+Before removing them, name where an operator who manages their own FRR config is expected to go. `unified` is the intended destination, but it is not a drop-in one today. Its bgpcfgd template renders no `fpm address` line, and zebra's `dplane_fpm_sonic` module does not connect without one, so that gap is closed first.
+
+**Change (202705):**
+
+- remove the `split` and `split-unified` branches in `dockers/docker-fpm-frr/docker_init.sh`, along with the `write_default_zebra_config` helper, which has no other caller
+- drop `split-unified` from the `vtysh_b` condition in `dockers/docker-fpm-frr/frr/supervisord/supervisord.conf.common.j2`
+- narrow the `docker_routing_config_mode` pattern in `src/sonic-yang-models/yang-models/sonic-device_metadata.yang` from `separated|unified|split|split-unified` to `separated|unified`, and drop the two descriptions above it
 
 ##### 7.2.3 REST API
 
-This should be removed in 202711. It is off by default. Its own spec calls it the "SONiC REST API for Baremetal Scenarios." It is an imperative agent for baremetal VNET, VXLAN, and VLAN config over HTTPS, not a general REST interface. gNMI is the intended replacement, but it does not cover two things. The first is bulk route programming with per-route partial success (HTTP 207). The second is route expiry, which is timed route aging. Because of that gap, this candidate gets the longest runway. Before removing it, confirm that no control plane still drives it. The mgmt-framework REST server is a different thing and stays.
+This should be removed in 202711. It is off by default in `rules/config`, though that is not the whole picture: the pull request pipeline sets `INCLUDE_RESTAPI: y` for the broadcom and marvell-prestera-armhf job groups, so community builds for those platforms do carry it, and `init_cfg.json.j2` has a broadcom-specific enable path on top. Its own spec calls it the "SONiC REST API for Baremetal Scenarios." It is an imperative agent for baremetal VNET, VXLAN, and VLAN config over HTTPS, not a general REST interface. gNMI is the intended replacement, but it does not cover two things. The first is bulk route programming with per-route partial success (HTTP 207). The second is route expiry, which is timed route aging. Because of that gap, this candidate gets the longest runway. Before removing it, confirm that no control plane still drives it.
 
-**Remove (202711):** `dockers/docker-sonic-restapi/`, `src/sonic-restapi/` and its `.gitmodules` entry, `rules/docker-restapi.{mk,dep}`, and `rules/restapi.{mk,dep}`; the `INCLUDE_RESTAPI` flag in `rules/config`; the `restapi` feature in `files/build_templates/init_cfg.json.j2`.
+This candidate is `sonic-restapi` and nothing else. **RESTCONF is not affected and is not going away.** The two are separate servers in separate repositories, and the names are close enough that it is worth being explicit about which is which.
+
+`sonic-restapi` is a hand-written imperative API. Its routes are `/v1/config/interface/vlan/{vlan_id}`, `/v1/config/tunnel/encap/vxlan/{vnid}`, `/v1/config/vrouter/{vnet_name}/routes` and the like, defined in `src/sonic-restapi/sonic_api.yaml` and served by `src/sonic-restapi/go-server-server/`. It is off by default and it is what this candidate removes. There is no RESTCONF anywhere in that repository.
+
+RESTCONF is implemented in the management framework, in `src/sonic-mgmt-framework/rest/server/restconf.go`, which serves `/restconf/data/`, `/restconf/operations/`, `yang-library-version` and the `ietf-restconf-monitoring` capabilities over `application/yang-data+json`. It is YANG driven through `src/sonic-mgmt-common/`, it listens on 443 rather than 8081, and it ships enabled by default, because `INCLUDE_MGMT_FRAMEWORK = y` in `rules/config`.
+
+RESTCONF is kept, but it is not a replacement for this API either, and it is worth saying so before anyone assumes it is. The management framework serves openconfig-acl, openconfig-interfaces with if-ethernet and if-ip, openconfig-lldp, openconfig-platform, openconfig-sampling-sflow, openconfig-system, the gnsi models, and sonic-acl, sonic-interface, sonic-port and sonic-show-techsupport, backed by translib apps for ACL, LLDP, platform and system in `src/sonic-mgmt-common/translib/`. None of the tables this API writes is modelled there, and those are `VNET`, `VXLAN_TUNNEL`, `VNET_ROUTE_TUNNEL`, `VLAN`, `VLAN_MEMBER`, `VLAN_INTERFACE`, `NEIGH`, and `STATIC_ROUTE`. Reaching them through RESTCONF would mean writing new YANG models and new translib apps, which is more work than the removal itself.
+
+gNMI reaches them without new models, because its Set writes CONFIG_DB rows directly rather than through a per-table model, in `MixedDbClient.Set` in `src/sonic-gnmi/sonic_data_client/mixed_db_client.go`. That is why gNMI, and not RESTCONF, is named as the replacement above.
+
+Neither closes the two gaps. The bulk route PATCH returns `http.StatusMultiStatus` per element in `src/sonic-restapi/go-server-server/go/default.go`, and route expiry is a server-side timer backed by the `STATIC_ROUTE_EXPIRY_TIME` table, reached through `/v1/config/vrf/route_expiry`. RESTCONF has no per-item partial success, because the management framework does not implement YANG Patch, and it has no notion of an expiring entry. Whoever drives this API today needs an answer for both before it goes.
+
+**Keep,** none of which this candidate touches:
+
+- `src/sonic-mgmt-framework/` and `src/sonic-mgmt-common/`
+- `dockers/docker-sonic-mgmt-framework/`
+- `rules/docker-sonic-mgmt-framework.{mk,dep}`, `rules/sonic-mgmt-framework.{mk,dep}`, and `rules/sonic-mgmt-common.{mk,dep}`
+- the `INCLUDE_MGMT_FRAMEWORK` flag in `rules/config`, which is `y`
+- the `mgmt-framework` feature in `files/build_templates/init_cfg.json.j2`
+
+**Remove (202711):**
+
+- `dockers/docker-sonic-restapi/`
+- `src/sonic-restapi/` and its `.gitmodules` entry
+- `rules/docker-restapi.{mk,dep}` and `rules/restapi.{mk,dep}`
+- the `INCLUDE_RESTAPI` flag in `rules/config`
+- the `restapi` feature in `files/build_templates/init_cfg.json.j2`
+- the `INCLUDE_RESTAPI: y` overrides in the broadcom and marvell-prestera-armhf job groups in `azure-pipelines.yml`
+
 ### 8. SAI API
 
 There is no change to the SAI API. Nothing here adds, removes, or modifies a SAI API or object, and silicon vendors have nothing to implement for this plan.
@@ -235,43 +400,38 @@ No command is added, and no command changes its syntax. The changes are deletion
 
 YANG models removed with their features:
 
-- `sonic-kubernetes_master.yang`, with 7.1.7.
-- The `sonic-dtel` model and the DTEL CONFIG_DB tables, with 7.1.3.
+- `src/sonic-yang-models/yang-models/sonic-kubernetes_master.yang`, with 7.1.7. This is the only YANG model this batch removes.
+- DTEL, with 7.1.3, drops CONFIG_DB tables but no model, because it never had one.
 
 CLI effects:
 
 - Collapsing the routing stack to FRR in 7.1.5 does not change any command an operator runs, because the FRR branch of every affected command already provides the same CLI. `clear ip bgp` keeps working through the renamed `clear/bgp_frr_v4.py`. The one visible difference is `show startupconfiguration bgp`, which loses its `/etc/quagga/bgpd.conf` branch and reads only `/etc/frr/bgpd.conf`.
-- `docker_routing_config_mode` accepts fewer values after 7.1.10, which is a narrowing of an existing setting rather than a CLI change.
 
 `sonic-utilities/doc/Command-Reference.md` carries more Quagga material than the code does, and it is updated in the same pull request as 7.1.5. That means the whole `## Quagga BGP Show Commands` section and its entry in the table of contents, the `Versions <= 201811 using Quagga routing stack` variants and the links to them under the BGP show commands, and the `## Routing Stack` section, which still tells the reader that SONiC is agnostic of the routing stack and that Quagga is a choice. The `show startupconfiguration bgp` entry loses its Quagga path with the code. Nothing in the reference describes the other candidates, because the Kubernetes commands documented there belong to the worker feature, which stays.
 
 #### 9.3 Config DB Enhancements
 
-Removing the code is only half of it, because a device that upgrades keeps whatever it already had in CONFIG_DB. Every removal that touches configuration therefore has to update `sonic-utilities/scripts/db_migrator.py`, and that update is part of the removal rather than a follow-up. Without it, an upgraded device carries dead `FEATURE` rows and orphaned tables forever, a table that outlives its YANG model can fail config validation, and a setting whose supported values have narrowed can leave the device pointing at a value that no longer exists.
+Removing the code is only half of it, because a device that upgrades keeps whatever it already had in CONFIG_DB. Every removal that touches configuration therefore has to update `sonic-utilities/scripts/db_migrator.py`, and that update is part of the removal rather than a follow-up. Without it, an upgraded device carries dead `FEATURE` rows and orphaned tables forever, and a table that outlives its YANG model can fail config validation.
 
 The shape of the change is the same each time. Add a new `version_<branch>_<build>` method chained onto the current tail of the version chain, bump `CURRENT_VERSION` to it, which is `version_202605_01` today, and drop the state that is going away with `delete_table` or with entry deletion. What this batch needs:
 
-- `DEVICE_METADATA|localhost|docker_routing_config_mode`. A device holding `separated` or `split` has to be migrated to `unified`, because 7.1.10 deletes the code behind both. This is the case that matters most, since skipping it leaves a device configured for a routing mode that no longer exists rather than merely carrying dead config.
 - The `KUBERNETES_MASTER` table, which goes with 7.1.7, along with its YANG model.
 - The DTEL tables, which go with 7.1.3.
 - `FEATURE|telemetry`, which goes with 7.1.9. `FEATURE|gnmi` stays, and the two must not be confused, because the surviving container is the gnmi one.
 - `FEATURE|restapi`, when the REST API is removed in 202711 under 7.2.3, which lands in that release's migrator rather than this one.
-
-The default for `docker_routing_config_mode` also changes. Today `src/sonic-config-engine/minigraph.py` hardcodes `separated` and init_cfg does not set it, so a device with no explicit value resolves to `separated`. 7.1.10 flips that default to `unified`.
+- `DEVICE_METADATA|localhost|docker_routing_config_mode`, when the split modes are removed in 202705 under 7.2.2. A device holding `split` or `split-unified` is migrated to a value that still exists, and this lands in that release's migrator rather than this one.
 
 ### 10. Warmboot and Fastboot Design Impact
 
 There is no warmboot or fastboot impact. Every candidate is off by default, already dead, or specific to hardware that is being removed. None of this touches the warmboot or fastboot path on supported platforms.
-
-The one candidate that touches a path a supported device runs is 7.1.10, and it changes which FRR config mode is selected at container start rather than anything in the warmboot or fastboot sequence. A device already running `unified`, which is the supported mode, sees no change at all.
 
 #### Warmboot and Fastboot Performance Impact
 
 There is no degradation, and the direction of every change is downward.
 
 - No stall, sleep, or IO operation is added to the boot critical chain. Code is deleted from it, not added.
-- No CPU heavy processing is added. 7.1.10 removes three of the four branches in `docker_init.sh` and the per-daemon Jinja templates behind them, which is strictly less template rendering at bgp container start.
-- No third party dependency is bumped for a device that ships today. The base image moves in 7.1.11 and 7.2.1 change which Debian base a container is built from, and the containers involved are the centec syncd and saiserver containers and `docker-sonic-sdk`. Those are build time changes, and the platforms that own them validate boot time as part of the move.
+- No CPU heavy processing is added. Nothing here renders a template, starts a process, or does work of any kind in the boot path that was not already there.
+- No third party dependency is bumped for a device that ships today. The base image moves in 7.1.10 and 7.2.1 change which Debian base a container is built from, and the containers involved are the centec syncd and saiserver containers and `docker-sonic-sdk`. Those are build time changes, and the platforms that own them validate boot time as part of the move.
 - Nothing here needs to be delayed, because nothing here starts.
 
 ### 11. Memory Consumption
@@ -282,7 +442,7 @@ The features that carried a running process are off by default today, so a devic
 
 ### 12. Restrictions/Limitations
 
-- Bullseye cannot be removed until five containers move off it, which are the centec syncd and saiserver containers under `platform/centec/` and `platform/centec-arm64/`, and `dockers/docker-sonic-sdk/`. That move is a prerequisite of 7.1.11 rather than part of it, and it depends on the platform owners.
+- Bullseye cannot be removed until five containers move off it, which are the centec syncd and saiserver containers under `platform/centec/` and `platform/centec-arm64/`, and `dockers/docker-sonic-sdk/`. That move is a prerequisite of 7.1.10 rather than part of it, and it depends on the platform owners.
 - The same applies to bookworm in 7.2.1, where three syncd containers have to move to trixie first.
 - gNMI does not fully replace the REST API. It does not cover bulk route programming with per-route partial success (HTTP 207), and it does not cover route expiry. That gap is why 7.2.3 gets the longest runway, and it is not closed by this plan.
 - Removing a feature that is off by default is not proof that nobody runs it. The notification steps in the policy exist for that reason, and a verdict can move to **Keep** at any point before the removal lands.
@@ -293,8 +453,7 @@ Each removal is tested in the pull request that performs it, rather than here. T
 
 #### 13.1 Unit Test cases
 
-- `db_migrator` unit tests cover each table and field this batch drops, including a device that starts on `separated` and one that starts on `split`, and both end on `unified`.
-- The `sonic-config-engine` tests cover the new `unified` default in `minigraph.py`, with and without an explicit `docker_routing_config_mode`.
+- `db_migrator` unit tests cover each table and field this batch drops, starting from a `config_db.json` that still carries them.
 - The `sonic-swss` test suite still passes with `tests/test_dtel.py` and the DTEL orchestration agent code removed.
 - YANG model tests pass with the removed models absent, and no remaining model references them.
 
@@ -302,9 +461,8 @@ Each removal is tested in the pull request that performs it, rather than here. T
 
 - Each supported CI platform still builds after the removals.
 - The removed packages no longer appear in the SBOM or the CVE scan, confirmed by an image diff.
-- The default FRR path (`unified`) comes up and programs routes.
+- BGP comes up and programs routes after the routing-stack collapse in 7.1.5, in whichever `docker_routing_config_mode` the device already runs.
 - A `config_db.json` from the previous release migrates cleanly, with no leftover tables for removed features and no config validation errors against the reduced YANG model set.
-- A device configured for `separated` or `split` comes up in `unified` after upgrade, rather than pointing at a mode whose code is gone.
 - Every remaining container builds with nothing pointing at a deleted base, and the centec and sonic-sdk containers build on their new base.
 - `show ip bgp` and `clear ip bgp` still work after the routing-stack collapse and the `clear/bgp_frr_v4.py` rename.
 - gNMI still serves Get, Set, Subscribe, and dial-out after the System Telemetry container is removed.
@@ -314,4 +472,5 @@ Each removal is tested in the pull request that performs it, rather than here. T
 - Component owner sign-off is outstanding for every candidate. No removal lands without it.
 - The three platform removals need a TSC decision, which is step 4 of the policy.
 - The five bullseye containers and the three bookworm containers need an owner to move them to a newer base, as described in section 12.
+- **FRR config modes were considered and dropped.** An earlier draft proposed removing the `separated` and `split` values of `docker_routing_config_mode` as dead code, on the grounds that FRR 10.5 had dropped per-daemon config files. That is not what happened. FRR still reads per-daemon files, and since FRR 9.0 `mgmtd` reads them on behalf of the daemons that moved to it, which are zebra, staticd, ripd, and ripngd. `separated` is the default that `minigraph.py` sets and it works. The candidate is recorded here so that a later cycle does not repeat the mistake. What survived the check is 7.2.2, which deprecates the two modes where SONiC generates no config at all, and which carries the prerequisite for any later consolidation on `unified`.
 - **swsssdk-py3.** This is the old Python Redis SDK. `swsscommon` replaces it, but code still imports `swsssdk` at runtime, including `sonic-utilities/scripts/dualtor_neighbor_check.py`, `sonic-py-common`, and the vpp container. It cannot be deprecated until those are ported to `swsscommon`, so it is not a candidate in this plan. It is recorded here so that a later cycle picks it up.

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -10,10 +10,10 @@
 - [6. Architecture Design](#6-architecture-design)
 - [7. High-Level Design](#7-high-level-design)
   - [7.1 Remove now](#71-remove-now)
-    - [7.1.1 Barefoot / Tofino platform](#711-barefoot--tofino-platform)
-    - [7.1.2 DTEL (data-plane telemetry)](#712-dtel-data-plane-telemetry)
-    - [7.1.3 Standalone P4 platform](#713-standalone-p4-platform)
-    - [7.1.4 Nephos platform](#714-nephos-platform)
+    - [7.1.1 Nephos platform](#711-nephos-platform)
+    - [7.1.2 Barefoot / Tofino platform](#712-barefoot--tofino-platform)
+    - [7.1.3 DTEL (data-plane telemetry)](#713-dtel-data-plane-telemetry)
+    - [7.1.4 Standalone P4 platform](#714-standalone-p4-platform)
     - [7.1.5 GoBGP and Quagga routing stacks](#715-gobgp-and-quagga-routing-stacks)
     - [7.1.6 Python 2 packages](#716-python-2-packages)
     - [7.1.7 Kubernetes master](#717-kubernetes-master)
@@ -46,6 +46,7 @@
 | 0.2 | 2026-07-24 | Brad House (Nexthop) | Added the Keep verdict. Moved bullseye to immediate removal and deprecated bookworm in its place. Folded Quagga into the GoBGP removal. |
 | 0.3 | 2026-07-24 | Brad House (Nexthop) | Filled in the notification steps of the process, which are the mailing list, the working groups, the TSC for platform removals, and a second round before the branch date. |
 | 0.4 | 2026-08-24 | Brad House (Nexthop) | Moved the standing process, the verdicts, and the rules of thumb into the TSC policy document, so that this HLD covers only the 202611 candidates. Restructured to the HLD template. |
+| 0.5 | 2026-08-24 | Brad House (Nexthop) | Moved Nephos to the head of the remove-now list, so that the platform removals read together. 7.1.1 through 7.1.4 are renumbered, and the rest of the list is unchanged. |
 
 ### 2. Scope
 
@@ -85,7 +86,7 @@ This HLD proposes the first batch to act on. Fourteen candidates are listed. Ele
 
 - Every candidate carries a verdict, the evidence behind it, and the exact paths it covers, as required by [section 6 of the policy](../../tsc/eol-deprecation/sonic_eol_deprecation_policy.md#6-what-a-release-plan-contains).
 - No feature is removed without component owner sign-off.
-- The three platform removals, which are 7.1.1 Barefoot, 7.1.3 standalone P4, and 7.1.4 Nephos, go to the TSC in addition to HLD review. The TSC decision is what settles them.
+- The three platform removals, which are 7.1.1 Nephos, 7.1.2 Barefoot, and 7.1.4 standalone P4, go to the TSC in addition to HLD review. The TSC decision is what settles them.
 - A user who never enabled any of these features sees no functional change and no CLI change.
 - Every removal that touches configuration is accompanied by a `db_migrator.py` update, so that a device that upgrades does not carry dead config or point at a value that no longer exists. See section 9.3.
 - Each supported CI platform still builds after the removals, and no remaining container points at a deleted base.
@@ -111,33 +112,33 @@ These are built-in SONiC features rather than Application Extensions. The reposi
 
 Each candidate below stands on its own. It states what the feature is, why it should go, the paths to remove, and anything to watch out for.
 
-Three of these are platform removals, which are 7.1.1 Barefoot, 7.1.3 standalone P4, and 7.1.4 Nephos. Those go to the TSC under step 4 of the policy, separately from the rest of this list.
+Three of these are platform removals, which are 7.1.1 Nephos, 7.1.2 Barefoot, and 7.1.4 standalone P4. Those go to the TSC under step 4 of the policy, separately from the rest of this list.
 
 #### 7.1 Remove now
 
-##### 7.1.1 Barefoot / Tofino platform
+##### 7.1.1 Nephos platform
+
+The Nephos and MediaTek switch silicon vendor left the market around 2019. The platform is about 2.3 MB across 160 files. There is no `device/nephos` tree, there has been no genuine commit in years, and it is not in CI.
+
+**Remove:** `platform/nephos/`; the `nephos` job in `.azure-pipelines/azure-pipelines-build.yml`.
+
+##### 7.1.2 Barefoot / Tofino platform
 
 Intel has ended the Tofino line, and the platform is not in the CI build matrix (aspeed_arm64, broadcom, marvell-prestera, mellanox, nvidia_bluefield, vs, alpinevs, and vpp). Because nothing builds it, nothing tests it. The platform is roughly 7.7 MB across about 880 files, and it pulls in the Barefoot SAI, saithrift, the `docker-syncd-bfn` and `docker-saiserver-bfn` containers, and the ODM sub-platforms built on Tofino (Accton Wedge100BF, Arista 7170, Ingrasys, Netberg, and WNC).
 
 **Remove:** `platform/barefoot/`; the Tofino `device/` folders (Accton Wedge100BF, Arista 7170, Ingrasys, Netberg, WNC); the `barefoot` job in `.azure-pipelines/azure-pipelines-build.yml`; the `barefoot` filter in `rules/docker-platform-monitor.mk`.
 
-##### 7.1.2 DTEL (data-plane telemetry)
+##### 7.1.3 DTEL (data-plane telemetry)
 
-DTEL is SONiC's in-band data-plane telemetry. In practice it only ever ran on Barefoot Tofino, and that platform is EOL and is being removed in 7.1.1. With the only hardware that ran it gone, the DTEL code in the orchestration agent is dead. TAM, which was added in 202605, already covers the same need on current hardware.
+DTEL is SONiC's in-band data-plane telemetry. In practice it only ever ran on Barefoot Tofino, and that platform is EOL and is being removed in 7.1.2. With the only hardware that ran it gone, the DTEL code in the orchestration agent is dead. TAM, which was added in 202605, already covers the same need on current hardware.
 
 **Remove:** `src/sonic-swss/orchagent/dtelorch.{cpp,h}`, the DTEL table set and initialization in `orchagent/orchdaemon.cpp`, and the DTEL handling in `orchagent/aclorch.{cpp,h}`; the DTEL CONFIG_DB tables and any `sonic-dtel` YANG model; `src/sonic-swss/tests/test_dtel.py`.
 
-##### 7.1.3 Standalone P4 platform
+##### 7.1.4 Standalone P4 platform
 
 This is the old bmv2 software behavioral model. It is a reference target rather than real hardware, and it has been dead since roughly 2022. Nothing in CI builds it. It is about 12 MB across 920 files, and it pulls in four stale external submodules. The only thing that references it outside `platform/p4/` is a Debian 8 era TODO in `rules/redis.mk`.
 
 **Remove:** `platform/p4/` (which includes `docker-sonic-p4`, `sai-p4-bm`, `p4c-bm`, `tenjin`, and `p4-hlir`); the four P4 submodule entries in `.gitmodules` (`platform/p4/p4c-bm/p4c-bm`, `platform/p4/p4-hlir/p4-hlir`, `platform/p4/p4-hlir/p4-hlir-v1.1`, `platform/p4/SAI-P4-BM`); the stale TODO in `rules/redis.mk`. **Keep:** `rules/p4lang.mk`. The p4lang toolchain it builds (bmv2, p4c, and PI) is a live dependency of DASH SAI, which ships in `sonic-vs.img.gz`, and of the PTF test containers.
-
-##### 7.1.4 Nephos platform
-
-The Nephos and MediaTek switch silicon vendor left the market around 2019. The platform is about 2.3 MB across 160 files. There is no `device/nephos` tree, there has been no genuine commit in years, and it is not in CI.
-
-**Remove:** `platform/nephos/`; the `nephos` job in `.azure-pipelines/azure-pipelines-build.yml`.
 
 ##### 7.1.5 GoBGP and Quagga routing stacks
 
@@ -149,7 +150,7 @@ The target here is stack selection rather than the word Quagga. FRR is itself a 
 
 Where a Quagga-named file turns out to be the live FRR implementation, rename it rather than delete it. `clear/bgp_quagga_v4.py` is the clear case, because the `frr` branch of `clear/main.py` imports it and there is no `clear/bgp_frr_v4.py`, which makes it the working implementation of `clear ip bgp` today.
 
-**Remove (GoBGP):** `dockers/docker-fpm-gobgp/`, `src/gobgp/`, `rules/gobgp.mk`, and `rules/gobgp.dep`. **Remove (stack selection in the build):** `rules/docker-fpm.mk` and `rules/docker-fpm.dep`, which exist only to elect a stack, so `DOCKER_FPM_FRR` can be referenced directly and the dead `DOCKER_FPM_GOBGP` and `DOCKER_FPM_QUAGGA` names go with them; the `else` branch that adds `$(GOBGP)` in `platform/vs/docker-sonic-vs.mk`; the `SONIC_ROUTING_STACK` conditionals in `slave.mk` and `files/build_templates/sonic_debian_extension.j2`, whose FRR blocks become unconditional; the commented-out `ROUTING_STACK` selection in `platform/p4/docker-sonic-p4.mk`, which goes with 7.1.3 in any case. Keep `SONIC_ROUTING_STACK = frr` in `rules/config` as a single-value knob, because downstream `rules/config.user` files may still set it. **Remove (stack selection in the CLI):** in sonic-utilities, the `routing_stack == "quagga"` branches of `show/main.py` and `clear/main.py` along with `show/bgp_quagga_v4.py`, `show/bgp_quagga_v6.py`, and `clear/bgp_quagga_v6.py`; the non-frr `else` branches that carry the Quagga `bgp` and `zebra` groups in `debug/main.py` and `undebug/main.py`; the `/etc/quagga/bgpd.conf` branch of `show startupconfiguration bgp` and the matching `docker exec bgp cat /etc/quagga/bgpd.conf` entry in `files/image_config/sudoers/sudoers`; the cases that exercise the removed branches in `tests/show_test.py`, `tests/clear_test.py`, and `tests/debug_test.py`. **Rename:** `src/sonic-utilities/clear/bgp_quagga_v4.py` to `clear/bgp_frr_v4.py`, and update the import in `clear/main.py`.
+**Remove (GoBGP):** `dockers/docker-fpm-gobgp/`, `src/gobgp/`, `rules/gobgp.mk`, and `rules/gobgp.dep`. **Remove (stack selection in the build):** `rules/docker-fpm.mk` and `rules/docker-fpm.dep`, which exist only to elect a stack, so `DOCKER_FPM_FRR` can be referenced directly and the dead `DOCKER_FPM_GOBGP` and `DOCKER_FPM_QUAGGA` names go with them; the `else` branch that adds `$(GOBGP)` in `platform/vs/docker-sonic-vs.mk`; the `SONIC_ROUTING_STACK` conditionals in `slave.mk` and `files/build_templates/sonic_debian_extension.j2`, whose FRR blocks become unconditional; the commented-out `ROUTING_STACK` selection in `platform/p4/docker-sonic-p4.mk`, which goes with 7.1.4 in any case. Keep `SONIC_ROUTING_STACK = frr` in `rules/config` as a single-value knob, because downstream `rules/config.user` files may still set it. **Remove (stack selection in the CLI):** in sonic-utilities, the `routing_stack == "quagga"` branches of `show/main.py` and `clear/main.py` along with `show/bgp_quagga_v4.py`, `show/bgp_quagga_v6.py`, and `clear/bgp_quagga_v6.py`; the non-frr `else` branches that carry the Quagga `bgp` and `zebra` groups in `debug/main.py` and `undebug/main.py`; the `/etc/quagga/bgpd.conf` branch of `show startupconfiguration bgp` and the matching `docker exec bgp cat /etc/quagga/bgpd.conf` entry in `files/image_config/sudoers/sudoers`; the cases that exercise the removed branches in `tests/show_test.py`, `tests/clear_test.py`, and `tests/debug_test.py`. **Rename:** `src/sonic-utilities/clear/bgp_quagga_v4.py` to `clear/bgp_frr_v4.py`, and update the import in `clear/main.py`.
 
 Comments that only mention Quagga in passing, such as the `docker-fpm.gz` line in `README.md`, the `## Quagga rules` header in `files/image_config/rsyslog/rsyslog.d/00-sonic.conf.j2`, and the "For quagga build" comments in the sonic-slave Dockerfiles, are worth correcting when the code around them is touched, but they are not the point of this candidate. The packages under that build comment, such as `libreadline-dev`, `libpam-dev`, and the texlive set, are FRR build dependencies now, so leave them alone.
 
@@ -193,7 +194,7 @@ Debian 8 (jessie), Debian 9 (stretch), Debian 10 (buster), and Debian 11 (bullse
 
 jessie, stretch, and buster are pure leftovers, because nothing builds on them. Bullseye is different, because containers still build on it today, so those have to move first. Before deleting any base, confirm that nothing still builds a container on it. Debian 12 (bookworm) is still a live base and is handled under Deprecate.
 
-**Remove (stretch):** `dockers/docker-base-stretch/`, `rules/docker-base-stretch.{mk,dep}`, `dockers/docker-config-engine-stretch/`, `rules/docker-config-engine-stretch.{mk,dep}`. **Remove (buster):** `dockers/docker-base-buster/`, `rules/docker-base-buster.{mk,dep}`, `dockers/docker-config-engine-buster/`, `rules/docker-config-engine-buster.{mk,dep}`, `dockers/docker-swss-layer-buster/`, `rules/docker-swss-layer-buster.{mk,dep}`. **Remove (jessie):** `sonic-slave-jessie/`, the `jessie` target in `Makefile`, and the jessie `SLAVE_DIR` branch in `Makefile.work`. jessie has no `docker-base-jessie`, so also check the jessie strings in the generic `dockers/docker-base/` (its armhf and arm64 sources and its `FROM ...:jessie` lines) before touching that container. **Move first (bullseye):** seven containers still build on a bullseye base. Two of them, `docker-syncd-bfn` and `docker-saiserver-bfn`, go away with Barefoot in 7.1.1. The other five have to move to bookworm or trixie before bullseye can go, and they are `docker-syncd-centec` and `docker-saiserver-centec` under both `platform/centec/` and `platform/centec-arm64/`, plus `dockers/docker-sonic-sdk/`. The centec containers reach bullseye through `platform/template/docker-syncd-bullseye.mk`, so pointing their `docker-syncd-centec.mk` at the bookworm or trixie template covers four of the five. **Remove (bullseye):** `dockers/docker-base-bullseye/`, `rules/docker-base-bullseye.{mk,dep}`, `dockers/docker-config-engine-bullseye/`, `rules/docker-config-engine-bullseye.{mk,dep}`, `dockers/docker-swss-layer-bullseye/`, `rules/docker-swss-layer-bullseye.{mk,dep}`, `platform/template/docker-syncd-bullseye.mk`, and `sonic-slave-bullseye/`; the `bullseye` target and the `NOBULLSEYE` and `BUILD_BULLSEYE` handling in `Makefile`, the bullseye `SLAVE_DIR` branch in `Makefile.work`, the `sonic-slave-bullseye` entry in `Makefile.cache`, and in `slave.mk` the `BULLSEYE_DEBS_PATH` and `BULLSEYE_FILES_PATH` variables, the `bullseye` target, and the `BLDENV` tests that name it; the `BLDENV == bullseye` conditionals in `rules/grpc.mk`, `rules/protobuf.mk`, `rules/sonic-dash-api.mk`, and `rules/sonic-fips.mk`.
+**Remove (stretch):** `dockers/docker-base-stretch/`, `rules/docker-base-stretch.{mk,dep}`, `dockers/docker-config-engine-stretch/`, `rules/docker-config-engine-stretch.{mk,dep}`. **Remove (buster):** `dockers/docker-base-buster/`, `rules/docker-base-buster.{mk,dep}`, `dockers/docker-config-engine-buster/`, `rules/docker-config-engine-buster.{mk,dep}`, `dockers/docker-swss-layer-buster/`, `rules/docker-swss-layer-buster.{mk,dep}`. **Remove (jessie):** `sonic-slave-jessie/`, the `jessie` target in `Makefile`, and the jessie `SLAVE_DIR` branch in `Makefile.work`. jessie has no `docker-base-jessie`, so also check the jessie strings in the generic `dockers/docker-base/` (its armhf and arm64 sources and its `FROM ...:jessie` lines) before touching that container. **Move first (bullseye):** seven containers still build on a bullseye base. Two of them, `docker-syncd-bfn` and `docker-saiserver-bfn`, go away with Barefoot in 7.1.2. The other five have to move to bookworm or trixie before bullseye can go, and they are `docker-syncd-centec` and `docker-saiserver-centec` under both `platform/centec/` and `platform/centec-arm64/`, plus `dockers/docker-sonic-sdk/`. The centec containers reach bullseye through `platform/template/docker-syncd-bullseye.mk`, so pointing their `docker-syncd-centec.mk` at the bookworm or trixie template covers four of the five. **Remove (bullseye):** `dockers/docker-base-bullseye/`, `rules/docker-base-bullseye.{mk,dep}`, `dockers/docker-config-engine-bullseye/`, `rules/docker-config-engine-bullseye.{mk,dep}`, `dockers/docker-swss-layer-bullseye/`, `rules/docker-swss-layer-bullseye.{mk,dep}`, `platform/template/docker-syncd-bullseye.mk`, and `sonic-slave-bullseye/`; the `bullseye` target and the `NOBULLSEYE` and `BUILD_BULLSEYE` handling in `Makefile`, the bullseye `SLAVE_DIR` branch in `Makefile.work`, the `sonic-slave-bullseye` entry in `Makefile.cache`, and in `slave.mk` the `BULLSEYE_DEBS_PATH` and `BULLSEYE_FILES_PATH` variables, the `bullseye` target, and the `BLDENV` tests that name it; the `BLDENV == bullseye` conditionals in `rules/grpc.mk`, `rules/protobuf.mk`, `rules/sonic-dash-api.mk`, and `rules/sonic-fips.mk`.
 
 #### 7.2 Deprecate now, remove later
 
@@ -218,7 +219,7 @@ This should be removed in 202711. It is off by default. Its own spec calls it th
 
 There is no change to the SAI API. Nothing here adds, removes, or modifies a SAI API or object, and silicon vendors have nothing to implement for this plan.
 
-Two candidates touch SAI adjacent code without changing the interface. 7.1.1 removes the Barefoot SAI implementation and saithrift wiring for a platform that is EOL, which is a vendor implementation rather than the API. 7.1.2 removes the orchestration agent code that calls the SAI DTEL APIs, which leaves those APIs in SAI itself untouched and simply stops SONiC from calling them.
+Two candidates touch SAI adjacent code without changing the interface. 7.1.2 removes the Barefoot SAI implementation and saithrift wiring for a platform that is EOL, which is a vendor implementation rather than the API. 7.1.3 removes the orchestration agent code that calls the SAI DTEL APIs, which leaves those APIs in SAI itself untouched and simply stops SONiC from calling them.
 
 ### 9. Configuration and management
 
@@ -235,7 +236,7 @@ No command is added, and no command changes its syntax. The changes are deletion
 YANG models removed with their features:
 
 - `sonic-kubernetes_master.yang`, with 7.1.7.
-- The `sonic-dtel` model and the DTEL CONFIG_DB tables, with 7.1.2.
+- The `sonic-dtel` model and the DTEL CONFIG_DB tables, with 7.1.3.
 
 CLI effects:
 
@@ -252,7 +253,7 @@ The shape of the change is the same each time. Add a new `version_<branch>_<buil
 
 - `DEVICE_METADATA|localhost|docker_routing_config_mode`. A device holding `separated` or `split` has to be migrated to `unified`, because 7.1.10 deletes the code behind both. This is the case that matters most, since skipping it leaves a device configured for a routing mode that no longer exists rather than merely carrying dead config.
 - The `KUBERNETES_MASTER` table, which goes with 7.1.7, along with its YANG model.
-- The DTEL tables, which go with 7.1.2.
+- The DTEL tables, which go with 7.1.3.
 - `FEATURE|telemetry`, which goes with 7.1.9. `FEATURE|gnmi` stays, and the two must not be confused, because the surviving container is the gnmi one.
 - `FEATURE|restapi`, when the REST API is removed in 202711 under 7.2.3, which lands in that release's migrator rather than this one.
 

--- a/doc/eol-planning/202611-eol-and-deprecation.md
+++ b/doc/eol-planning/202611-eol-and-deprecation.md
@@ -6,9 +6,9 @@
 - [2. Scope](#2-scope)
 - [3. Definitions/Abbreviations](#3-definitionsabbreviations)
 - [4. Overview](#4-overview)
-- [5. Why remove code](#5-why-remove-code)
-- [6. Process](#6-process)
-- [7. Candidates for 202611](#7-candidates-for-202611)
+- [5. Requirements](#5-requirements)
+- [6. Architecture Design](#6-architecture-design)
+- [7. High-Level Design](#7-high-level-design)
   - [7.1 Remove now](#71-remove-now)
     - [7.1.1 Barefoot / Tofino platform](#711-barefoot--tofino-platform)
     - [7.1.2 DTEL (data-plane telemetry)](#712-dtel-data-plane-telemetry)
@@ -25,10 +25,18 @@
     - [7.2.1 Bookworm base containers](#721-bookworm-base-containers)
     - [7.2.2 FRR split-unified config mode](#722-frr-split-unified-config-mode)
     - [7.2.3 REST API](#723-rest-api)
-- [8. Config and management impact](#8-config-and-management-impact)
-- [9. Warmboot/Fastboot impact](#9-warmbootfastboot-impact)
-- [10. Testing](#10-testing)
-- [11. Additional findings](#11-additional-findings)
+- [8. SAI API](#8-sai-api)
+- [9. Configuration and management](#9-configuration-and-management)
+  - [9.1 Manifest](#91-manifest)
+  - [9.2 CLI/YANG model Enhancements](#92-cliyang-model-enhancements)
+  - [9.3 Config DB Enhancements](#93-config-db-enhancements)
+- [10. Warmboot and Fastboot Design Impact](#10-warmboot-and-fastboot-design-impact)
+- [11. Memory Consumption](#11-memory-consumption)
+- [12. Restrictions/Limitations](#12-restrictionslimitations)
+- [13. Testing Requirements/Design](#13-testing-requirementsdesign)
+  - [13.1 Unit Test cases](#131-unit-test-cases)
+  - [13.2 System Test cases](#132-system-test-cases)
+- [14. Open/Action items](#14-openaction-items)
 
 ### 1. Revision
 
@@ -37,19 +45,23 @@
 | 0.1 | 2026-07-19 | Brad House (Nexthop) | First draft. Security WG. |
 | 0.2 | 2026-07-24 | Brad House (Nexthop) | Added the Keep verdict. Moved bullseye to immediate removal and deprecated bookworm in its place. Folded Quagga into the GoBGP removal. |
 | 0.3 | 2026-07-24 | Brad House (Nexthop) | Filled in the notification steps of the process, which are the mailing list, the working groups, the TSC for platform removals, and a second round before the branch date. |
+| 0.4 | 2026-08-24 | Brad House (Nexthop) | Moved the standing process, the verdicts, and the rules of thumb into the TSC policy document, so that this HLD covers only the 202611 candidates. Restructured to the HLD template. |
 
 ### 2. Scope
 
-This HLD does two things:
+This HLD is the 202611 release plan for feature deprecation and removal. It lists the features proposed for a verdict in this cycle, states what each one is, why it should go, and the exact paths that go with it.
 
-1. It sets up a repeatable, per-release process to deprecate and remove SONiC features.
-2. It lists the features we propose to act on in 202611.
+The process this plan follows is not defined here. It lives in [the SONiC Feature Deprecation and Removal Policy](../../tsc/eol-deprecation/sonic_eol_deprecation_policy.md), which is release independent and covers the verdicts, the review and notification steps, the rules of thumb behind the calls, and what a release plan has to contain. This document is one instance of that policy. A later release files its own plan beside this one and does not restate the process.
 
 The work comes from the SONiC Security Working Group, whose goal is to shrink the attack surface. Less code means fewer packages, fewer CVEs, and less to build and test.
 
 Releases ship twice a year, in November (`YYYY11`) and in May (`YYYY05`). The cycles referenced here are 202611 (November 2026), 202705 (May 2027), and 202711 (November 2027).
 
+This document is documentation only. It removes nothing by itself. Each removal lands as its own pull request after review and component owner sign-off.
+
 ### 3. Definitions/Abbreviations
+
+The verdicts used below, which are **Remove now**, **Deprecate now, remove later**, and **Keep**, are defined in [the policy](../../tsc/eol-deprecation/sonic_eol_deprecation_policy.md#3-verdicts).
 
 | Term | Meaning |
 |------|---------|
@@ -67,49 +79,39 @@ Releases ship twice a year, in November (`YYYY11`) and in May (`YYYY05`). The cy
 
 SONiC still ships features that few or no one runs. Some of them are dead. Some broke when a dependency moved on. Some were tied to hardware that no longer exists. Each one still adds packages to the image, findings to every CVE scan, and jobs to CI.
 
-This HLD proposes a standing process to retire those features, along with the first batch to act on.
+This HLD proposes the first batch to act on. Fourteen candidates are listed. Eleven are proposed for removal in 202611, and three are proposed for deprecation now with a named removal release, which is 202705 for two of them and 202711 for the REST API.
 
-### 5. Why remove code
+### 5. Requirements
 
-- The best fix for a CVE is to delete the code that carries it.
-- Unmaintained code is a standing risk, because it rarely gets patched.
-- Dead build wiring hides real problems and slows builds.
-- Fewer features mean a smaller image, fewer scans to triage, and less CI.
+- Every candidate carries a verdict, the evidence behind it, and the exact paths it covers, as required by [section 6 of the policy](../../tsc/eol-deprecation/sonic_eol_deprecation_policy.md#6-what-a-release-plan-contains).
+- No feature is removed without component owner sign-off.
+- The three platform removals, which are 7.1.1 Barefoot, 7.1.3 standalone P4, and 7.1.4 Nephos, go to the TSC in addition to HLD review. The TSC decision is what settles them.
+- A user who never enabled any of these features sees no functional change and no CLI change.
+- Every removal that touches configuration is accompanied by a `db_migrator.py` update, so that a device that upgrades does not carry dead config or point at a value that no longer exists. See section 9.3.
+- Each supported CI platform still builds after the removals, and no remaining container points at a deleted base.
 
-### 6. Process
+Out of scope for this plan:
 
-This section is the boilerplate for the deprecation cycle itself. It is meant to carry forward unchanged into the plan for each following release, so that only the candidate list in section 7 changes from one cycle to the next.
+- The removals themselves. This document is documentation only, and each removal is a separate pull request.
+- The standing process, which is the policy document.
+- Anything under section 14, which needs code porting this plan does not cover.
 
-For each release:
+### 6. Architecture Design
 
-1. **Propose.** File or update this HLD with candidates. Each candidate states what it is, what replaces it, the gap in what you lose, and a verdict.
-2. **Pick a verdict.** There are three:
-   - **Remove now:** dead, broken, or EOL with no real users. Delete it this cycle.
-   - **Deprecate now, remove later:** still has possible users or needs migration work. Name a removal release.
-   - **Keep:** the feature stays. Review turned up real usage, a dependency another feature relies on, or a gap that the proposed replacement does not cover.
-3. **Review.** The community reviews it, and this HLD is scheduled at the weekly HLD review on Tuesdays. Component owners sign off. A feature is not removed without owner sign-off. Review can change a verdict in either direction, and moving a candidate to **Keep** is a normal outcome rather than a failure of the process. When that happens, record what the review turned up and why the feature stays, so that a later cycle does not have to rediscover it.
-4. **Take platform removals to the TSC.** Platforms are special, because a platform is somebody's hardware and the people who own it are not always the people who read HLDs. Every platform removal is proposed to the TSC in addition to the steps above, and the TSC can reject it. Owner sign-off does not substitute for that, and the TSC decision is what settles a platform removal.
-5. **Notify the mailing list.** After HLD review, send the proposal to `sonic-dev@lists.sonicfoundation.dev`. Not everyone with a stake attends HLD review, and the mailing list is how the rest of them find out while there is still time to object. Include the full candidate list, the verdict for each one, the named removal release, and a date by which responses are wanted.
-6. **Notify the interested working groups.** Send each candidate to the working group that owns the area it touches, where one exists. A working group knows its own users, so it is the fastest way to turn "we think nobody runs this" into a real answer. Reach the routing group for routing stack and FRR changes, the telemetry group for telemetry changes, the management group for management interface changes, and the platform and hardware groups for platform removals. Sending the same item to more than one group is fine and is better than missing one.
-7. **Notify again before the branch date.** Every notification above goes out a second time, no later than two months before the release branch is cut, and revised for whatever the first round turned up. Anyone who has since changed a verdict says so in that second round. This gives a user who missed the first notice a last chance to speak up while there is still time to revert a removal.
-8. **Announce.** Deprecations go in the release notes.
-9. **Remove** in the named release.
+There is no change to the SONiC architecture. Every candidate below removes a component, a build rule, or a platform, and nothing is added. None of these features is a SONiC Application Extension, so the Application Extension infrastructure is not involved.
 
-The goal of steps 4 through 7 is to over-communicate. It costs little to send the same proposal to one more list or one more group, and it costs a great deal to remove something that a user turns out to depend on. Nobody should learn that a feature is gone from the release notes, or from their build breaking.
+Two candidates narrow an existing choice rather than deleting a leaf:
 
-A few rules of thumb guide the calls above:
+- 7.1.10 collapses `docker_routing_config_mode` from four values to `unified` and `split-unified`, and makes `unified` the default. The supported path is unchanged, because `unified` already works today and the two removed modes are broken with the FRR version SONiC ships.
+- 7.1.5 collapses the routing stack to FRR alone. `rules/config` already documents `frr` as the sole supported value of `SONIC_ROUTING_STACK`, and neither alternative has been buildable for years, so this deletes unreachable branches rather than changing which stack runs.
 
-- "Not built by default" and "not in CI" are hints, not proof. We check real use before calling anything dead.
-- A forced bump, such as a libyang, base image, submodule pointer, or mass format change, does not count as maintenance.
-- If a replacement has a gap, we name it so users can speak up.
-- Silence is not consent on its own. It counts only after the notifications above have gone out twice and the second round has had time to draw a response.
-- A removal that touches configuration is not finished until `db_migrator.py` cleans up what it leaves behind in CONFIG_DB. See section 8.
+### 7. High-Level Design
 
-### 7. Candidates for 202611
+These are built-in SONiC features rather than Application Extensions. The repositories that change are `sonic-buildimage` for the platforms, containers, build rules, and pipeline jobs, `sonic-swss` for the DTEL orchestration agent code, `sonic-utilities` for `db_migrator.py` and the routing CLI, and `sonic-restapi`, which is removed outright in 202711. No new module or interface is introduced, and no sequence diagram applies, because nothing new runs.
 
 Each candidate below stands on its own. It states what the feature is, why it should go, the paths to remove, and anything to watch out for.
 
-Three of these are platform removals, which are 7.1.1 Barefoot, 7.1.3 standalone P4, and 7.1.4 Nephos. Those go to the TSC under step 4 of the process, separately from the rest of this list.
+Three of these are platform removals, which are 7.1.1 Barefoot, 7.1.3 standalone P4, and 7.1.4 Nephos. Those go to the TSC under step 4 of the policy, separately from the rest of this list.
 
 #### 7.1 Remove now
 
@@ -129,8 +131,7 @@ DTEL is SONiC's in-band data-plane telemetry. In practice it only ever ran on Ba
 
 This is the old bmv2 software behavioral model. It is a reference target rather than real hardware, and it has been dead since roughly 2022. Nothing in CI builds it. It is about 12 MB across 920 files, and it pulls in four stale external submodules. The only thing that references it outside `platform/p4/` is a Debian 8 era TODO in `rules/redis.mk`.
 
-**Remove:** `platform/p4/` (which includes `docker-sonic-p4`, `sai-p4-bm`, `p4c-bm`, `tenjin`, and `p4-hlir`); the four P4 submodule entries in `.gitmodules` (`platform/p4/p4c-bm/p4c-bm`, `platform/p4/p4-hlir/p4-hlir`, `platform/p4/p4-hlir/p4-hlir-v1.1`, `platform/p4/SAI-P4-BM`); the stale TODO in `rules/redis.mk`.
-**Keep:** `rules/p4lang.mk`. The p4lang toolchain it builds (bmv2, p4c, and PI) is a live dependency of DASH SAI, which ships in `sonic-vs.img.gz`, and of the PTF test containers.
+**Remove:** `platform/p4/` (which includes `docker-sonic-p4`, `sai-p4-bm`, `p4c-bm`, `tenjin`, and `p4-hlir`); the four P4 submodule entries in `.gitmodules` (`platform/p4/p4c-bm/p4c-bm`, `platform/p4/p4-hlir/p4-hlir`, `platform/p4/p4-hlir/p4-hlir-v1.1`, `platform/p4/SAI-P4-BM`); the stale TODO in `rules/redis.mk`. **Keep:** `rules/p4lang.mk`. The p4lang toolchain it builds (bmv2, p4c, and PI) is a live dependency of DASH SAI, which ships in `sonic-vs.img.gz`, and of the PTF test containers.
 
 ##### 7.1.4 Nephos platform
 
@@ -148,10 +149,7 @@ The target here is stack selection rather than the word Quagga. FRR is itself a 
 
 Where a Quagga-named file turns out to be the live FRR implementation, rename it rather than delete it. `clear/bgp_quagga_v4.py` is the clear case, because the `frr` branch of `clear/main.py` imports it and there is no `clear/bgp_frr_v4.py`, which makes it the working implementation of `clear ip bgp` today.
 
-**Remove (GoBGP):** `dockers/docker-fpm-gobgp/`, `src/gobgp/`, `rules/gobgp.mk`, and `rules/gobgp.dep`.
-**Remove (stack selection in the build):** `rules/docker-fpm.mk` and `rules/docker-fpm.dep`, which exist only to elect a stack, so `DOCKER_FPM_FRR` can be referenced directly and the dead `DOCKER_FPM_GOBGP` and `DOCKER_FPM_QUAGGA` names go with them; the `else` branch that adds `$(GOBGP)` in `platform/vs/docker-sonic-vs.mk`; the `SONIC_ROUTING_STACK` conditionals in `slave.mk` and `files/build_templates/sonic_debian_extension.j2`, whose FRR blocks become unconditional; the commented-out `ROUTING_STACK` selection in `platform/p4/docker-sonic-p4.mk`, which goes with 7.1.3 in any case. Keep `SONIC_ROUTING_STACK = frr` in `rules/config` as a single-value knob, because downstream `rules/config.user` files may still set it.
-**Remove (stack selection in the CLI):** in sonic-utilities, the `routing_stack == "quagga"` branches of `show/main.py` and `clear/main.py` along with `show/bgp_quagga_v4.py`, `show/bgp_quagga_v6.py`, and `clear/bgp_quagga_v6.py`; the non-frr `else` branches that carry the Quagga `bgp` and `zebra` groups in `debug/main.py` and `undebug/main.py`; the `/etc/quagga/bgpd.conf` branch of `show startupconfiguration bgp` and the matching `docker exec bgp cat /etc/quagga/bgpd.conf` entry in `files/image_config/sudoers/sudoers`; the cases that exercise the removed branches in `tests/show_test.py`, `tests/clear_test.py`, and `tests/debug_test.py`.
-**Rename:** `src/sonic-utilities/clear/bgp_quagga_v4.py` to `clear/bgp_frr_v4.py`, and update the import in `clear/main.py`.
+**Remove (GoBGP):** `dockers/docker-fpm-gobgp/`, `src/gobgp/`, `rules/gobgp.mk`, and `rules/gobgp.dep`. **Remove (stack selection in the build):** `rules/docker-fpm.mk` and `rules/docker-fpm.dep`, which exist only to elect a stack, so `DOCKER_FPM_FRR` can be referenced directly and the dead `DOCKER_FPM_GOBGP` and `DOCKER_FPM_QUAGGA` names go with them; the `else` branch that adds `$(GOBGP)` in `platform/vs/docker-sonic-vs.mk`; the `SONIC_ROUTING_STACK` conditionals in `slave.mk` and `files/build_templates/sonic_debian_extension.j2`, whose FRR blocks become unconditional; the commented-out `ROUTING_STACK` selection in `platform/p4/docker-sonic-p4.mk`, which goes with 7.1.3 in any case. Keep `SONIC_ROUTING_STACK = frr` in `rules/config` as a single-value knob, because downstream `rules/config.user` files may still set it. **Remove (stack selection in the CLI):** in sonic-utilities, the `routing_stack == "quagga"` branches of `show/main.py` and `clear/main.py` along with `show/bgp_quagga_v4.py`, `show/bgp_quagga_v6.py`, and `clear/bgp_quagga_v6.py`; the non-frr `else` branches that carry the Quagga `bgp` and `zebra` groups in `debug/main.py` and `undebug/main.py`; the `/etc/quagga/bgpd.conf` branch of `show startupconfiguration bgp` and the matching `docker exec bgp cat /etc/quagga/bgpd.conf` entry in `files/image_config/sudoers/sudoers`; the cases that exercise the removed branches in `tests/show_test.py`, `tests/clear_test.py`, and `tests/debug_test.py`. **Rename:** `src/sonic-utilities/clear/bgp_quagga_v4.py` to `clear/bgp_frr_v4.py`, and update the import in `clear/main.py`.
 
 Comments that only mention Quagga in passing, such as the `docker-fpm.gz` line in `README.md`, the `## Quagga rules` header in `files/image_config/rsyslog/rsyslog.d/00-sonic.conf.j2`, and the "For quagga build" comments in the sonic-slave Dockerfiles, are worth correcting when the code around them is touched, but they are not the point of this candidate. The packages under that build comment, such as `libreadline-dev`, `libpam-dev`, and the texlive set, are FRR build dependencies now, so leave them alone.
 
@@ -167,8 +165,7 @@ This runs a full Kubernetes control plane on the switch. That includes the apise
 
 This applies to the master only. The worker feature (`INCLUDE_KUBERNETES`) is a separate feature and should stay. Someone hardened its cluster-join security before this working group existed, which points to a real user.
 
-**Remove:** `files/image_config/kubernetes/` (`kubernetes_master_entrance.sh`, `kubernetes_master_entrance.service`, `kubernetes.list`); the `INCLUDE_KUBERNETES_MASTER` flag and the master version pins in `rules/config`; the master-only blocks in `files/build_templates/sonic_debian_extension.j2`; `sonic-kubernetes_master.yang`; the master build in `.azure-pipelines/azure-pipelines-build.yml`.
-**Keep:** `INCLUDE_KUBERNETES` (the worker), `src/sonic-ctrmgrd*`, and the `ctrmgrd` wrapper, which runs for ordinary feature start and stop rather than only for k8s.
+**Remove:** `files/image_config/kubernetes/` (`kubernetes_master_entrance.sh`, `kubernetes_master_entrance.service`, `kubernetes.list`); the `INCLUDE_KUBERNETES_MASTER` flag and the master version pins in `rules/config`; the master-only blocks in `files/build_templates/sonic_debian_extension.j2`; `sonic-kubernetes_master.yang`; the master build in `.azure-pipelines/azure-pipelines-build.yml`. **Keep:** `INCLUDE_KUBERNETES` (the worker), `src/sonic-ctrmgrd*`, and the `ctrmgrd` wrapper, which runs for ordinary feature start and stop rather than only for k8s.
 
 ##### 7.1.8 docker-basic_router
 
@@ -180,8 +177,7 @@ This is a SAI demo and reference container. It is not wired into any build rule,
 
 This container is off by default, and it is redundant. Both this container and the gnmi container run the same binary, `/usr/sbin/telemetry`, started by `telemetry.sh` and `gnmi-native.sh` respectively. There is no separate gNMI server. The `telemetry` binary is the server, and the name is only historical. Both containers read the same `TELEMETRY|gnmi` config, and the gnmi start script simply adds ZMQ and VRF options on top. There is therefore no functional gap, because Get, Set, Subscribe, and dial-out are identical in both.
 
-**Remove:** `dockers/docker-sonic-telemetry/`, `rules/docker-telemetry.mk`, and `rules/docker-telemetry.dep`; the `INCLUDE_SYSTEM_TELEMETRY` flag in `rules/config`.
-**Keep:** the `telemetry` binary, which is built by sonic-gnmi and run by the gnmi container.
+**Remove:** `dockers/docker-sonic-telemetry/`, `rules/docker-telemetry.mk`, and `rules/docker-telemetry.dep`; the `INCLUDE_SYSTEM_TELEMETRY` flag in `rules/config`. **Keep:** the `telemetry` binary, which is built by sonic-gnmi and run by the gnmi container.
 
 ##### 7.1.10 Broken FRR config modes
 
@@ -197,11 +193,7 @@ Debian 8 (jessie), Debian 9 (stretch), Debian 10 (buster), and Debian 11 (bullse
 
 jessie, stretch, and buster are pure leftovers, because nothing builds on them. Bullseye is different, because containers still build on it today, so those have to move first. Before deleting any base, confirm that nothing still builds a container on it. Debian 12 (bookworm) is still a live base and is handled under Deprecate.
 
-**Remove (stretch):** `dockers/docker-base-stretch/`, `rules/docker-base-stretch.{mk,dep}`, `dockers/docker-config-engine-stretch/`, `rules/docker-config-engine-stretch.{mk,dep}`.
-**Remove (buster):** `dockers/docker-base-buster/`, `rules/docker-base-buster.{mk,dep}`, `dockers/docker-config-engine-buster/`, `rules/docker-config-engine-buster.{mk,dep}`, `dockers/docker-swss-layer-buster/`, `rules/docker-swss-layer-buster.{mk,dep}`.
-**Remove (jessie):** `sonic-slave-jessie/`, the `jessie` target in `Makefile`, and the jessie `SLAVE_DIR` branch in `Makefile.work`. jessie has no `docker-base-jessie`, so also check the jessie strings in the generic `dockers/docker-base/` (its armhf and arm64 sources and its `FROM ...:jessie` lines) before touching that container.
-**Move first (bullseye):** seven containers still build on a bullseye base. Two of them, `docker-syncd-bfn` and `docker-saiserver-bfn`, go away with Barefoot in 7.1.1. The other five have to move to bookworm or trixie before bullseye can go, and they are `docker-syncd-centec` and `docker-saiserver-centec` under both `platform/centec/` and `platform/centec-arm64/`, plus `dockers/docker-sonic-sdk/`. The centec containers reach bullseye through `platform/template/docker-syncd-bullseye.mk`, so pointing their `docker-syncd-centec.mk` at the bookworm or trixie template covers four of the five.
-**Remove (bullseye):** `dockers/docker-base-bullseye/`, `rules/docker-base-bullseye.{mk,dep}`, `dockers/docker-config-engine-bullseye/`, `rules/docker-config-engine-bullseye.{mk,dep}`, `dockers/docker-swss-layer-bullseye/`, `rules/docker-swss-layer-bullseye.{mk,dep}`, `platform/template/docker-syncd-bullseye.mk`, and `sonic-slave-bullseye/`; the `bullseye` target and the `NOBULLSEYE` and `BUILD_BULLSEYE` handling in `Makefile`, the bullseye `SLAVE_DIR` branch in `Makefile.work`, the `sonic-slave-bullseye` entry in `Makefile.cache`, and in `slave.mk` the `BULLSEYE_DEBS_PATH` and `BULLSEYE_FILES_PATH` variables, the `bullseye` target, and the `BLDENV` tests that name it; the `BLDENV == bullseye` conditionals in `rules/grpc.mk`, `rules/protobuf.mk`, `rules/sonic-dash-api.mk`, and `rules/sonic-fips.mk`.
+**Remove (stretch):** `dockers/docker-base-stretch/`, `rules/docker-base-stretch.{mk,dep}`, `dockers/docker-config-engine-stretch/`, `rules/docker-config-engine-stretch.{mk,dep}`. **Remove (buster):** `dockers/docker-base-buster/`, `rules/docker-base-buster.{mk,dep}`, `dockers/docker-config-engine-buster/`, `rules/docker-config-engine-buster.{mk,dep}`, `dockers/docker-swss-layer-buster/`, `rules/docker-swss-layer-buster.{mk,dep}`. **Remove (jessie):** `sonic-slave-jessie/`, the `jessie` target in `Makefile`, and the jessie `SLAVE_DIR` branch in `Makefile.work`. jessie has no `docker-base-jessie`, so also check the jessie strings in the generic `dockers/docker-base/` (its armhf and arm64 sources and its `FROM ...:jessie` lines) before touching that container. **Move first (bullseye):** seven containers still build on a bullseye base. Two of them, `docker-syncd-bfn` and `docker-saiserver-bfn`, go away with Barefoot in 7.1.1. The other five have to move to bookworm or trixie before bullseye can go, and they are `docker-syncd-centec` and `docker-saiserver-centec` under both `platform/centec/` and `platform/centec-arm64/`, plus `dockers/docker-sonic-sdk/`. The centec containers reach bullseye through `platform/template/docker-syncd-bullseye.mk`, so pointing their `docker-syncd-centec.mk` at the bookworm or trixie template covers four of the five. **Remove (bullseye):** `dockers/docker-base-bullseye/`, `rules/docker-base-bullseye.{mk,dep}`, `dockers/docker-config-engine-bullseye/`, `rules/docker-config-engine-bullseye.{mk,dep}`, `dockers/docker-swss-layer-bullseye/`, `rules/docker-swss-layer-bullseye.{mk,dep}`, `platform/template/docker-syncd-bullseye.mk`, and `sonic-slave-bullseye/`; the `bullseye` target and the `NOBULLSEYE` and `BUILD_BULLSEYE` handling in `Makefile`, the bullseye `SLAVE_DIR` branch in `Makefile.work`, the `sonic-slave-bullseye` entry in `Makefile.cache`, and in `slave.mk` the `BULLSEYE_DEBS_PATH` and `BULLSEYE_FILES_PATH` variables, the `bullseye` target, and the `BLDENV` tests that name it; the `BLDENV == bullseye` conditionals in `rules/grpc.mk`, `rules/protobuf.mk`, `rules/sonic-dash-api.mk`, and `rules/sonic-fips.mk`.
 
 #### 7.2 Deprecate now, remove later
 
@@ -222,10 +214,37 @@ This should be removed in 202705. It is the manual routing mode, where the opera
 This should be removed in 202711. It is off by default. Its own spec calls it the "SONiC REST API for Baremetal Scenarios." It is an imperative agent for baremetal VNET, VXLAN, and VLAN config over HTTPS, not a general REST interface. gNMI is the intended replacement, but it does not cover two things. The first is bulk route programming with per-route partial success (HTTP 207). The second is route expiry, which is timed route aging. Because of that gap, this candidate gets the longest runway. Before removing it, confirm that no control plane still drives it. The mgmt-framework REST server is a different thing and stays.
 
 **Remove (202711):** `dockers/docker-sonic-restapi/`, `src/sonic-restapi/` and its `.gitmodules` entry, `rules/docker-restapi.{mk,dep}`, and `rules/restapi.{mk,dep}`; the `INCLUDE_RESTAPI` flag in `rules/config`; the `restapi` feature in `files/build_templates/init_cfg.json.j2`.
+### 8. SAI API
 
-### 8. Config and management impact
+There is no change to the SAI API. Nothing here adds, removes, or modifies a SAI API or object, and silicon vendors have nothing to implement for this plan.
 
-Removing a feature drops its `FEATURE` table entries, its build flags, and any YANG models tied to it, such as `sonic-kubernetes_master.yang`. Users who never enabled these features see no CLI change.
+Two candidates touch SAI adjacent code without changing the interface. 7.1.1 removes the Barefoot SAI implementation and saithrift wiring for a platform that is EOL, which is a vendor implementation rather than the API. 7.1.2 removes the orchestration agent code that calls the SAI DTEL APIs, which leaves those APIs in SAI itself untouched and simply stops SONiC from calling them.
+
+### 9. Configuration and management
+
+Removing a feature drops its `FEATURE` table entries, its build flags, and any YANG models tied to it. Users who never enabled these features see no CLI change.
+
+#### 9.1 Manifest
+
+Not applicable. None of these features is a SONiC Application Extension, so there is no manifest.
+
+#### 9.2 CLI/YANG model Enhancements
+
+No command is added, and no command changes its syntax. The changes are deletions and one default.
+
+YANG models removed with their features:
+
+- `sonic-kubernetes_master.yang`, with 7.1.7.
+- The `sonic-dtel` model and the DTEL CONFIG_DB tables, with 7.1.2.
+
+CLI effects:
+
+- Collapsing the routing stack to FRR in 7.1.5 does not change any command an operator runs, because the FRR branch of every affected command already provides the same CLI. `clear ip bgp` keeps working through the renamed `clear/bgp_frr_v4.py`. The one visible difference is `show startupconfiguration bgp`, which loses its `/etc/quagga/bgpd.conf` branch and reads only `/etc/frr/bgpd.conf`.
+- `docker_routing_config_mode` accepts fewer values after 7.1.10, which is a narrowing of an existing setting rather than a CLI change.
+
+`sonic-utilities/doc/Command-Reference.md` carries more Quagga material than the code does, and it is updated in the same pull request as 7.1.5. That means the whole `## Quagga BGP Show Commands` section and its entry in the table of contents, the `Versions <= 201811 using Quagga routing stack` variants and the links to them under the BGP show commands, and the `## Routing Stack` section, which still tells the reader that SONiC is agnostic of the routing stack and that Quagga is a choice. The `show startupconfiguration bgp` entry loses its Quagga path with the code. Nothing in the reference describes the other candidates, because the Kubernetes commands documented there belong to the worker feature, which stays.
+
+#### 9.3 Config DB Enhancements
 
 Removing the code is only half of it, because a device that upgrades keeps whatever it already had in CONFIG_DB. Every removal that touches configuration therefore has to update `sonic-utilities/scripts/db_migrator.py`, and that update is part of the removal rather than a follow-up. Without it, an upgraded device carries dead `FEATURE` rows and orphaned tables forever, a table that outlives its YANG model can fail config validation, and a setting whose supported values have narrowed can leave the device pointing at a value that no longer exists.
 
@@ -237,15 +256,48 @@ The shape of the change is the same each time. Add a new `version_<branch>_<buil
 - `FEATURE|telemetry`, which goes with 7.1.9. `FEATURE|gnmi` stays, and the two must not be confused, because the surviving container is the gnmi one.
 - `FEATURE|restapi`, when the REST API is removed in 202711 under 7.2.3, which lands in that release's migrator rather than this one.
 
-The FRR change removes `separated` and `split` from `docker_routing_config_mode` and makes `unified` the default. The platform removals do not affect other platforms.
+The default for `docker_routing_config_mode` also changes. Today `src/sonic-config-engine/minigraph.py` hardcodes `separated` and init_cfg does not set it, so a device with no explicit value resolves to `separated`. 7.1.10 flips that default to `unified`.
 
-Collapsing the routing stack to FRR alone does not change any command an operator runs, because the FRR branch of every affected command already provides the same CLI. `clear ip bgp` keeps working through the renamed `clear/bgp_frr_v4.py`. The one visible difference is `show startupconfiguration bgp`, which loses its `/etc/quagga/bgpd.conf` branch and reads only `/etc/frr/bgpd.conf`.
-
-### 9. Warmboot/Fastboot impact
+### 10. Warmboot and Fastboot Design Impact
 
 There is no warmboot or fastboot impact. Every candidate is off by default, already dead, or specific to hardware that is being removed. None of this touches the warmboot or fastboot path on supported platforms.
 
-### 10. Testing
+The one candidate that touches a path a supported device runs is 7.1.10, and it changes which FRR config mode is selected at container start rather than anything in the warmboot or fastboot sequence. A device already running `unified`, which is the supported mode, sees no change at all.
+
+#### Warmboot and Fastboot Performance Impact
+
+There is no degradation, and the direction of every change is downward.
+
+- No stall, sleep, or IO operation is added to the boot critical chain. Code is deleted from it, not added.
+- No CPU heavy processing is added. 7.1.10 removes three of the four branches in `docker_init.sh` and the per-daemon Jinja templates behind them, which is strictly less template rendering at bgp container start.
+- No third party dependency is bumped for a device that ships today. The base image moves in 7.1.11 and 7.2.1 change which Debian base a container is built from, and the containers involved are the centec syncd and saiserver containers and `docker-sonic-sdk`. Those are build time changes, and the platforms that own them validate boot time as part of the move.
+- Nothing here needs to be delayed, because nothing here starts.
+
+### 11. Memory Consumption
+
+No memory is added. Every candidate is a removal, so runtime memory either drops or is unchanged, and image size drops.
+
+The features that carried a running process are off by default today, so a device that never enabled them frees nothing at runtime and simply stops carrying the code. A device that did enable the System Telemetry container (7.1.9) or the Kubernetes master (7.1.7) frees whatever those processes used, and in the telemetry case the same functionality continues in the gnmi container, which is already running the same binary.
+
+### 12. Restrictions/Limitations
+
+- Bullseye cannot be removed until five containers move off it, which are the centec syncd and saiserver containers under `platform/centec/` and `platform/centec-arm64/`, and `dockers/docker-sonic-sdk/`. That move is a prerequisite of 7.1.11 rather than part of it, and it depends on the platform owners.
+- The same applies to bookworm in 7.2.1, where three syncd containers have to move to trixie first.
+- gNMI does not fully replace the REST API. It does not cover bulk route programming with per-route partial success (HTTP 207), and it does not cover route expiry. That gap is why 7.2.3 gets the longest runway, and it is not closed by this plan.
+- Removing a feature that is off by default is not proof that nobody runs it. The notification steps in the policy exist for that reason, and a verdict can move to **Keep** at any point before the removal lands.
+
+### 13. Testing Requirements/Design
+
+Each removal is tested in the pull request that performs it, rather than here. The requirements below apply to that pull request and to the release as a whole.
+
+#### 13.1 Unit Test cases
+
+- `db_migrator` unit tests cover each table and field this batch drops, including a device that starts on `separated` and one that starts on `split`, and both end on `unified`.
+- The `sonic-config-engine` tests cover the new `unified` default in `minigraph.py`, with and without an explicit `docker_routing_config_mode`.
+- The `sonic-swss` test suite still passes with `tests/test_dtel.py` and the DTEL orchestration agent code removed.
+- YANG model tests pass with the removed models absent, and no remaining model references them.
+
+#### 13.2 System Test cases
 
 - Each supported CI platform still builds after the removals.
 - The removed packages no longer appear in the SBOM or the CVE scan, confirmed by an image diff.
@@ -254,9 +306,11 @@ There is no warmboot or fastboot impact. Every candidate is off by default, alre
 - A device configured for `separated` or `split` comes up in `unified` after upgrade, rather than pointing at a mode whose code is gone.
 - Every remaining container builds with nothing pointing at a deleted base, and the centec and sonic-sdk containers build on their new base.
 - `show ip bgp` and `clear ip bgp` still work after the routing-stack collapse and the `clear/bgp_frr_v4.py` rename.
+- gNMI still serves Get, Set, Subscribe, and dial-out after the System Telemetry container is removed.
 
-### 11. Additional findings
+### 14. Open/Action items
 
-These are real, but they are out of scope here, because removing them needs code porting that this HLD does not cover. They are listed so they are tracked.
-
-- **swsssdk-py3.** This is the old Python Redis SDK. `swsscommon` replaces it, but code still imports `swsssdk` at runtime, including `sonic-utilities/scripts/dualtor_neighbor_check.py`, `sonic-py-common`, and the vpp container. It cannot be deprecated until those are ported to `swsscommon`.
+- Component owner sign-off is outstanding for every candidate. No removal lands without it.
+- The three platform removals need a TSC decision, which is step 4 of the policy.
+- The five bullseye containers and the three bookworm containers need an owner to move them to a newer base, as described in section 12.
+- **swsssdk-py3.** This is the old Python Redis SDK. `swsscommon` replaces it, but code still imports `swsssdk` at runtime, including `sonic-utilities/scripts/dualtor_neighbor_check.py`, `sonic-py-common`, and the vpp container. It cannot be deprecated until those are ported to `swsscommon`, so it is not a candidate in this plan. It is recorded here so that a later cycle picks it up.

--- a/tsc/eol-deprecation/sonic_eol_deprecation_policy.md
+++ b/tsc/eol-deprecation/sonic_eol_deprecation_policy.md
@@ -1,0 +1,80 @@
+# SONiC Feature Deprecation and Removal Policy
+
+This document is the standing policy and procedure for deprecating and removing features from SONiC. It is release independent. It defines the verdicts a feature can be given, the steps a proposal goes through before anything is deleted, and the notification a removal owes the community.
+
+It was proposed by the SONiC Security Working Group, whose goal is to shrink the attack surface of the image. Less code means fewer packages, fewer CVEs, and less to build and test. Deprecation is not only a security matter, so this policy covers any feature removal, whatever the reason for it.
+
+Each release that acts on this policy files its own plan as a High Level Design under `doc/eol-planning/`, named `<release>-eol-and-deprecation.md`. The plan lists that release's candidates and nothing more. The process itself stays here, so that it is reviewed and changed on its own rather than being rewritten in every cycle. The first such plan is [202611](../../doc/eol-planning/202611-eol-and-deprecation.md).
+
+## 1. Why we remove code
+
+- The best fix for a CVE is to delete the code that carries it.
+- Unmaintained code is a standing risk, because it rarely gets patched.
+- Dead build wiring hides real problems and slows builds.
+- Fewer features mean a smaller image, fewer scans to triage, and less CI.
+
+## 2. Definitions
+
+| Term | Meaning |
+|------|---------|
+| Deprecate | Mark a feature as going away. It still ships, but it warns of removal. |
+| Remove | Delete the code and its build wiring. |
+| Keep | The feature stays. Review turned up a reason not to remove it. |
+| Candidate | A feature proposed for a verdict in a given release plan. |
+| EOL | End of life. |
+| TSC | Technical Steering Committee. |
+| WG | Working group. |
+
+Releases ship twice a year, in November (`YYYY11`) and in May (`YYYY05`). A removal release is always named by that identifier.
+
+## 3. Verdicts
+
+Every candidate carries exactly one of three verdicts.
+
+- **Remove now.** Dead, broken, or EOL with no real users. Delete it this cycle.
+- **Deprecate now, remove later.** Still has possible users or needs migration work. Name a removal release.
+- **Keep.** The feature stays. Review turned up real usage, a dependency another feature relies on, or a gap that the proposed replacement does not cover.
+
+## 4. The per-release cycle
+
+For each release:
+
+1. **Propose.** File a release plan HLD under `doc/eol-planning/` with the candidates for that release. Each candidate states what it is, what replaces it, the gap in what you lose, the exact paths to remove, and a verdict.
+2. **Pick a verdict.** One of the three in section 3.
+3. **Review.** The community reviews the plan, and it is scheduled at the weekly HLD review on Tuesdays. Component owners sign off. A feature is not removed without owner sign-off. Review can change a verdict in either direction, and moving a candidate to **Keep** is a normal outcome rather than a failure of the process. When that happens, record what the review turned up and why the feature stays, so that a later cycle does not have to rediscover it.
+4. **Take platform removals to the TSC.** Platforms are special, because a platform is somebody's hardware and the people who own it are not always the people who read HLDs. Every platform removal is proposed to the TSC in addition to the steps above, and the TSC can reject it. Owner sign-off does not substitute for that, and the TSC decision is what settles a platform removal.
+5. **Notify the mailing list.** After HLD review, send the proposal to `sonic-dev@lists.sonicfoundation.dev`. Not everyone with a stake attends HLD review, and the mailing list is how the rest of them find out while there is still time to object. Include the full candidate list, the verdict for each one, the named removal release, and a date by which responses are wanted.
+6. **Notify the interested working groups.** Send each candidate to the working group that owns the area it touches, where one exists. A working group knows its own users, so it is the fastest way to turn "we think nobody runs this" into a real answer. Reach the routing group for routing stack and FRR changes, the telemetry group for telemetry changes, the management group for management interface changes, and the platform and hardware groups for platform removals. Sending the same item to more than one group is fine and is better than missing one.
+7. **Notify again before the branch date.** Every notification above goes out a second time, no later than two months before the release branch is cut, and revised for whatever the first round turned up. Anyone who has since changed a verdict says so in that second round. This gives a user who missed the first notice a last chance to speak up while there is still time to revert a removal.
+8. **Announce.** Deprecations go in the release notes.
+9. **Remove** in the named release.
+
+The goal of steps 4 through 7 is to over-communicate. It costs little to send the same proposal to one more list or one more group, and it costs a great deal to remove something that a user turns out to depend on. Nobody should learn that a feature is gone from the release notes, or from their build breaking.
+
+## 5. Rules of thumb
+
+These guide the calls above.
+
+- "Not built by default" and "not in CI" are hints, not proof. We check real use before calling anything dead.
+- A forced bump, such as a libyang, base image, submodule pointer, or mass format change, does not count as maintenance. A feature that has seen only those is unmaintained.
+- If a replacement has a gap, we name it so users can speak up.
+- Silence is not consent on its own. It counts only after the notifications above have gone out twice and the second round has had time to draw a response.
+- A removal that touches configuration is not finished until `sonic-utilities/scripts/db_migrator.py` cleans up what it leaves behind in CONFIG_DB. A device that upgrades keeps whatever it already had, so without a migrator change it carries dead `FEATURE` rows and orphaned tables forever, a table that outlives its YANG model can fail config validation, and a setting whose supported values have narrowed can leave the device pointing at a value that no longer exists.
+- A removal lands as its own pull request, per candidate, after review and sign-off. A release plan is documentation and removes nothing by itself.
+
+## 6. What a release plan contains
+
+A release plan is an HLD and follows [the HLD template](../../doc/guidelines/hld_template.md). The candidate list is the body of its High Level Design section, split into the verdicts from section 3. Each candidate stands on its own and states:
+
+- What the feature is, and where it came from.
+- Why it should go, with the evidence behind the call, such as CI coverage, last genuine change, size, and known users.
+- What replaces it, and any gap in what a user loses.
+- The exact paths, build rules, flags, and pipeline jobs to remove.
+- Anything to keep, and anything to check or move first.
+- For a deferred removal, the release it is removed in.
+
+Beyond the candidates, a plan covers the CONFIG_DB migration the removals need, the CLI and YANG models that go with them, and how the result is tested.
+
+## 7. Changing this policy
+
+This policy is owned by the TSC. Changes are made by pull request against this file and are reviewed the same way a release plan is, at HLD review and with the TSC settling anything contested.


### PR DESCRIPTION
## Why

The SONiC Security Working Group is proposing a repeatable, per-release process to deprecate and remove unused, broken, or EOL features. The goal is to shrink the attack surface: fewer packages, fewer CVEs, and less to build and test. This is the first such HLD.

## What

Adds `doc/eol-planning/202611-eol-and-deprecation.md`:

- The per-release process (propose, pick a verdict, community review at the weekly HLD review, announce, remove) and the rules of thumb behind the calls.
- The 202611 candidate list. Each candidate says what it is, why it should go, the exact paths to remove, and anything to keep or watch out for.

**Remove now:** Barefoot / Tofino platform, DTEL, standalone P4 platform, Nephos platform, GoBGP FPM container, Python 2 packages, Kubernetes master, docker-basic_router, System Telemetry container, broken FRR config modes, and old Debian build leftovers (jessie/stretch/buster).

**Deprecate now, remove later:** bullseye base containers (202705), FRR split-unified config mode (202705), and the REST API (202711).

## Notes

- This PR is documentation only. There are no code or build changes.
- Actual removals happen in follow-up PRs, per candidate, after HLD review and component-owner sign-off. A feature is not removed without owner sign-off.
