### PR TITLE
[sonic-buildimage] Maintainer nomination: Volodymyr Samotiy

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -65,6 +65,7 @@
 |  | sonic-buildimage-maintainer | Yilan Ji (Google) | baxia-lan | enabled |
 |  | sonic-buildimage-maintainer | Praveen Elagala (BRCM) | Praveen-Brcm | Approved on 5/3/2023 and enabled |
 |  | sonic-buildimage-maintainer | Prasanth Veettil (BRCM) | Prasanth-KV | Approved on 5/3/2023 and enabled |
+|  | sonic-buildimage-maintainer | Volodymyr Samotiy (Nvidia) | volodymyrsamotiy | Request on 08/25/2026 |
 | sonic-mgmt | sonic-mgmt-maintainer | Ying Xie (Microsoft) | yxieca | enabled |
 |  | sonic-mgmt-maintainer | Bhavani Parise (Cisco) | bpar9 | enabled |
 |  | sonic-mgmt-maintainer | John Cheung (Intel) | johcheun | invitation sent |


### PR DESCRIPTION
Name: Volodymyr Samotiy
Organization: Nvidia
Github ID: volodymyrsamotiy
Target Repository: sonic-buildimage

Justification:

Volodymyr is part of active sonic contributors for past 10+ years. Active participant in SONiC community meetings, SONiC bug triage and has several PRs contributed to sonic-buildimage

Split from https://github.com/sonic-net/SONiC/pull/2488
