### PR TITLE
[sonic-sairedis] Maintainer nomination: Stephen Sun

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -40,6 +40,7 @@
 |  | sonic-sairedis-maintainer | Volodymyr Boiko (Intel) | vboykox | enabled |
 |  | sonic-sairedis-maintainer | Kishore Gummadidala(Google) | erohsik | invitation sent |
 |  | sonic-sairedis-maintainer | Vishnu Shetty | vishnushetty | enabled |
+|  | sonic-sairedis-maintainer | Stephen Sun (Nvidia) | stephenxs | Request on 08/25/2026 |
 | sonic-snmpagent | sonic-snmpagent-maintainer | Suvarna Meenakshi (Microsoft) | SuvarnaMeenakshi | enabled |
 | sonic-swss | sonic-swss-maintainer | Guohan Lu (Microsoft) | lguohan | added |
 |  | sonic-swss-maintainer | Prince Sunny (Microsoft) | prsunny | added |


### PR DESCRIPTION
Name: Stephen Sun
Organization: Nvidia
Github ID: stephenxs
Target Repository: sonic-sairedis

Justification:

Stephen is part of active sonic contributors for past 7 years. Contributed multiple features including asic health event, optimized counter initialization, dynamic buffer calculation.Has more than 100 commits in the three repositories

Split from https://github.com/sonic-net/SONiC/pull/2488
