### PR TITLE
[sonic-buildimage] Maintainer nomination: Amit Abel

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -65,6 +65,7 @@
 |  | sonic-buildimage-maintainer | Yilan Ji (Google) | baxia-lan | enabled |
 |  | sonic-buildimage-maintainer | Praveen Elagala (BRCM) | Praveen-Brcm | Approved on 5/3/2023 and enabled |
 |  | sonic-buildimage-maintainer | Prasanth Veettil (BRCM) | Prasanth-KV | Approved on 5/3/2023 and enabled |
+|  | sonic-buildimage-maintainer | Amit Abel (Nvidia) | abelamit | Request on 08/25/2026 |
 | sonic-mgmt | sonic-mgmt-maintainer | Ying Xie (Microsoft) | yxieca | enabled |
 |  | sonic-mgmt-maintainer | Bhavani Parise (Cisco) | bpar9 | enabled |
 |  | sonic-mgmt-maintainer | John Cheung (Intel) | johcheun | invitation sent |


### PR DESCRIPTION
Name: Amit Abel
Organization: Nvidia
Github ID: abelamit
Target Repository: sonic-buildimage

Justification:

Amit is a software team manager at NVIDIA, responsible of different domains and features under SONiC Layer 1 (SFP and CPO), warm and fast reboot, build infrastructure, platform code, telemetry (including HFT) and more. Actively participate in SONiC L1 subgroup and SONiC Build subgroup. Outside of SONiC, Amit brings 11+ years of experience in Networking

Split from https://github.com/sonic-net/SONiC/pull/2488
