### PR TITLE
[sonic-linux-kernel] Maintainer nomination: Hemanth Kumar Tirupati

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -15,6 +15,7 @@
 |  | sonic-linkmgrd-maintainer | Longxiang Lyu (Microsoft) | lolyu | enabled |
 |  | sonic-linkmgrd-maintainer | Ying Xie (Microsoft) | yxieca | enabled |
 | sonic-linux-kernel | sonic-linux-kernel-maintainer | Saikrishna Arcot (Microsoft) | saiarcot895 | enabled |
+|  | sonic-linux-kernel-maintainer | Hemanth Kumar Tirupati (Nvidia) | tirupatihemanth | Request on 08/25/2026 |
 | sonic-mgmt-common | sonic-mgmt-common-maintainer | Kim, Kwan (DELL) | kwangsuk | enabled |
 |  | sonic-mgmt-common-maintainer | Shashank Neelam (Google) | sneelam20 | enabled |
 |  | sonic-mgmt-common-maintainer | Anand Subramanian (BRCM) | anand-kumar-subramanian | enabled |


### PR DESCRIPTION
Name: Hemanth Kumar Tirupati
Organization: Nvidia
Github ID: tirupatihemanth
Target Repository: sonic-linux-kernel

Justification:

Hemanth is an active contributor to SONiC for past two years. Major contributions include Debian 13 upgrade, fixing issues related to secure boot. Hemanth is an active participant in sonic-platform-subgroup.

Split from https://github.com/sonic-net/SONiC/pull/2488
