### PR TITLE
[sonic-swss-common] Maintainer nomination: Stephen Sun

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -51,6 +51,7 @@
 |  | sonic-swss-common-maintainer | Myron Sosyak (Intel) | msosyak | enabled |
 |  | sonic-swss-common-maintainer | Marian Pritsak (Nvidia) | marian-pritsak | enabled |
 |  | sonic-swss-common-maintainer | Runming Wu(Google) | mint570 | enabled |
+|  | sonic-swss-common-maintainer | Stephen Sun (Nvidia) | stephenxs | Request on 08/25/2026 |
 | sonic-gnmi (previously sonic-telemetry) | sonic-gnmi-maintainer | Qi Luo (Microsoft) | qiluo-msft | enabled |
 |  | sonic-gnmi-maintainer | Shashank Neelam | sneelam20 | Replace Tomek on 3/5/2024 |
 |  | sonic-gnmi-maintainer | Shishao (Alibaba) | shishao7sxm | invitation sent |


### PR DESCRIPTION
Name: Stephen Sun
Organization: Nvidia
Github ID: stephenxs
Target Repository: sonic-swss-common

Justification:

Stephen is part of active sonic contributors for past 7 years. Contributed multiple features including asic health event, optimized counter initialization, dynamic buffer calculation.Has more than 100 commits in the three repositories

Split from https://github.com/sonic-net/SONiC/pull/2488
