### PR TITLE
[sonic-platform-daemons] Maintainer nomination: Junchao Chen

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -31,6 +31,7 @@
 | sonic-platform-daemons | sonic-platform-daemons-maintainer | Prince George (Microsoft) | prgeor | enabled |
 |  | sonic-platform-daemons-maintainer | Mridul Bajpai (Cisco) | bmridul | enabled |
 |  | sonic-platform-daemons-maintainer | Kebo Liu (Nvidia) | keboliu | enabled |
+|  | sonic-platform-daemons-maintainer | Junchao Chen (Nvidia) | Junchao-Mellanox | Request on 08/25/2026 |
 | sonic-platform-pdk-pde | sonic-platform-pdk-pde-maintainer | Geans Pin (BRCM) | geans-pin | enabled |
 | sonic-py-swsssdk | sonic-py-swsssdk-maintainer | Prince Sunny (Microsoft) | prsunny | enabled |
 | sonic-restapi | sonic-restapi-maintainer | Lawrence Lee (Microsoft) | theasianpianist | enabled |


### PR DESCRIPTION
Name: Junchao Chen
Organization: Nvidia
Github ID: Junchao-Mellanox
Target Repository: sonic-platform-daemons

Justification:

Junchao is part of active sonic contributors for past 7 years. Contributed several features including syslog rate limit, route & trap flow counter,Has more than 100 commits in the three repositories

Split from https://github.com/sonic-net/SONiC/pull/2488
