### PR TITLE
[sonic-platform-common] Maintainer nomination: Junchao Chen

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -28,6 +28,7 @@
 | sonic-platform-common | sonic-platform-common-maintainer | Prince George (Microsoft) | prgeor | enabled |
 |  | sonic-platform-common-maintainer | Mridul Bajpai (Cisco) | bmridul | enabled |
 |  | sonic-platform-common-maintainer | Kebo Liu (Nvidia) | keboliu | enabled |
+|  | sonic-platform-common-maintainer | Junchao Chen (Nvidia) | Junchao-Mellanox | Request on 08/25/2026 |
 | sonic-platform-daemons | sonic-platform-daemons-maintainer | Prince George (Microsoft) | prgeor | enabled |
 |  | sonic-platform-daemons-maintainer | Mridul Bajpai (Cisco) | bmridul | enabled |
 |  | sonic-platform-daemons-maintainer | Kebo Liu (Nvidia) | keboliu | enabled |


### PR DESCRIPTION
Name: Junchao Chen
Organization: Nvidia
Github ID: Junchao-Mellanox
Target Repository: sonic-platform-common

Justification:

Junchao is part of active sonic contributors for past 7 years. Contributed several features including syslog rate limit, route & trap flow counter,Has more than 100 commits in the three repositories

Split from https://github.com/sonic-net/SONiC/pull/2488
