### PR TITLE
Maintainer Nomination requests for Nvidia team members

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -17,6 +17,7 @@
 |  | Longxiang Lyu (Microsoft) | lolyu | enabled |
 |  | Ying Xie (Microsoft) | yxieca | enabled |
 | sonic-linux-kernel | Saikrishna Arcot (Microsoft) | saiarcot895 | enabled |
+|  | Hemanth Kumar Tirupati (Nvidia) | tirupatihemanth | Request on 05/08/2026 |
 | sonic-mgmt-common | Kim, Kwan (DELL) | kwangsuk | enabled |
 |  | Shashank Neelam (Google) | sneelam20 | enabled |
 |  | Anand Subramanian (BRCM) | anand-kumar-subramanian | enabled |
@@ -30,9 +31,11 @@
 | sonic-platform-common | Prince George (Microsoft) | prgeor | enabled |
 |  | Mridul Bajpai (Cisco) | bmridul | enabled |
 |  | Kebo Liu (Nvidia) | keboliu | enabled |
+|  | Junchao Chen (Nvidia) | Junchao-Mellanox | Request on 05/08/2026 |
 | sonic-platform-daemons | Prince George (Microsoft) | prgeor | enabled |
 |  | Mridul Bajpai (Cisco) | bmridul | enabled |
 |  | Kebo Liu (Nvidia) | keboliu | enabled |
+|  | Junchao Chen (Nvidia) | Junchao-Mellanox | Request on 05/08/2026 |
 | sonic-platform-pdk-pde | Geans Pin (BRCM) | geans-pin | enabled |
 | sonic-py-swsssdk | Hua Liu (Microsoft) | liuh-80 | enabled |
 | sonic-restapi | Lawrence Lee (Microsoft) | theasianpianist | enabled |
@@ -42,24 +45,29 @@
 |  | Volodymyr Boiko (Intel) | vboykox | enabled |
 |  | Kishore Gummadidala(Google) | erohsik | invitation sent |
 |  | Vishnu Shetty | vishnushetty | enabled |
+|  | Stephen Sun (Nvidia) | stephenxs | Request on 05/08/2026 |
 | sonic-snmpagent | Suvarna Meenakshi (Microsoft) | SuvarnaMeenakshi | enabled |
 | sonic-swss | Guohan Lu (Microsoft) | lguohan | added |
 |  | Prince Sunny (Microsoft) | prsunny | added |
-|  | Marian Pritsak (Nvidia) | marian-pritsak | added |
 |  | Stephen Wang(Google) | StephenWangGoogle | enabled |
 |  | Laveen Thamilchelvam (BRCM) | LaveenBrcm | Approved on 5/3/2023 and enabled |
 |  | Rajesh Sankaran (BRCM) | srj102 | Approved on 5/3/2023 and enabled |
+|  | Stephen Sun (Nvidia) | stephenxs | Request on 05/08/2026 |
+|  | Sudharsan Dhamal Gopalarathnam (Nvidia) | dgsudharsan | enabled |
 | sonic-swss-common | Qi Luo (Microsoft) | qiluo-msft | eanbled |
 |  | Hua Liu (Microsoft) | liuh-80 | enabled |
 |  | Myron Sosyak (Intel) | msosyak | enabled |
-|  | Marian Pritsak (Nvidia) | marian-pritsak | enabled |
 |  | Runming Wu(Google) | mint570 | enabled |
+|  | Stephen Sun (Nvidia) | stephenxs | Request on 05/08/2026 |
 | sonic-gnmi (previously sonic-telemetry) | Qi Luo (Microsoft) | qiluo-msft | enabled |
 |  | Shashank Neelam | sneelam20 | Replace Tomek on 3/5/2024 |
 |  | Shishao (Alibaba) | shishao7sxm | invitation sent |
 |  | Seifert, Eric (DELL) | seiferteric | enabled |
 |  | Anand Subramanian (BRCM) | anand-kumar-subramanian | Approved on 5/3/2023 and enabled |
+|  | Geoffrey Lyu (Nvidia) | ganglyu | Request on 05/08/2026 |
 | sonic-utilities | Qi Luo (Microsoft) | qiluo-msft | enabled |
+|  | Junchao Chen (Nvidia) | Junchao-Mellanox | Request on 05/08/2026 |
+|  | Oleksandr Ivantsiv (Nvidia) | oleksandrivantsiv | Request on 05/08/2026 |
 | sonic-wpa-supplicant | Ze Gan (Microsoft) | Pterosaur | enabled |
 | sonic-buildimage | Guohan Lu (Microsoft) | lguohan | enabled |
 |  | Ying Xie (Microsoft) | yxieca | enabled |
@@ -68,6 +76,9 @@
 |  | Yilan Ji (Google) | baxia-lan | enabled |
 |  | Praveen Elagala (BRCM) | Praveen-Brcm | Approved on 5/3/2023 and enabled |
 |  | Prasanth Veettil (BRCM) | Prasanth-KV | Approved on 5/3/2023 and enabled |
+|  | Sudharsan Dhamal Gopalarathnam (Nvidia) | dgsudharsan | Request on 05/08/2026 |
+|  | Amit Abel (Nvidia) | abelamit | Request on 05/08/2026 |
+|  | Volodymyr Samotiy (Nvidia) | volodymyrsamotiy | Request on 05/08/2026 |
 | sonic-mgmt | Ying Xie (Microsoft) | yxieca | enabled |
 |  | Xin Wang (Microsoft) | wangxin | enabled |
 |  | Bhavani Parise (Cisco) | bpar9 | enabled |
@@ -85,6 +96,9 @@
 | sonic-bmp | Feng Pan (Microsoft) | FengPan-Frank |  |
 |  | Qi Luo(Microsoft) | qiluo-msft | enabled |
 | sonic-host-services | Qi Luo(Microsoft) | qiluo-msft |  |
+|  | Amit Abel (Nvidia) | abelamit | Request on 05/08/2026 |
 | sonic-formal-infra | Mengqi Liu (Alibaba) | mengqiliu20 | enabled |
 |  | Ali Kheradmand (Google) | kheradmandG |enabled  |
 | sonic-redfish |  |  |  |
+|  | Oleksandr Ivantsiv (Nvidia) | oleksandrivantsiv | Request on 05/08/2026 |
+|  | Ben Levi (Nvidia) | benle7 | Request on 05/08/2026 |


### PR DESCRIPTION
Add maintainer nomination requests for Nvidia team members.

| Name | Organization | Github ID | Target repositories | Justification |
| :--- | :---: | :--- | :--- | :--- |
| Sudharsan Dhamal Gopalarathnam  | Nvidia | dgsudharsan | sonic-swss, sonic-buildimage | Sudharsan is part of active sonic contributors for past 7 years. Active participant in routing subgroup. Reviewed several features and PRs over several years. Contributed multiple features including auto-fec, SAI failure dump, sflow and port media settings update. Manage sonic-swss repository for past 3 years|
| Junchao Chen  | Nvidia | Junchao-Mellanox |sonic-platform-common , sonic-platform-daemon, sonic-utilities | Junchao is part of active sonic contributors for past 7 years. Contributed several features including syslog rate limit, route & trap flow counter,Has more than 100 commits in the three repositories |
| Stephen Sun  | Nvidia | stephenxs |sonic-swss , sonic-sairedis, sonic-swss-common | Stephen is part of active sonic contributors for past 7 years. Contributed multiple features including asic health event, optimized counter initialization, dynamic buffer calculation.Has more than 100 commits in the three repositories |
| Oleksandr Ivantsiv  | Nvidia | oleksandrivantsiv |sonic-utilities , sonic-redfis | Oleksandr is part of active sonic contributors for past 10+ years. Active participant in BMC subgroup, Smartswitch and DASH projects. Contributed several features including static DNS and Ip address assignment in smartswitch |
| Volodymyr Samotiy  | Nvidia | volodymyrsamotiy |sonic-buildimage | Volodymyr is part of active sonic contributors for past 10+ years. Active participant in SONiC community meetings, SONiC bug triage and has several PRs contributed to sonic-buildimage |
| Geoffrey Lyu  | Nvidia | ganglyu |sonic-gnmi | Geoffrey is part of active sonic contributors for past 5 years. Active contributor in SONiC community, has 50+ commits in sonic-gnmi repository |
| Amit Abel  | Nvidia | abelamit |sonic-buildimage, sonic-host-services | Amit is a software team manager at NVIDIA, responsible of different domains and features under SONiC Layer 1 (SFP and CPO), warm and fast reboot, build infrastructure, platform code, telemetry (including HFT) and more. Actively participate in SONiC L1 subgroup and SONiC Build subgroup. Outside of SONiC, Amit brings 11+ years of experience in Networking |
| Ben Levi  | Nvidia | benle7 | sonic-redfish| Ben has spent the past two years working on SONiC platform management and infrastructure, building the foundation for SONiC’s integration with OpenBMC. Work includes the bmc_base.py framework, redfish_client.py, BMC CLI commands, USB0 interface configuration for SONiC–BMC communication across OpenBMC and SONiC BMC platforms, and ongoing work to enable SONiC BMC communication through Redis. |
| Hemanth Kumar Tirupati  | Nvidia | tirupatihemanth | sonic-linux-kernel| Hemanth is an active contributor to SONiC for past two years. Major contributions include Debian 13 upgrade, fixing issues related to secure boot. Hemanth is an active participant in sonic-platform-subgroup.  |