### PR TITLE
[tsc/repo-maintainer] Bobby McGonigle

### DIFF
--- a/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
+++ b/tsc/repo-maintainer/SONiC_Repo_Maintainer.md
@@ -28,9 +28,11 @@
 | sonic-platform-common | sonic-platform-common-maintainer | Prince George (Microsoft) | prgeor | enabled |
 |  | sonic-platform-common-maintainer | Mridul Bajpai (Cisco) | bmridul | enabled |
 |  | sonic-platform-common-maintainer | Kebo Liu (Nvidia) | keboliu | enabled |
+|  | sonic-platform-common-maintainer | Bobby McGonigle (Nexthop) | bobby-nexthop | Request on 8/27/2026 |
 | sonic-platform-daemons | sonic-platform-daemons-maintainer | Prince George (Microsoft) | prgeor | enabled |
 |  | sonic-platform-daemons-maintainer | Mridul Bajpai (Cisco) | bmridul | enabled |
 |  | sonic-platform-daemons-maintainer | Kebo Liu (Nvidia) | keboliu | enabled |
+|  | sonic-platform-daemons-maintainer | Bobby McGonigle (Nexthop) | bobby-nexthop | Request on 8/27/2026 |
 | sonic-platform-pdk-pde | sonic-platform-pdk-pde-maintainer | Geans Pin (BRCM) | geans-pin | enabled |
 | sonic-py-swsssdk | sonic-py-swsssdk-maintainer | Prince Sunny (Microsoft) | prsunny | enabled |
 | sonic-restapi | sonic-restapi-maintainer | Lawrence Lee (Microsoft) | theasianpianist | enabled |


### PR DESCRIPTION
Company: Nexthop Systems Inc
Github ID: bobby-nexthop
Target Repositories: sonic-platform-daemons, sonic-platform-common

Justification:

I'm a software engineer at Nexthop AI, working on Layer 1 features, platform bring-up, and physical-layer debugging for SONiC systems. Over the past three years, I have contributed to SONiC across all Layer 1 areas, including new feature support, bug fixing, and driving community events.

- sonic-platform-daemons (xcvrd)
- sonic-platform-common (SFP, SFF, CMIS)

Community Events:

- Presented a session on ["Configuring and Debugging the Physical Layer in SONiC"](https://www.youtube.com/watch?v=siEq-sjehLQ) at OCP EMEA (Barcelona 2026).
- Led the L1 working group session at SONiC Day at OCP (Sunnyvale 2025, Google Sunnyvale Campus), presenting a talk on L1 architecture, recent additions in the area, upcoming technologies, and expected features and needs.

Feature Work Highlights:

- Added CMIS banking support: Base feature needed for CPO and multi-device systems ([HLD](https://github.com/sonic-net/SONiC/pull/2183))
- Added show interface l1-summary ([HLD](https://github.com/sonic-net/SONiC/pull/2185))
- Added speed support for 1.6T ([HLD](https://github.com/sonic-net/SONiC/pull/2037))
- Added timestamp support for FEC Histograms ([sonic-utilities PR](https://github.com/sonic-net/sonic-utilities/pull/4513), [sonic-sairedis PR](https://github.com/sonic-net/sonic-sairedis/pull/1882))
- Added dynamic media setting support: TX FIR Taps per medium and speed ([PR](https://github.com/sonic-net/sonic-platform-daemons/pull/731))
- Performed a full xcvrd refactor: Submitted 13 PRs to improve the readability, debuggability, and organization of xcvrd.
- Link Debounce Feature (In progress and upstreaming soon)
- sudo config hwsku profile load CLI (In progress and upstreaming soon)
- show interfaces cmis transitions CLI (In progress and upstreaming soon)
- ER/NR + Precoding mode (In progress and upstreaming soon)

Review Activity:

Prince George actively involves me and requests that I review PRs regularly; a reasonable portion of my week involves reviewing community PRs in the Layer 1 area. Recent examples:

- sonic-platform-daemons: [#685](https://github.com/sonic-net/sonic-platform-daemons/pull/685) (xcvrd temperature polling thread), [#687](https://github.com/sonic-net/sonic-platform-daemons/pull/687) (LPO support in media_settings_parser), [#697](https://github.com/sonic-net/sonic-platform-daemons/pull/697) (skip lpmode setting when unsupported), [#649](https://github.com/sonic-net/sonic-platform-daemons/pull/649) (port SI settings per speed during speed change)
- sonic-linux-kernel: [#473](https://github.com/sonic-net/sonic-linux-kernel/pull/473) (optoe CMIS bank support for transceivers with >8 lanes)
- sonic-sairedis: [#2030](https://github.com/sonic-net/sonic-sairedis/pull/2030) (PHY SerDes counter wedge fix), [#2018](https://github.com/sonic-net/sonic-sairedis/pull/2018) (FlexCounter PHY/SerDes attribute polling)
- sonic-utilities: [#4153](https://github.com/sonic-net/sonic-utilities/pull/4153) (FEC maxT in fec stat CLI), [#4027](https://github.com/sonic-net/sonic-utilities/pull/4027) (max pre-FEC BER counter)

It is a rapidly evolving area featuring new optics, FEC schemes, and SerDes technologies. Having more maintainers focused on this domain will ensure timely, high-quality reviews and keep the codebase aligned with the latest hardware capabilities.

Thank you for your consideration.