### PR TITLE
[sonic-buildimage] Maintainer nomination: Sudharsan Dhamal Gopalarathnam

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -65,6 +65,7 @@
 |  | sonic-buildimage-maintainer | Yilan Ji (Google) | baxia-lan | enabled |
 |  | sonic-buildimage-maintainer | Praveen Elagala (BRCM) | Praveen-Brcm | Approved on 5/3/2023 and enabled |
 |  | sonic-buildimage-maintainer | Prasanth Veettil (BRCM) | Prasanth-KV | Approved on 5/3/2023 and enabled |
+|  | sonic-buildimage-maintainer | Sudharsan Dhamal Gopalarathnam (Nvidia) | dgsudharsan | Request on 08/25/2026 |
 | sonic-mgmt | sonic-mgmt-maintainer | Ying Xie (Microsoft) | yxieca | enabled |
 |  | sonic-mgmt-maintainer | Bhavani Parise (Cisco) | bpar9 | enabled |
 |  | sonic-mgmt-maintainer | John Cheung (Intel) | johcheun | invitation sent |


### PR DESCRIPTION
Name: Sudharsan Dhamal Gopalarathnam
Organization: Nvidia
Github ID: dgsudharsan
Target Repository: sonic-buildimage

Justification:

Sudharsan is part of active sonic contributors for past 7 years. Active participant in routing subgroup. Reviewed several features and PRs over several years. Contributed multiple features including auto-fec, SAI failure dump, sflow and port media settings update. Manage sonic-swss repository for past 3 years

Split from https://github.com/sonic-net/SONiC/pull/2488
