### PR TITLE
[sonic-host-services] Maintainer nomination: Amit Abel

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -80,5 +80,6 @@
 | sonic-dash-ha | sonic-dash-ha-maintainer | Riff Jiang (Microsoft) | r12f |  |
 | sonic-bmp | sonic-bmp-maintainer | Qi Luo(Microsoft) | qiluo-msft | enabled |
 | sonic-host-services | sonic-host-services-maintainer | Qi Luo(Microsoft) | qiluo-msft |  |
+|  | sonic-host-services-maintainer | Amit Abel (Nvidia) | abelamit | Request on 08/25/2026 |
 | sonic-formal-infra | sonic-formal-infra-maintainer | Mengqi Liu (Alibaba) | mengqiliu20 | enabled |
 |  | sonic-formal-infra-maintainer | Ali Kheradmand (Google) | kheradmandG |enabled  |


### PR DESCRIPTION
Name: Amit Abel
Organization: Nvidia
Github ID: abelamit
Target Repository: sonic-host-services

Justification:

Amit is a software team manager at NVIDIA, responsible of different domains and features under SONiC Layer 1 (SFP and CPO), warm and fast reboot, build infrastructure, platform code, telemetry (including HFT) and more. Actively participate in SONiC L1 subgroup and SONiC Build subgroup. Outside of SONiC, Amit brings 11+ years of experience in Networking

Split from https://github.com/sonic-net/SONiC/pull/2488
