### PR TITLE
[sonic-utilities] Maintainer nomination: Junchao Chen

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -57,6 +57,7 @@
 |  | sonic-gnmi-maintainer | Seifert, Eric (DELL) | seiferteric | enabled |
 |  | sonic-gnmi-maintainer | Anand Subramanian (BRCM) | anand-kumar-subramanian | Approved on 5/3/2023 and enabled |
 | sonic-utilities | sonic-utilities-maintainer | Qi Luo (Microsoft) | qiluo-msft | enabled |
+|  | sonic-utilities-maintainer | Junchao Chen (Nvidia) | Junchao-Mellanox | Request on 08/25/2026 |
 | sonic-wpa-supplicant | sonic-wpa-supplicant-maintainer | Ze Gan (Microsoft) | Pterosaur | enabled |
 | sonic-buildimage | sonic-buildimage-maintainer | Guohan Lu (Microsoft) | lguohan | enabled |
 |  | sonic-buildimage-maintainer | Ying Xie (Microsoft) | yxieca | enabled |


### PR DESCRIPTION
Name: Junchao Chen
Organization: Nvidia
Github ID: Junchao-Mellanox
Target Repository: sonic-utilities

Justification:

Junchao is part of active sonic contributors for past 7 years. Contributed several features including syslog rate limit, route & trap flow counter,Has more than 100 commits in the three repositories

Split from https://github.com/sonic-net/SONiC/pull/2488
