### PR TITLE
[sonic-redfish] Maintainer nomination: Oleksandr Ivantsiv

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -82,3 +82,4 @@
 | sonic-host-services | sonic-host-services-maintainer | Qi Luo(Microsoft) | qiluo-msft |  |
 | sonic-formal-infra | sonic-formal-infra-maintainer | Mengqi Liu (Alibaba) | mengqiliu20 | enabled |
 |  | sonic-formal-infra-maintainer | Ali Kheradmand (Google) | kheradmandG |enabled  |
+| sonic-redfish | sonic-redfish-maintainer | Oleksandr Ivantsiv (Nvidia) | oleksandrivantsiv | Request on 08/25/2026 |


### PR DESCRIPTION
Name: Oleksandr Ivantsiv
Organization: Nvidia
Github ID: oleksandrivantsiv
Target Repository: sonic-redfish

Justification:

Oleksandr is part of active sonic contributors for past 10+ years. Active participant in BMC subgroup, Smartswitch and DASH projects. Contributed several features including static DNS and Ip address assignment in smartswitch

Split from https://github.com/sonic-net/SONiC/pull/2488
