### PR TITLE
[sonic-swss] Maintainer nomination: Stephen Sun

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -47,6 +47,7 @@
 |  | sonic-swss-maintainer | Stephen Wang(Google) | StephenWangGoogle | enabled |
 |  | sonic-swss-maintainer | Laveen Thamilchelvam (BRCM) | LaveenBrcm | Approved on 5/3/2023 and enabled |
 |  | sonic-swss-maintainer | Rajesh Sankaran (BRCM) | srj102 | Approved on 5/3/2023 and enabled |
+|  | sonic-swss-maintainer | Stephen Sun (Nvidia) | stephenxs | Request on 08/25/2026 |
 | sonic-swss-common | sonic-swss-common-maintainer | Qi Luo (Microsoft) | qiluo-msft | enabled |
 |  | sonic-swss-common-maintainer | Myron Sosyak (Intel) | msosyak | enabled |
 |  | sonic-swss-common-maintainer | Marian Pritsak (Nvidia) | marian-pritsak | enabled |


### PR DESCRIPTION
Name: Stephen Sun
Organization: Nvidia
Github ID: stephenxs
Target Repository: sonic-swss

Justification:

Stephen is part of active sonic contributors for past 7 years. Contributed multiple features including asic health event, optimized counter initialization, dynamic buffer calculation.Has more than 100 commits in the three repositories

Split from https://github.com/sonic-net/SONiC/pull/2488
