### PR TITLE
[sonic-swss] Maintainer nomination: Sudharsan Dhamal Gopalarathnam

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -47,6 +47,7 @@
 |  | sonic-swss-maintainer | Stephen Wang(Google) | StephenWangGoogle | enabled |
 |  | sonic-swss-maintainer | Laveen Thamilchelvam (BRCM) | LaveenBrcm | Approved on 5/3/2023 and enabled |
 |  | sonic-swss-maintainer | Rajesh Sankaran (BRCM) | srj102 | Approved on 5/3/2023 and enabled |
+|  | sonic-swss-maintainer | Sudharsan Dhamal Gopalarathnam (Nvidia) | dgsudharsan | Request on 08/25/2026 |
 | sonic-swss-common | sonic-swss-common-maintainer | Qi Luo (Microsoft) | qiluo-msft | enabled |
 |  | sonic-swss-common-maintainer | Myron Sosyak (Intel) | msosyak | enabled |
 |  | sonic-swss-common-maintainer | Marian Pritsak (Nvidia) | marian-pritsak | enabled |


### PR DESCRIPTION
Name: Sudharsan Dhamal Gopalarathnam
Organization: Nvidia
Github ID: dgsudharsan
Target Repository: sonic-swss

Justification:

Sudharsan is part of active sonic contributors for past 7 years. Active participant in routing subgroup. Reviewed several features and PRs over several years. Contributed multiple features including auto-fec, SAI failure dump, sflow and port media settings update. Manage sonic-swss repository for past 3 years

Split from https://github.com/sonic-net/SONiC/pull/2488
